### PR TITLE
feat: display opponent hand size

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
           <span class="label-text">End Turn</span>
           <span class="sec-text">100</span>
         </button>
+        <div id="opponent-hand" class="hand-count mt-1" title="0 cards"></div>
       </div>
     </div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import * as UIPanels from './ui/panels.js';
 // UI modules
 import * as TurnTimer from './ui/turnTimer.js';
 import * as Banner from './ui/banner.js';
+import * as OpponentHand from './ui/opponentHand.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -134,7 +135,10 @@ try {
   window.__ui.log = UILog;
   window.__ui.mana = UIMana;
   window.__ui.panels = UIPanels;
+  window.__ui.opponentHand = OpponentHand;
 } catch {}
+
+try { OpponentHand.init(); } catch {}
 
 import * as UISync from './ui/sync.js';
 try { UISync.attachSocketUIRefresh(); if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.sync = UISync; } } catch {}

--- a/src/ui/opponentHand.js
+++ b/src/ui/opponentHand.js
@@ -1,0 +1,83 @@
+// Opponent hand count indicator
+let _container = null;
+let _hooked = false;
+
+function _getContainer() {
+  if (_container) return _container;
+  try {
+    _container = (typeof document !== 'undefined') ? document.getElementById('opponent-hand') : null;
+  } catch {
+    _container = null;
+  }
+  return _container;
+}
+
+function _render(count) {
+  const el = _getContainer();
+  if (!el) return;
+  try {
+    el.innerHTML = '';
+    const maxCards = Math.max(0, Number(count) || 0);
+    const n = Math.min(maxCards, 10);
+    const step = 6; // degrees between cards
+    const start = -(n - 1) * step / 2;
+    for (let i = 0; i < n; i++) {
+      const card = document.createElement('div');
+      card.className = 'hand-count-card';
+      const ang = start + i * step;
+      card.style.transform = `translateX(-50%) rotate(${ang}deg)`;
+      card.style.zIndex = String(i + 1);
+      el.appendChild(card);
+    }
+    el.title = `${maxCards} card${maxCards === 1 ? '' : 's'}`;
+  } catch {}
+}
+
+export function update() {
+  try {
+    const gs = (typeof window !== 'undefined') ? window.gameState : null;
+    const mySeat = (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number') ? window.MY_SEAT : 0;
+    const opp = 1 - mySeat;
+    const count = gs?.players?.[opp]?.hand?.length || 0;
+    _render(count);
+  } catch {}
+}
+
+function _hookUpdateUI() {
+  if (_hooked) return;
+  try {
+    const prev = (typeof window !== 'undefined') ? window.updateUI : null;
+    if (prev) {
+      window.updateUI = function (...args) {
+        const res = prev.apply(this, args);
+        try { update(); } catch {}
+        return res;
+      };
+    } else if (typeof window !== 'undefined') {
+      window.updateUI = function (...args) {
+        const res = undefined;
+        try { update(); } catch {}
+        return res;
+      };
+    }
+  } catch {}
+  _hooked = true;
+}
+
+export function init() {
+  try { _container = null; _getContainer(); } catch {}
+  _hookUpdateUI();
+  try { update(); } catch {}
+  return api;
+}
+
+const api = { init, update };
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.opponentHand = api;
+  }
+} catch {}
+
+export default api;

--- a/styles/main.css
+++ b/styles/main.css
@@ -86,3 +86,15 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 .battle-flash-scan { position:absolute; inset:0; background: linear-gradient( to bottom, transparent 0%, rgba(255,255,255,0.08) 50%, transparent 100% ); transform: translateY(-100%); }
 /* Tooltip для 3D-колод/кладбищ */
 #hover-tooltip { position: fixed; pointer-events: none; z-index: 50; }
+
+/* Opponent hand card count */
+.hand-count { position: relative; width: 84px; height: 32px; }
+.hand-count-card {
+  position: absolute;
+  bottom: 0; left: 50%;
+  width: 24px; height: 32px;
+  border: 2px solid #ffffff;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.05);
+  transform-origin: bottom center;
+}


### PR DESCRIPTION
## Summary
- show fan of cards under end-turn button to indicate opponent hand size
- add UI module that updates the indicator whenever hand changes
- wire module into main initialization and expose via window

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba897c47548330a96baf0274caed2c