### PR TITLE
refactor: extract delta animations and streamline UI hookups

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,6 @@
       let tileMeshes = [];    // 2D массив мешей клеток игрового поля
       let tileFrames = [];    // рамки подсветки/выделения клеток
     let unitMeshes = [];      // текущие меши юнитов на поле
-    let handCardMeshes = [];  // меши карт в руке игрока
       let gameState = null;
       // Tile textures are now managed by scene/board module
     // Настройки показа большой карты при доборе — можно править из консоли
@@ -210,81 +209,9 @@
     // Очереди догоняющих анимаций боя для наблюдателя
     let PENDING_BATTLE_ANIMS = [];
     let PENDING_RETALIATIONS = [];
-    // Recently shown remote damage (to avoid duplicate delta popups)
-    let RECENT_REMOTE_DAMAGE = new Map();
-    try { window.RECENT_REMOTE_DAMAGE = RECENT_REMOTE_DAMAGE; } catch {}
     // Pending HP popups scheduled by playDeltaAnimations, so we can cancel if battleAnim shows earlier
     // HP popup scheduling moved to src/scene/effects.js
     let PENDING_HIDE_HAND_CARDS = [];
-    // Управление анимациями заставки хода и добора карты
-    let lastTurnSplashPromise = Promise.resolve();
-    let lastSplashTurnRequested = 0;
-    let lastSplashTurnShown = 0;
-    let turnSplashTurnQueued = 0;
-    function queueTurnSplash(title) {
-      try {
-        lastTurnSplashPromise = lastTurnSplashPromise.then(() => showTurnSplash(title));
-      } catch {}
-      return lastTurnSplashPromise;
-    }
-    
-    // Функция показа заставки хода
-    async function showTurnSplash(title) {
-      splashActive = true;
-      refreshInputLockUI();
-      
-      const banner = document.getElementById('turn-banner');
-      if (banner) {
-        banner.innerHTML = `<div class="text-4xl font-bold bg-gradient-to-br from-blue-600/80 to-purple-500/80 px-8 py-4 rounded-2xl shadow-2xl ring-4 ring-blue-400/40">${title}</div>`;
-        banner.classList.remove('hidden');
-        banner.classList.add('flex');
-        
-        // Показываем заставку на 1 секунду <-- важно - длительность заставки боя!
-        setTimeout(() => {
-          banner.classList.add('hidden');
-          banner.classList.remove('flex');
-          splashActive = false;
-          refreshInputLockUI();
-        }, 1000);
-      }
-      
-      return new Promise(resolve => setTimeout(resolve, 1000));
-    }
-    // Резерв: гарантированно показать заставку с повтором, если вдруг не отрисовалась
-    async function forceTurnSplashWithRetry(maxRetries = 2) {
-      let tries = 0;
-      let shown = false;
-      while (tries <= maxRetries && !shown) {
-        tries += 1;
-        await requestTurnSplash();
-        // ждем 2 кадра, чтобы DOM успел применить display:flex
-        await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
-        try {
-          const tb = document.getElementById('turn-banner');
-          shown = !!tb && (tb.classList.contains('flex') || tb.style.display === 'flex');
-        } catch {}
-      }
-      // Страховка от зависания блокировки ввода
-      setTimeout(() => { splashActive = false; refreshInputLockUI(); }, 1000);
-    }
-    async function requestTurnSplash() {
-      if (!gameState) return;
-      const currentTurn = gameState.turn;
-      // если уже показали в этом ходу — ничего не делаем
-      if (lastSplashTurnShown >= currentTurn) return lastTurnSplashPromise;
-      // если уже стоит в очереди на этот ход — возвращаем существующий промис
-      if (turnSplashTurnQueued === currentTurn) return lastTurnSplashPromise;
-      lastSplashTurnRequested = currentTurn;
-      turnSplashTurnQueued = currentTurn;
-      const title = `Ход ${currentTurn} - Игрок ${gameState.active + 1}`;
-      // Оборачиваем в промис, который по завершении отмечает ход показанным
-      lastTurnSplashPromise = queueTurnSplash(title).then(() => {
-        try { lastSplashTurnShown = currentTurn; } catch {}
-        if (turnSplashTurnQueued === currentTurn) turnSplashTurnQueued = 0;
-      });
-      return lastTurnSplashPromise;
-    }
-    
     let manaGainActive = false;
     let PENDING_MANA_ANIM = null; // { ownerIndex, startIdx, endIdx }
     let PENDING_MANA_BLOCK = [0,0]; // by player index
