### PR TITLE
Fix board and hand init after scene refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,12 +534,21 @@
       } catch {}
     }
 
-    function init() {
+    async function init() {
       wireModules();
       initThreeJS();
       // Start render loop early so scene is visible even if game init fails
       animate();
-      window.__ui.game.initGame();
+      await window.__ui.game.initGame();
+      // sync legacy globals used by inline helpers / status chip
+      try {
+        gameState = window.gameState;
+        const ctx = window.__scene.getCtx();
+        tileMeshes = ctx.tileMeshes || [];
+        tileFrames = ctx.tileFrames || [];
+        window.tileMeshes = tileMeshes;
+        window.tileFrames = tileFrames;
+      } catch {}
       window.__scene.interactions.attachInteractions();
     }
     try { window.init = init; window.initThreeJS = initThreeJS; window.animate = animate; } catch {}

--- a/src/ui/game.js
+++ b/src/ui/game.js
@@ -44,6 +44,12 @@ export async function initGame() {
   gameState = startGame(STARTER_FIRESET, STARTER_FIRESET);
   try { window.gameState = gameState; } catch {}
   createBoard(gameState);
+  // expose board arrays for legacy code (status chip, inline helpers)
+  try {
+    const ctx = getCtx();
+    window.tileMeshes = ctx.tileMeshes;
+    window.tileFrames = ctx.tileFrames;
+  } catch {}
   window.__scene?.interactions?.createMetaObjects(gameState);
   updateUnits(gameState);
   updateHand(gameState);
@@ -75,6 +81,7 @@ export async function initGame() {
   } catch {}
   addLog('The game has begun! Player 1 goes first.');
   addLog('Drag units to the field, use spells by clicking.');
+  return gameState;
 }
 
 // Установка отложенного размещения существа


### PR DESCRIPTION
## Summary
- Sync legacy globals after game init so inline helpers and status chip see board tiles
- Expose board tile arrays from game init for compatibility and return game state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb53278288330bf85b6279220b3cf