### PR TITLE
fix: restore mana gain animations

### DIFF
--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -158,11 +158,18 @@ export function animateManaGainFromWorld(pos, ownerIndex, visualOnly = true) {
 export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationMs = 1500) {
   return new Promise(resolve => {
     try {
-      // Проверяем, не идет ли уже анимация
+      // Если предыдущая анимация зависла и флаг не сброшен —
+      // очищаем состояние, чтобы не блокировать новые анимации
       if (getManaGainActive()) {
-        console.warn('Mana animation already in progress, skipping');
-        resolve();
-        return;
+        console.warn('Mana animation flag was stuck, force-resetting');
+        setManaGainActive(false);
+        setAnim(null);
+        try {
+          if (typeof window !== 'undefined' && window.gameState && window.gameState.players && window.gameState.players[ownerIndex]) {
+            delete window.gameState.players[ownerIndex]._beforeMana;
+          }
+        } catch {}
+        try { if (typeof window.updateUI === 'function') window.updateUI(); } catch {}
       }
       
       console.log(`[MANA] Starting animation for player ${ownerIndex}: ${beforeMana} -> ${afterMana}`);


### PR DESCRIPTION
## Summary
- Reset stale mana animation state before starting a new turn animation to avoid skipped animations and outdated mana displays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf75dc7848330b03a16c912919ec3