@@ -388,30 +315,7 @@
 
     
     // ====== HAND RENDERING AND LAYOUT ======
-    function updateHand() {
-      if (window.__hand && typeof window.__hand.updateHand === 'function') {
-        window.__hand.updateHand(gameState);
-        const ctx = window.__scene && typeof window.__scene.getCtx === 'function'
-          ? window.__scene.getCtx() : null;
-        if (ctx && ctx.handCardMeshes) {
-          handCardMeshes = ctx.handCardMeshes;
-        }
-      }
-      hoveredHandCard = null;
-    }
-
-    function setHandCardHoverVisual(mesh, hovered) {
-      if (window.__hand && typeof window.__hand.setHandCardHoverVisual === 'function') {
-        window.__hand.setHandCardHoverVisual(mesh, hovered);
-      }
-    }
-
-    async function animateDrawnCardToHand(cardTpl) {
-      if (window.__hand && typeof window.__hand.animateDrawnCardToHand === 'function') {
-        return window.__hand.animateDrawnCardToHand(cardTpl);
-      }
-    }
-
+    // Функция updateHand теперь предоставляется модулем Hand и экспортируется в window
     // Синхронизирует 3D-модели юнитов с текущим состоянием gameState
     function updateUnits() {
       if (window.__units && typeof window.__units.updateUnits === 'function') {
@@ -425,104 +329,8 @@
       }
     }
 
-    // Визуализировать изменения между предыдущим и новым состоянием (для наблюдателя/оппонента)
-    // Показывает визуальные различия на поле между предыдущим и новым состоянием
-    function playDeltaAnimations(prevState, nextState) {
-      try {
-        if (!prevState || !nextState) return;
-        
-        // Для активного игрока не показываем числа HP из playDeltaAnimations - они идут из локальных анимаций
-        const isActivePlayer = (typeof MY_SEAT === 'number' && typeof gameState !== 'undefined' && gameState && typeof gameState.active === 'number' && MY_SEAT === gameState.active);
-        
-        const prevB = prevState.board || [];
-        const nextB = nextState.board || [];
-        
-        // Обрабатываем появление/исчезновение юнитов для всех игроков
-        for (let r = 0; r < 3; r++) {
-          for (let c = 0; c < 3; c++) {
-            const pu = (prevB[r] && prevB[r][c] && prevB[r][c].unit) ? prevB[r][c].unit : null;
-            const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
-            if (pu && !nu) {
-              // Юнит исчез — проигрываем шейдерное «исчезновение» фантома и орб маны
-              try {
-                const tile = tileMeshes?.[r]?.[c]; if (!tile) continue;
-                const ghost = createCard3D(CARDS[pu.tplId], false);
-                ghost.position.copy(tile.position).add(new THREE.Vector3(0, 0.28, 0));
-                try { effectsGroup.add(ghost); } catch { cardGroup.add(ghost); }
-                window.__fx.dissolveAndAsh(ghost, new THREE.Vector3(0,0,0.6), 0.9);
-                const p = tile.position.clone().add(new THREE.Vector3(0, 1.2, 0));
-                animateManaGainFromWorld(p, pu.owner, true);
-                try { if (!NET_ACTIVE && gameState && gameState.players && typeof pu.owner === 'number') { gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana||0) + 1); updateUI(); } } catch {}
-              } catch {}
-            } else if (!pu && nu) {
-              // Юнит появился — лёгкий «поп» масштаба
-              try {
-                const tMesh = unitMeshes.find(m => m.userData.row === r && m.userData.col === c);
-                if (tMesh) {
-                  const s = tMesh.scale.clone();
-                  tMesh.scale.set(s.x * 0.7, s.y * 0.7, s.z * 0.7);
-                  gsap.to(tMesh.scale, { x: s.x, y: s.y, z: s.z, duration: 0.28, ease: 'power2.out' });
-                }
-              } catch {}
-            }
-          }
-        }
-        
-        // Для активного игрока не показываем числа HP - они есть в локальных анимациях
-        if (isActivePlayer) {
-          return;
-        }
+    // Взаимодействия с 3D-сценой вынесены в модуль src/scene/interactions.js
 
