### PR TITLE
Fix turn sync and mana animations

### DIFF
--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -88,15 +88,15 @@ export function animateManaGainFromWorld(pos, ownerIndex, visualOnly = true) {
     let currentMana = Math.max(0, (gameState?.players?.[ownerIndex]?.mana) || 0);
     const currentBlocks = Math.max(0, Number(getBlocks()?.[ownerIndex]) || 0);
     
-    // Исправление: для visualOnly анимации нужно учесть уже запланированные блокировки
-    // и лететь в правильную позицию с учетом реального количества орбов на экране
+    // Определяем целевой индекс с учётом режима визуализации
+    // Для purely visual полёта (visualOnly = true) состояние gameState ещё не обновлено,
+    // поэтому целимся в следующий свободный слот, основываясь на фактическом количестве маны.
+    // Для реального обновления (visualOnly = false) мана уже увеличена и орб должен прилететь
+    // в последний заполненный слот.
     let targetIdx;
     if (visualOnly) {
-      // Показываем визуально в следующем свободном слоте, учитывая существующие блокировки
-      const visibleMana = Math.max(0, currentMana - currentBlocks);
-      targetIdx = Math.min(9, visibleMana);
+      targetIdx = Math.min(9, currentMana);
     } else {
-      // Состояние уже обновлено, целимся в последний заполненный орб
       targetIdx = Math.max(0, Math.min(9, currentMana - 1));
     }
     

--- a/src/ui/sync.js
+++ b/src/ui/sync.js
@@ -20,26 +20,46 @@ export function attachSocketUIRefresh() {
       };
       
       // Enhanced turn switch handler with better state sync
-      const onTurnSwitched = () => {
+      const onTurnSwitched = async () => {
         console.log('[SYNC] Turn switched event received');
         try { if (typeof window.updateIndicator === 'function') window.updateIndicator(); } catch {}
         try { if (typeof window.updateInputLock === 'function') window.updateInputLock(); } catch {}
-        
-        // Force UI update first to sync mana displays
-        try { if (typeof window.updateUI === 'function') window.updateUI(); } catch {}
-        
-        // Then handle turn splash with retry mechanism
+
         try {
-          const turn = (typeof window !== 'undefined' && window.gameState && typeof window.gameState.turn === 'number') ? window.gameState.turn : null;
-          if (turn && window.__ui && window.__ui.banner && typeof window.__ui.banner.forceTurnSplashWithRetry === 'function') {
-            // Use retry mechanism for better reliability
-            window.__ui.banner.forceTurnSplashWithRetry(2, turn).catch(e => {
-              console.warn('[SYNC] Failed to show turn splash:', e);
-            });
+          const gs = (typeof window !== 'undefined') ? window.gameState : null;
+          if (gs && Array.isArray(gs.players)) {
+            const predictedTurn = (gs.turn || 0) + 1;
+            let lastSeen = 0; try { lastSeen = Number(window.__lastTurnSeen) || 0; } catch {}
+            if (predictedTurn > lastSeen) {
+              const nextActive = gs.active === 0 ? 1 : 0;
+              const pl = gs.players[nextActive];
+              const before = Number(pl?.mana || 0);
+              const after = (typeof window.capMana === 'function') ? window.capMana(before + 2) : (before + 2);
+              pl._beforeMana = before;
+              pl.mana = after;
+              gs.active = nextActive;
+              gs.turn = predictedTurn;
+              try { window.__lastTurnSeen = predictedTurn; } catch {}
+
+              if (window.__ui && window.__ui.banner && typeof window.__ui.banner.forceTurnSplashWithRetry === 'function') {
+                await window.__ui.banner.forceTurnSplashWithRetry(2, gs.turn);
+              }
+              if (window.__ui && window.__ui.mana && typeof window.__ui.mana.animateTurnManaGain === 'function') {
+                await window.__ui.mana.animateTurnManaGain(nextActive, before, after, 1500);
+              }
+            } else {
+              // Turn already processed via state push; ensure splash if missing
+              if (window.__ui && window.__ui.banner && typeof window.__ui.banner.forceTurnSplashWithRetry === 'function') {
+                try { await window.__ui.banner.forceTurnSplashWithRetry(2, gs.turn); } catch {}
+              }
+            }
           }
         } catch (e) {
-          console.warn('[SYNC] Error in turn splash handling:', e);
+          console.warn('[SYNC] Error in turn switch handling:', e);
         }
+
+        // Final UI refresh after animations
+        try { if (typeof window.updateUI === 'function') window.updateUI(); } catch {}
       };
       
       // Additional handler for general state sync (e.g., when gameState changes)


### PR DESCRIPTION
## Summary
- Ensure turn switch events update local state, show start-of-turn banner and animate mana gain
- Correct mana orb animation target for inactive player when gaining mana from world events

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b93869b4848330b9f500cfb640b18e