### PR TITLE
Fix turn sync and mana animations

### DIFF
--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -31,10 +31,12 @@ export function renderBars(gameState) {
       continue;
     }
     
-    // Если идет анимация получения маны в начале хода и есть _beforeMana, используем его
+    // Если на игроке висит предыдущее значение маны (_beforeMana), отображаем его до
+    // начала анимации пополнения. Это предотвращает преждевременное появление +2 маны
+    // в панели ещё до запуска анимации и делает поведение одинаковым для обоих клиентов.
     let displayMana = currentMana;
-    if (getManaGainActive() && typeof beforeMana === 'number' && pending) {
-      displayMana = beforeMana; // Показываем старое значение во время анимации
+    if (typeof beforeMana === 'number') {
+      displayMana = beforeMana;
     }
     
     const blockAdjusted = Math.max(0, displayMana - block);
@@ -94,7 +96,8 @@ export function animateManaGainFromWorld(pos, ownerIndex, visualOnly = true) {
     if (visualOnly) {
       // Показываем визуально в следующем свободном слоте, учитывая существующие блокировки
       const visibleMana = Math.max(0, currentMana - currentBlocks);
-      targetIdx = Math.min(9, visibleMana);
+      // Орб должен лететь в ячейку, которая будет заполнена после прибавки маны
+      targetIdx = Math.max(0, Math.min(9, visibleMana - 1));
     } else {
       // Состояние уже обновлено, целимся в последний заполненный орб
       targetIdx = Math.max(0, Math.min(9, currentMana - 1));

--- a/src/ui/sync.js
+++ b/src/ui/sync.js
@@ -1,6 +1,8 @@
 ﻿// Lightweight UI sync for socket events, decoupled from index.html
 // Attaches best-effort listeners to refresh UI highlights on turn change/timer
 
+import { capMana } from '../core/constants.js';
+
 let _attached = false;
 
 export function attachSocketUIRefresh() {
@@ -20,19 +22,41 @@ export function attachSocketUIRefresh() {
       };
       
       // Enhanced turn switch handler with better state sync
-      const onTurnSwitched = () => {
+      const onTurnSwitched = ({ activeSeat } = {}) => {
         console.log('[SYNC] Turn switched event received');
+
+        // Предварительно обновляем локальный стейт, чтобы оппонент сразу увидел +2 маны и заставку хода
+        try {
+          const gs = (typeof window !== 'undefined' && window.gameState) ? window.gameState : null;
+          if (gs && typeof activeSeat === 'number') {
+            const prevTurn = Number(gs.turn) || 0;
+            gs.active = activeSeat;
+            gs.turn = prevTurn + 1;
+            const pl = gs.players?.[activeSeat];
+            if (pl) {
+              const before = Number(pl.mana) || 0;
+              pl._beforeMana = before;
+              pl.mana = capMana(before + 2);
+              try { if (typeof window !== 'undefined') {
+                window.PENDING_MANA_ANIM = { ownerIndex: activeSeat, startIdx: Math.max(0, Math.min(9, before)), endIdx: Math.max(-1, Math.min(9, pl.mana - 1)) };
+              } } catch {}
+              try {
+                if (window.__ui && window.__ui.mana && typeof window.__ui.mana.animateTurnManaGain === 'function') {
+                  window.__ui.mana.animateTurnManaGain(activeSeat, before, pl.mana, 1500).catch(()=>{});
+                }
+              } catch {}
+            }
+          }
+        } catch {}
+
         try { if (typeof window.updateIndicator === 'function') window.updateIndicator(); } catch {}
         try { if (typeof window.updateInputLock === 'function') window.updateInputLock(); } catch {}
-        
-        // Force UI update first to sync mana displays
         try { if (typeof window.updateUI === 'function') window.updateUI(); } catch {}
-        
+
         // Then handle turn splash with retry mechanism
         try {
           const turn = (typeof window !== 'undefined' && window.gameState && typeof window.gameState.turn === 'number') ? window.gameState.turn : null;
           if (turn && window.__ui && window.__ui.banner && typeof window.__ui.banner.forceTurnSplashWithRetry === 'function') {
-            // Use retry mechanism for better reliability
             window.__ui.banner.forceTurnSplashWithRetry(2, turn).catch(e => {
               console.warn('[SYNC] Failed to show turn splash:', e);
             });


### PR DESCRIPTION
## Summary
- show previous mana value during start-of-turn to sync with animation
- correct mana orb target slot when animating visual-only gains
- preemptively update turn and mana on `turnSwitched` events so opponents see the banner and mana change immediately

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b93869b4848330b9f500cfb640b18e