-        // Для неактивного игрока показываем числа HP с последовательными задержками
-        const hpChanges = [];
-        for (let r = 0; r < 3; r++) {
-          for (let c = 0; c < 3; c++) {
-            const pu = (prevB[r] && prevB[r][c] && prevB[r][c].unit) ? prevB[r][c].unit : null;
-            const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
-            if (pu && nu) {
-              const pHP = (typeof pu.currentHP === 'number') ? pu.currentHP : pu.hp;
-              const nHP = (typeof nu.currentHP === 'number') ? nu.currentHP : nu.hp;
-              const delta = (typeof pHP === 'number' && typeof nHP === 'number') ? (nHP - pHP) : 0;
-              if (delta !== 0) {
-                hpChanges.push({ r, c, delta });
-              }
-            }
-          }
-        }
-
-        // Показываем HP изменения последовательно
-        // Первая половина изменений - через 500мс (после первой атаки)
-        // Вторая половина - через 1300мс (после контратаки)
-        // Filter out recent remote damage already shown during battleAnim/retaliation
-        const __now = Date.now();
-        const pendingHpChanges = (typeof window !== 'undefined' && window.RECENT_REMOTE_DAMAGE && window.RECENT_REMOTE_DAMAGE.size)
-          ? hpChanges.filter(change => {
-              try {
-                const key = `${change.r},${change.c}`;
-                const rec = window.RECENT_REMOTE_DAMAGE.get(key);
-                return !(rec && rec.delta === change.delta && (__now - rec.ts) < 2000);
-              } catch { return true; }
-            })
-          : hpChanges;
-
-        // Schedule HP popups in a cancelable way to sync with remote battle shakes
-        const halfCount = Math.ceil(pendingHpChanges.length / 2);
-        for (let i = 0; i < halfCount && i < pendingHpChanges.length; i++) {
-          const change = pendingHpChanges[i];
-          window.__fx.scheduleHpPopup(change.r, change.c, change.delta, 800);
-        }
-        if (pendingHpChanges.length > halfCount) {
-          for (let i = halfCount; i < pendingHpChanges.length; i++) {
-            const change = pendingHpChanges[i];
-            window.__fx.scheduleHpPopup(change.r, change.c, change.delta, 1600);
-          }
-        }
-      } catch {}
-    }
-    // attachHpOverlay удалён, т.к. HP теперь перерисовывается на самой карте
-    
-      // Взаимодействия с 3D-сценой вынесены в модуль src/scene/interactions.js
-    
     async function initGame() {
       gameState = startGame(STARTER_FIRESET, STARTER_FIRESET);
       try { window.gameState = gameState; } catch {}
@@ -807,7 +615,6 @@
     // UI wrappers: use modules only
     try { showNotification = (message, type) => window.__ui.notifications.show(message, type); } catch {}
     try { addLog = (message) => window.__ui.log.add(message); } catch {}
-    try { animateManaGainFromWorld = (pos, ownerIndex, visualOnly) => window.__ui.mana.animateManaGainFromWorld(pos, ownerIndex, visualOnly); } catch {}
     // animateTurnManaGain теперь вызывается напрямую через модуль
       
 
@@ -1166,47 +973,6 @@
       splashActive = false; refreshInputLockUI();
     }
 
-    async function showTurnSplash(title) {
-      splashActive = true; refreshInputLockUI();
-      const tb = document.getElementById('turn-banner');
-      if (!tb) { splashActive = false; refreshInputLockUI(); return; }
-      tb.innerHTML = '';
-      // Разметка нового экрана
-      const wrap = document.createElement('div'); wrap.className = 'ts-wrap';
-      const bg = document.createElement('div'); bg.className = 'ts-bg'; wrap.appendChild(bg);
-      const ringOuter = document.createElement('div'); ringOuter.className = 'ts-ring thin'; wrap.appendChild(ringOuter);
-      const ringInner = document.createElement('div'); ringInner.className = 'ts-ring'; wrap.appendChild(ringInner);
-      const streaks = document.createElement('div'); streaks.className = 'ts-streaks'; wrap.appendChild(streaks);
-      const txt = document.createElement('div'); txt.className = 'ts-title ts-title-solid text-4xl md:text-6xl'; txt.textContent = title; wrap.appendChild(txt);
-      const scan = document.createElement('div'); scan.className = 'ts-scan'; wrap.appendChild(scan);
-      tb.appendChild(wrap);
-      tb.style.display = 'flex'; tb.classList.remove('hidden'); tb.classList.add('flex');
-      // Анимации (ускорены на 30%)
-      const tl = gsap.timeline();
-      tl.set(txt, { scale: 0.65, opacity: 0 })
-        .set(ringOuter, { scale: 0.8, opacity: 0 })
-        .set(ringInner, { scale: 0.5, opacity: 0 })
-        .fromTo(bg, { opacity: 0 }, { opacity: 0.6, duration: 0.126, ease: 'power2.out' }, 0)
-        .to(ringOuter, { opacity: 1, scale: 1.0, duration: 0.196, ease: 'back.out(2.2)' }, 0.014)
-        .to(ringInner, { opacity: 1, scale: 1.0, duration: 0.224, ease: 'back.out(2.2)' }, 0.042)
-        .to(txt, { opacity: 1, scale: 1.08, duration: 0.252, ease: 'back.out(1.9)' }, 0.056)
-        .to(txt, { scale: 1.0, duration: 0.154, ease: 'power2.out' })
-        .to(scan, { yPercent: 200, duration: 0.49, ease: 'power1.inOut' }, 0.084)
-        .to(streaks, { opacity: 0.25, duration: 0.35 }, 0.14)
-        .to([ringOuter, ringInner], { opacity: 0.9, duration: 0.14 }, 0.315)
-        .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
-        .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
-        .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      await sleep(1330);
-      tb.classList.add('hidden'); tb.classList.remove('flex'); tb.style.display = 'none';
-      tb.style.opacity = '';
-      tb.innerHTML = '';
-      splashActive = false; refreshInputLockUI();
-      try {
-        lastSplashTurnShown = (gameState?.turn || lastSplashTurnShown);
-      } catch {}
-    }
-    
     // (убраны несуществующие обработчики magic-btn и draw-btn)
   </script>
 <!-- MODULE: network/multiplayer (socket.io sync, queue, indicator) -->

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import * as Units from './scene/units.js';
 import * as Hand from './scene/hand.js';
 import * as Interactions from './scene/interactions.js';
 import { getCtx as getSceneCtx } from './scene/context.js';
