### PR TITLE
Fix board initialization regression after refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,6 +540,12 @@
       // Start render loop early so scene is visible even if game init fails
       animate();
       window.__ui.game.initGame();
+      // Sync legacy globals for code still accessing them directly
+      try {
+        gameState = window.gameState;
+        tileMeshes = window.tileMeshes || [];
+        tileFrames = window.tileFrames || [];
+      } catch {}
       window.__scene.interactions.attachInteractions();
     }
     try { window.init = init; window.initThreeJS = initThreeJS; window.animate = animate; } catch {}

--- a/src/scene/board.js
+++ b/src/scene/board.js
@@ -167,5 +167,13 @@ export function createBoard(gameState) {
     ctx.tileFrames.push(frameRow);
   }
 
+  // Expose board arrays for legacy code still relying on globals
+  try {
+    if (typeof window !== 'undefined') {
+      window.tileMeshes = ctx.tileMeshes;
+      window.tileFrames = ctx.tileFrames;
+    }
+  } catch {}
+
   return ctx.tileMeshes;
 }


### PR DESCRIPTION
## Summary
- expose board tile and frame arrays globally for legacy scripts
- sync legacy `gameState` and board arrays after game init

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbb53278288330bf85b6279220b3cf