### PR TITLE
Fix mana and draw turn animations

### DIFF
--- a/src/net/client.js
+++ b/src/net/client.js
@@ -223,8 +223,8 @@
   // --- RECEIVING: применяем снапшот и перерисовываем ---
   socket.on('state', async (state)=>{
     if (!state) return;
-    const prev = APPLYING ? null : (gameState ? JSON.parse(JSON.stringify(gameState)) : null);
-    // Robust previous snapshot even if prev is null due to concurrent APPLYING
+    const prev = gameState ? JSON.parse(JSON.stringify(gameState)) : null;
+    // Always capture previous snapshot for diffing even if another apply is in progress
     let __lastTurnSeen = 0;
     try { __lastTurnSeen = (typeof window !== 'undefined' && typeof window.__lastTurnSeen === 'number') ? window.__lastTurnSeen : (gameState?.turn || 0); } catch {}
     const __hadNewTurn = (typeof state.turn === 'number') && (state.turn > (__lastTurnSeen || 0));

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -25,19 +25,14 @@ export function renderBars(gameState) {
     // Apply pending animation window for both clients so +2 doesn't pop in early
     const pending = (anim && anim.ownerIndex === p) ? anim : null;
     const block = Math.max(0, Number(getBlocks()?.[p]) || 0);
-    
-    // If this bar is scheduled or currently animating, avoid rebuilding to prevent flicker
-    if (pending || getManaGainActive()) {
-      continue;
-    }
-    
-    // Если идет анимация получения маны в начале хода и есть _beforeMana, используем его
+
+    // Always rebuild to allow clamping during pending animation
     let displayMana = currentMana;
-    if (typeof beforeMana === 'number' && beforeMana < currentMana) {
+    if (getManaGainActive() && typeof beforeMana === 'number' && pending) {
       displayMana = beforeMana; // Показываем старое значение во время анимации
     }
-    
-    const blockAdjusted = Math.max(0, displayMana - Math.min(block, displayMana));
+
+    const blockAdjusted = Math.max(0, displayMana - block);
     const renderManaBase = pending ? Math.min(blockAdjusted, Math.max(0, pending.startIdx)) : blockAdjusted;
     const renderMana = Math.max(0, Math.min(total, renderManaBase));
     


### PR DESCRIPTION
## Summary
- Always clone previous state on snapshot updates to properly diff turn changes
- Rebuild mana bars during pending animations so both players see accurate mana and gain animations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf75dc7848330b03a16c912919ec3