+import { playDeltaAnimations, RECENT_REMOTE_DAMAGE } from './scene/delta.js';
 // UI modules
 import * as UINotifications from './ui/notifications.js';
 import * as UILog from './ui/log.js';
@@ -158,6 +159,22 @@ try {
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;
   window.burnSpellCard = UISpellUtils.burnSpellCard;
   window.__spells = Spells;
+  // Expose frequently used helpers for legacy inline code
+  window.updateHand = (gs = window.gameState) => Hand.updateHand(gs);
+  window.animateDrawnCardToHand = Hand.animateDrawnCardToHand;
+  window.setHandCardHoverVisual = Hand.setHandCardHoverVisual;
+  window.updateUnits = (gs = window.gameState) => {
+    Units.updateUnits(gs);
+    try { window.unitMeshes = getSceneCtx().unitMeshes; } catch {}
+  };
+  window.animateManaGainFromWorld = UIMana.animateManaGainFromWorld;
+  window.showTurnSplash = Banner.showTurnSplash;
+  window.queueTurnSplash = Banner.queueTurnSplash;
+  window.requestTurnSplash = Banner.requestTurnSplash;
+  window.forceTurnSplashWithRetry = Banner.forceTurnSplashWithRetry;
+  window.ensureTurnSplashVisible = Banner.ensureTurnSplashVisible;
+  window.playDeltaAnimations = playDeltaAnimations;
+  window.RECENT_REMOTE_DAMAGE = RECENT_REMOTE_DAMAGE;
 } catch {}
 
 import * as UISync from './ui/sync.js';

