### PR TITLE
Fix card interaction globals and multiplayer setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@
       let tileFrames = [];    // рамки подсветки/выделения клеток
     let unitMeshes = [];      // текущие меши юнитов на поле
     let handCardMeshes = [];  // меши карт в руке игрока
+    try { window.handCardMeshes = handCardMeshes; } catch {}
       let gameState = window.gameState || null;
       // Tile textures are now managed by scene/board module
     // Настройки показа большой карты при доборе — можно править из консоли
@@ -317,6 +318,7 @@
     // 3D объекты справа (колоды/кладбища)
     let deckMeshes = [];
     let graveyardMeshes = [];
+    try { window.deckMeshes = deckMeshes; window.graveyardMeshes = graveyardMeshes; } catch {}
     let hoveredMeta = null; // { metaType: 'deck'|'grave', player: 0|1 }
     
     // Состояние взаимодействия
@@ -412,6 +414,7 @@
           ? window.__scene.getCtx() : null;
         if (ctx && ctx.handCardMeshes) {
           handCardMeshes = ctx.handCardMeshes;
+          try { window.handCardMeshes = handCardMeshes; } catch {}
         }
       }
     }
@@ -639,6 +642,7 @@
         g.add(base); g.add(icon); metaGroup.add(g); graveyardMeshes.push(g);
       }
       buildDeck(0, zA); buildDeck(1, zB); buildGrave(0, zA); buildGrave(1, zB);
+      try { window.deckMeshes = deckMeshes; window.graveyardMeshes = graveyardMeshes; } catch {}
     }
     
     // Обработчики UI

--- a/src/scene/index.js
+++ b/src/scene/index.js
@@ -81,9 +81,17 @@ export function initThreeJS({ canvasId = 'three-canvas', clearColor = 0x0b1220 }
   ctx.effectsGroup = effectsGroup;
   ctx.metaGroup = metaGroup;
 
-  // Convenience exposure for debugging
+  // Convenience exposure for debugging and legacy access
   try {
-    window.renderer = renderer; window.scene = scene; window.camera = camera; window.boardGroup = boardGroup;
+    window.renderer = renderer;
+    window.scene = scene;
+    window.camera = camera;
+    window.boardGroup = boardGroup;
+    window.cardGroup = cardGroup;
+    window.effectsGroup = effectsGroup;
+    window.metaGroup = metaGroup;
+    window.raycaster = raycaster;
+    window.mouse = mouse;
   } catch {}
 
   // Resize handler


### PR DESCRIPTION
## Summary
- expose scene context objects (raycaster, mouse, groups) on `window`
- share hand, deck, and graveyard mesh arrays globally for interaction modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbbf5726f0833083d848cb681a8cad