### PR TITLE
feat(ui): show opponent hand count

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
           <span class="label-text">End Turn</span>
           <span class="sec-text">100</span>
         </button>
+        <div id="opponent-hand-count" title="Opponent has 0 cards"></div>
       </div>
     </div>
 
@@ -870,6 +871,18 @@
             const percent = s / 100; // 1 -> top:0%, 0 -> top:100%
             if (fill) fill.style.top = `${Math.round((1 - percent) * 100)}%`;
           }
+        }
+      } catch {}
+      // Update opponent hand count indicator
+      try {
+        const mySeat = (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number') ? window.MY_SEAT : 0;
+        const oppSeat = mySeat === 0 ? 1 : 0;
+        const count = gameState?.players?.[oppSeat]?.hand?.length || 0;
+        if (window.__ui && window.__ui.handCount && typeof window.__ui.handCount.render === 'function') {
+          window.__ui.handCount.render(count);
+        } else {
+          const el = document.getElementById('opponent-hand-count');
+          if (el) el.textContent = `Cards: ${count}`;
         }
       } catch {}
       // Выделение активного игрока - с гарантией обновления

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import * as UIPanels from './ui/panels.js';
 // UI modules
 import * as TurnTimer from './ui/turnTimer.js';
 import * as Banner from './ui/banner.js';
+import * as HandCount from './ui/handCount.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -134,6 +135,7 @@ try {
   window.__ui.log = UILog;
   window.__ui.mana = UIMana;
   window.__ui.panels = UIPanels;
+  window.__ui.handCount = HandCount;
 } catch {}
 
 import * as UISync from './ui/sync.js';

--- a/src/ui/handCount.js
+++ b/src/ui/handCount.js
@@ -1,0 +1,48 @@
+// Opponent hand count indicator
+// Renders small fan of cards representing opponent hand size
+
+let _container = null;
+
+function _ensureContainer(id = 'opponent-hand-count') {
+  if (!_container && typeof document !== 'undefined') {
+    _container = document.getElementById(id);
+    if (_container) _container.innerHTML = '';
+  }
+  return _container;
+}
+
+export function render(count) {
+  const el = _ensureContainer();
+  if (!el) return;
+  const n = Math.max(0, Number(count) || 0);
+  el.innerHTML = '';
+  el.setAttribute('title', `Opponent has ${n} card${n === 1 ? '' : 's'}`);
+  // basic fan layout: cards rotate around bottom center
+  for (let i = 0; i < n; i++) {
+    const card = document.createElement('div');
+    card.className = 'opp-card';
+    const stepAngle = 8; // degrees between cards
+    const stepOffset = 6; // px horizontal offset
+    const offsetIndex = i - (n - 1) / 2;
+    const angle = offsetIndex * stepAngle;
+    const offset = offsetIndex * stepOffset;
+    card.style.transform = `translateX(${offset}px) rotate(${angle}deg)`;
+    el.appendChild(card);
+  }
+}
+
+export function init(id = 'opponent-hand-count') {
+  _container = document.getElementById(id);
+  return api;
+}
+
+const api = { render, init };
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.handCount = api;
+  }
+} catch {}
+
+export default api;

--- a/styles/main.css
+++ b/styles/main.css
@@ -86,3 +86,23 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 .battle-flash-scan { position:absolute; inset:0; background: linear-gradient( to bottom, transparent 0%, rgba(255,255,255,0.08) 50%, transparent 100% ); transform: translateY(-100%); }
 /* Tooltip для 3D-колод/кладбищ */
 #hover-tooltip { position: fixed; pointer-events: none; z-index: 50; }
+
+/* Opponent hand count indicator */
+#opponent-hand-count {
+  position: relative;
+  width: 84px;
+  height: 24px;
+  margin-top: 4px;
+}
+#opponent-hand-count .opp-card {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: 16px;
+  height: 22px;
+  margin-left: -8px;
+  border: 2px solid #ffffff;
+  border-radius: 3px;
+  background: transparent;
+  transform-origin: bottom center;
+}


### PR DESCRIPTION
## Summary
- add module to render opponent hand fan indicator and expose via `window.__ui`
- show opponent hand count under end turn button and update from `updateUI`
- style small card fan indicator with white outlines

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install vitest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba897c47548330a96baf0274caed2c