--- a/src/scene/delta.js
+++ b/src/scene/delta.js
@@ -1,0 +1,112 @@
+// Delta animations: visualizes changes between game states (unit spawns, deaths, HP deltas)
+// Extracted from legacy inline script in index.html to allow reuse across modules.
+import { getCtx } from './context.js';
+import { createCard3D } from './cards.js';
+
+// Tracks recently shown remote damage to avoid duplicate popups
+export const RECENT_REMOTE_DAMAGE = new Map();
+try {
+  if (typeof window !== 'undefined') window.RECENT_REMOTE_DAMAGE = RECENT_REMOTE_DAMAGE;
+} catch {}
+
+// Show visual differences between previous and next state
+export function playDeltaAnimations(prevState, nextState) {
+  try {
+    if (!prevState || !nextState) return;
+    const ctx = getCtx();
+    const {
+      tileMeshes = [],
+      unitMeshes = [],
+      effectsGroup,
+      cardGroup,
+      THREE = (typeof window !== 'undefined' ? window.THREE : undefined),
+    } = ctx;
+    const gsap = (typeof window !== 'undefined' ? window.gsap : undefined);
+    const animateManaGainFromWorld = (typeof window !== 'undefined' ? window.animateManaGainFromWorld : undefined);
+    const updateUI = (typeof window !== 'undefined' ? window.updateUI : undefined);
+    const capMana = (typeof window !== 'undefined' ? window.capMana : undefined);
+    const NET_ACTIVE = (typeof window !== 'undefined' ? window.NET_ACTIVE : undefined);
+    const gameState = (typeof window !== 'undefined' ? window.gameState : undefined);
+    const isActivePlayer = (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number' && gameState && typeof gameState.active === 'number' && window.MY_SEAT === gameState.active);
+
+    const prevB = prevState.board || [];
+    const nextB = nextState.board || [];
+
+    // Handle unit removal/appearance
+    for (let r = 0; r < 3; r++) {
+      for (let c = 0; c < 3; c++) {
+        const pu = (prevB[r] && prevB[r][c] && prevB[r][c].unit) ? prevB[r][c].unit : null;
+        const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
+        if (pu && !nu) {
+          try {
+            const tile = tileMeshes?.[r]?.[c];
+            if (!tile) continue;
+            const ghost = createCard3D(window.CARDS[pu.tplId], false);
+            ghost.position.copy(tile.position).add(new THREE.Vector3(0, 0.28, 0));
+            try { effectsGroup.add(ghost); } catch { cardGroup.add(ghost); }
+            window.__fx?.dissolveAndAsh(ghost, new THREE.Vector3(0, 0, 0.6), 0.9);
+            const p = tile.position.clone().add(new THREE.Vector3(0, 1.2, 0));
+            animateManaGainFromWorld?.(p, pu.owner, true);
+            try {
+              if (!NET_ACTIVE && gameState?.players && typeof pu.owner === 'number') {
+                gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana || 0) + 1);
+                updateUI?.(gameState);
+              }
+            } catch {}
+          } catch {}
+        } else if (!pu && nu) {
+          try {
+            const tMesh = unitMeshes.find(m => m.userData.row === r && m.userData.col === c);
+            if (tMesh) {
+              const s = tMesh.scale.clone();
+              tMesh.scale.set(s.x * 0.7, s.y * 0.7, s.z * 0.7);
+              gsap?.to(tMesh.scale, { x: s.x, y: s.y, z: s.z, duration: 0.28, ease: 'power2.out' });
+            }
+          } catch {}
+        }
+      }
+    }
+
+    // Active player already sees HP changes via local animations
+    if (isActivePlayer) return;
+
+    const hpChanges = [];
+    for (let r = 0; r < 3; r++) {
+      for (let c = 0; c < 3; c++) {
+        const pu = (prevB[r] && prevB[r][c] && prevB[r][c].unit) ? prevB[r][c].unit : null;
+        const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
+        if (pu && nu) {
+          const pHP = (typeof pu.currentHP === 'number') ? pu.currentHP : pu.hp;
+          const nHP = (typeof nu.currentHP === 'number') ? nu.currentHP : nu.hp;
+          const delta = (typeof pHP === 'number' && typeof nHP === 'number') ? (nHP - pHP) : 0;
+          if (delta !== 0) hpChanges.push({ r, c, delta });
+        }
+      }
+    }
+
+    const now = Date.now();
+    const pendingHpChanges = (typeof window !== 'undefined' && window.RECENT_REMOTE_DAMAGE && window.RECENT_REMOTE_DAMAGE.size)
+      ? hpChanges.filter(change => {
+          try {
+            const key = `${change.r},${change.c}`;
+            const rec = window.RECENT_REMOTE_DAMAGE.get(key);
+            return !(rec && rec.delta === change.delta && (now - rec.ts) < 2000);
+          } catch { return true; }
+        })
+      : hpChanges;
+
+    const halfCount = Math.ceil(pendingHpChanges.length / 2);
+    for (let i = 0; i < halfCount && i < pendingHpChanges.length; i++) {
+      const change = pendingHpChanges[i];
+      window.__fx?.scheduleHpPopup(change.r, change.c, change.delta, 800);
+    }
+    if (pendingHpChanges.length > halfCount) {
+      for (let i = halfCount; i < pendingHpChanges.length; i++) {
+        const change = pendingHpChanges[i];
+        window.__fx?.scheduleHpPopup(change.r, change.c, change.delta, 1600);
+      }
+    }
+  } catch {}
+}
+
+export default { playDeltaAnimations, RECENT_REMOTE_DAMAGE };


### PR DESCRIPTION
## Summary
- move playDeltaAnimations and damage tracking into new scene/delta module
- expose hand/unit helpers and banner utilities globally from main.js
- drop old inline turn-splash and hand wrappers from index.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe6e58e40833092b40879499343dc