### PR TITLE
feat: show opponent hand size under end turn button

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,15 +37,16 @@
 
     <!-- Верхний центр: номер хода и круглая кнопка с таймером -->
     <div id="top-center" class="ui-panel fixed top-3 left-1/2 -translate-x-1/2 z-20">
-      <div class="overlay-panel px-4 py-3 flex flex-col items-center gap-2">
-        <div id="turn-info" class="text-sm tracking-wide">Turn: 1</div>
-        <button id="end-turn-btn" class="end-turn-btn" aria-label="End Turn">
-          <span class="time-fill"></span>
-          <span class="label-text">End Turn</span>
-          <span class="sec-text">100</span>
-        </button>
+        <div class="overlay-panel px-4 py-3 flex flex-col items-center gap-2">
+          <div id="turn-info" class="text-sm tracking-wide">Turn: 1</div>
+          <button id="end-turn-btn" class="end-turn-btn" aria-label="End Turn">
+            <span class="time-fill"></span>
+            <span class="label-text">End Turn</span>
+            <span class="sec-text">100</span>
+          </button>
+          <div id="opponent-hand" class="opponent-hand" title="0 cards"></div>
+        </div>
       </div>
-    </div>
 
     <!-- Правый нижний угол: сервисные кнопки -->
     <div id="corner-right" class="ui-panel fixed right-4 bottom-4 z-20">
@@ -916,6 +917,13 @@
       const controlB = countControlled(gameState, 1);
       const ci0 = document.getElementById('control-info-0'); if (ci0) ci0.textContent = `Контроль: ${controlA}`;
       const ci1 = document.getElementById('control-info-1'); if (ci1) ci1.textContent = `Контроль: ${controlB}`;
+
+      // Update opponent hand count display via module
+      try {
+        if (window.__ui && window.__ui.opponentHand && typeof window.__ui.opponentHand.render === 'function') {
+          window.__ui.opponentHand.render(gameState);
+        }
+      } catch {}
       
       if (controlA >= 5) {
         showNotification('Player 1 wins!', 'success');

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import * as UIPanels from './ui/panels.js';
 // UI modules
 import * as TurnTimer from './ui/turnTimer.js';
 import * as Banner from './ui/banner.js';
+import * as OpponentHand from './ui/opponentHand.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -134,6 +135,7 @@ try {
   window.__ui.log = UILog;
   window.__ui.mana = UIMana;
   window.__ui.panels = UIPanels;
+  window.__ui.opponentHand = OpponentHand;
 } catch {}
 
 import * as UISync from './ui/sync.js';

--- a/src/ui/opponentHand.js
+++ b/src/ui/opponentHand.js
@@ -1,0 +1,59 @@
+// Opponent hand size display UI
+// Renders a small fan of cards showing how many cards the other player holds
+
+let _el = null;
+
+function _getEl(id = 'opponent-hand') {
+  if (!_el && typeof document !== 'undefined') {
+    _el = document.getElementById(id);
+  }
+  return _el;
+}
+
+export function render(gameState, id = 'opponent-hand') {
+  const el = _getEl(id);
+  if (!el || !gameState || !Array.isArray(gameState.players)) return;
+
+  const mySeat = (typeof window !== 'undefined' && window.MY_SEAT != null)
+    ? window.MY_SEAT
+    : gameState.active;
+  const otherSeat = mySeat === 0 ? 1 : 0;
+  const count = gameState.players?.[otherSeat]?.hand?.length || 0;
+
+  // Clear previous cards
+  el.innerHTML = '';
+
+  const maxDisplay = Math.min(count, 10); // don't overflow visually
+  for (let i = 0; i < maxDisplay; i++) {
+    const card = document.createElement('div');
+    card.className = 'opp-card';
+    // Fan out cards with small rotation/translation
+    const offset = -((maxDisplay - 1) * 6) / 2 + i * 6;
+    const rot = -((maxDisplay - 1) * 3) / 2 + i * 3;
+    card.style.transform = `translateX(${offset}px) rotate(${rot}deg)`;
+    el.appendChild(card);
+  }
+
+  // Update tooltip
+  el.title = `${count} card${count === 1 ? '' : 's'} in opponent's hand`;
+}
+
+export function init(id = 'opponent-hand') {
+  _el = (typeof document !== 'undefined') ? document.getElementById(id) : null;
+  if (typeof window !== 'undefined' && window.gameState) {
+    render(window.gameState, id);
+  }
+  return api;
+}
+
+const api = { init, render };
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.opponentHand = api;
+  }
+} catch {}
+
+export default api;
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -43,6 +43,25 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
   100% { box-shadow: inset 0 2px 10px rgba(0,0,0,0.45), 0 0 0 2px rgba(239,68,68,1.0), 0 0 22px rgba(239,68,68,0.75), 0 0 0 6px rgba(239,68,68,0.28); }
 }
 .end-turn-btn.urgent { animation: urgentPulse 0.8s ease-in-out infinite alternate; }
+
+/* Opponent hand fan under end turn button */
+.opponent-hand {
+  position: relative;
+  width: 84px;
+  height: 26px;
+  margin-top: 4px;
+}
+.opponent-hand .opp-card {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 16px;
+  height: 24px;
+  border: 2px solid #ffffff;
+  border-radius: 3px;
+  background: rgba(255,255,255,0.02);
+  transform-origin: bottom center;
+}
 /* Выделение активного игрока */
 .active-player-panel { 
   box-shadow: 0 0 0 2px rgba(34,197,94,0.9), 0 0 16px rgba(34,197,94,0.45);


### PR DESCRIPTION
## Summary
- show fan of cards under End Turn button to represent opponent hand size
- expose and update opponent hand module alongside other UI modules
- style fan element and refresh it from UI updates with tooltip

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba897c47548330a96baf0274caed2c