### PR TITLE
Fix board and hand init by syncing global game state

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
       let tileFrames = [];    // рамки подсветки/выделения клеток
     let unitMeshes = [];      // текущие меши юнитов на поле
     let handCardMeshes = [];  // меши карт в руке игрока
-      let gameState = null;
+      var gameState = null;
       // Tile textures are now managed by scene/board module
     // Настройки показа большой карты при доборе — можно править из консоли
     window.DRAW_CARD_TUNE = {


### PR DESCRIPTION
## Summary
- Ensure global `gameState` variable stays synchronized with `window.gameState` so board and hand render correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb7dcf03c8330883d6c48f9426d09