### PR TITLE
refactor: move end turn handling to ui module

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,99 +217,24 @@
     // HP popup scheduling moved to src/scene/effects.js
     let PENDING_HIDE_HAND_CARDS = [];
     // Управление анимациями заставки хода и добора карты
-    let lastTurnSplashPromise = Promise.resolve();
-    let lastSplashTurnRequested = 0;
-    let lastSplashTurnShown = 0;
-    let turnSplashTurnQueued = 0;
-    function queueTurnSplash(title) {
-      try {
-        lastTurnSplashPromise = lastTurnSplashPromise.then(() => showTurnSplash(title));
-      } catch {}
-      return lastTurnSplashPromise;
-    }
-    
-    // Функция показа заставки хода
-    async function showTurnSplash(title) {
-      splashActive = true;
-      refreshInputLockUI();
-      
-      const banner = document.getElementById('turn-banner');
-      if (banner) {
-        banner.innerHTML = `<div class="text-4xl font-bold bg-gradient-to-br from-blue-600/80 to-purple-500/80 px-8 py-4 rounded-2xl shadow-2xl ring-4 ring-blue-400/40">${title}</div>`;
-        banner.classList.remove('hidden');
-        banner.classList.add('flex');
-        
-        // Показываем заставку на 1 секунду <-- важно - длительность заставки боя!
-        setTimeout(() => {
-          banner.classList.add('hidden');
-          banner.classList.remove('flex');
-          splashActive = false;
-          refreshInputLockUI();
-        }, 1000);
-      }
-      
-      return new Promise(resolve => setTimeout(resolve, 1000));
-    }
-    // Резерв: гарантированно показать заставку с повтором, если вдруг не отрисовалась
-    async function forceTurnSplashWithRetry(maxRetries = 2) {
-      let tries = 0;
-      let shown = false;
-      while (tries <= maxRetries && !shown) {
-        tries += 1;
-        await requestTurnSplash();
-        // ждем 2 кадра, чтобы DOM успел применить display:flex
-        await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
-        try {
-          const tb = document.getElementById('turn-banner');
-          shown = !!tb && (tb.classList.contains('flex') || tb.style.display === 'flex');
-        } catch {}
-      }
-      // Страховка от зависания блокировки ввода
-      setTimeout(() => { splashActive = false; refreshInputLockUI(); }, 1000);
-    }
-    async function requestTurnSplash() {
-      if (!gameState) return;
-      const currentTurn = gameState.turn;
-      // если уже показали в этом ходу — ничего не делаем
-      if (lastSplashTurnShown >= currentTurn) return lastTurnSplashPromise;
-      // если уже стоит в очереди на этот ход — возвращаем существующий промис
-      if (turnSplashTurnQueued === currentTurn) return lastTurnSplashPromise;
-      lastSplashTurnRequested = currentTurn;
-      turnSplashTurnQueued = currentTurn;
-      const title = `Ход ${currentTurn} - Игрок ${gameState.active + 1}`;
-      // Оборачиваем в промис, который по завершении отмечает ход показанным
-      lastTurnSplashPromise = queueTurnSplash(title).then(() => {
-        try { lastSplashTurnShown = currentTurn; } catch {}
-        if (turnSplashTurnQueued === currentTurn) turnSplashTurnQueued = 0;
-      });
-      return lastTurnSplashPromise;
-    }
-    
     let manaGainActive = false;
     let PENDING_MANA_ANIM = null; // { ownerIndex, startIdx, endIdx }
     let PENDING_MANA_BLOCK = [0,0]; // by player index
-// Ожидаемая анимация маны: диапазон новых орбов, которые должны появиться синхронно со вспышкой
-        try { window.PENDING_MANA_ANIM = PENDING_MANA_ANIM; } catch {}
+    try { window.manaGainActive = manaGainActive; } catch {}
+    // Ожидаемая анимация маны: диапазон новых орбов, которые должны появиться синхронно со вспышкой
+    try { window.PENDING_MANA_ANIM = PENDING_MANA_ANIM; } catch {}
     // Блокировка появления N последних орбов маны на панели до завершения «полетевших» визуальных орбов (смерть/эффекты)
-        try { window.PENDING_MANA_BLOCK = PENDING_MANA_BLOCK; } catch {}
+    try { window.PENDING_MANA_BLOCK = PENDING_MANA_BLOCK; } catch {}
     // Прячет один экземпляр ритуального спелла в руке активного игрока, пока ждём выбора жертвы
     let pendingRitualSpellHandIndex = null;
     let pendingRitualSpellCard = null; // ссылка на сам объект карты-спелла, чтобы скрывать по идентичности
     // Сколько последних добранных карт временно скрывать из моей руки (для красивой анимации влёта)
     let pendingDrawCount = 0;
-    function isInputLocked() {
-  const splash = (typeof window !== 'undefined' && window.__ui && window.__ui.banner)
-    ? !!window.__ui.banner.getState()._splashActive : false;
-  return (typeof __endTurnInProgress !== 'undefined' && __endTurnInProgress) ||
-         (typeof drawAnimationActive !== 'undefined' && drawAnimationActive) ||
-         splash || manaGainActive;
-}
-    function refreshInputLockUI() {
-      try {
-        const endBtn = document.getElementById('end-turn-btn');
-        if (endBtn) endBtn.disabled = isInputLocked();
-      } catch {}
-    }
+    try {
+      window.pendingRitualSpellHandIndex = pendingRitualSpellHandIndex;
+      window.pendingRitualSpellCard = pendingRitualSpellCard;
+      window.pendingDrawCount = pendingDrawCount;
+    } catch {}
     // Отступ руки по оси Z (положительное — дальше от камеры)
     const HAND_Z_OFFSET = 1.0;
     // Смещение колод/кладбищ от камеры вдоль оси Z (положительное значение — дальше от камеры)
@@ -534,14 +459,10 @@
       updateHand();
       updateUI();
       // Заставка хода при старте игры с резервом (ускорена)
-      try { 
-        if (window.__ui && window.__ui.banner) {
-          const b = window.__ui.banner; const t = gameState?.turn;
-          const fn = (typeof b.ensureTurnSplashVisible === 'function') ? b.ensureTurnSplashVisible : b.forceTurnSplashWithRetry;
-          await fn.call(b, 2, t);
-        } else {
-          await forceTurnSplashWithRetry(2, gameState?.turn);
-        }
+      try {
+        const b = window.__ui?.banner; const t = gameState?.turn;
+        const fn = b?.ensureTurnSplashVisible || b?.forceTurnSplashWithRetry;
+        if (typeof fn === 'function') await fn.call(b, 2, t);
       } catch {}
       // Запуск таймера на первом ходу
       try { if (window.__turnTimerId) clearInterval(window.__turnTimerId); } catch {}
@@ -565,213 +486,6 @@
       
       addLog('The game has begun! Player 1 goes first.');
       addLog('Drag units to the field, use spells by clicking.');
-    }
-    
-    async function endTurn() {
-      if (!gameState || gameState.winner !== null) return;
-      if (isInputLocked()) return;
-      // Онлайн-гейт: не позволяем завершить ход, если сейчас не ваш ход
-      try {
-        if (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number') {
-          if (gameState.active !== window.MY_SEAT) { showNotification('Opponent\'s turn', 'error'); return; }
-        }
-      } catch {}
-      
-      // Защита от преждевременного завершения хода во время анимаций
-      if (typeof isInputLocked === 'function' ? isInputLocked() : (manaGainActive || drawAnimationActive || splashActive)) {
-        showNotification('Wait for animations to complete', 'warning');
-        return;
-      }
-      
-      __endTurnInProgress = true;
-      // Сброс и запуск таймера хода на 100 секунд
-      try { if (window.__turnTimerId) clearInterval(window.__turnTimerId); } catch {}
-      window.__turnTimerSeconds = 100;
-      (function syncBtn(){ try {
-        const btn = document.getElementById('end-turn-btn');
-        if (btn) {
-          const fill = btn.querySelector('.time-fill');
-          const txt = btn.querySelector('.sec-text');
-          if (txt) txt.textContent = `${window.__turnTimerSeconds}`;
-          if (fill) fill.style.top = `0%`;
-        }
-      } catch {} })();
-      window.__turnTimerId = setInterval(() => {
-        if (typeof window.__turnTimerSeconds !== 'number') window.__turnTimerSeconds = 100;
-        if (window.__turnTimerSeconds > 0) window.__turnTimerSeconds -= 1;
-        try {
-          const btn = document.getElementById('end-turn-btn');
-          if (btn) {
-            const fill = btn.querySelector('.time-fill');
-            const txt = btn.querySelector('.sec-text');
-            const s = Math.max(0, Math.min(100, window.__turnTimerSeconds));
-            if (txt) txt.textContent = `${s}`;
-            const percent = s / 100; // 1 -> top:0%, 0 -> top:100%
-            if (fill) fill.style.top = `${Math.round((1 - percent) * 100)}%`;
-            // Пульсация рамки в последние 10 секунд
-            if (s <= 10) { btn.classList.add('urgent'); } else { btn.classList.remove('urgent'); }
-          }
-        } catch {}
-      }, 1000);
-      try { if (window.__turnTimerId) { clearInterval(window.__turnTimerId); window.__turnTimerId = null; } } catch {}
-      try {
-        if (window.__ui && window.__ui.turnTimer) {
-          const tt = window.__ui.turnTimer.attach('end-turn-btn');
-          const online = (typeof NET_ON === 'function') ? NET_ON() : !!(typeof NET_ACTIVE !== 'undefined' && NET_ACTIVE);
-          if (online) { tt.stop(); } else { tt.reset(100).start(); }
-        }
-      } catch {}
-
-      // Online: delegate authoritative turn advance to the server
-      try {
-        const online = (typeof NET_ON === 'function') ? NET_ON() : !!(typeof NET_ACTIVE !== 'undefined' && NET_ACTIVE);
-        if (online) {
-          try { (window.socket || socket).emit('endTurn'); } catch {}
-          // Keep input locked until server pushes new state/turnSwitched
-          refreshInputLockUI();
-          return;
-        }
-      } catch {}
-      
-      const controlledCells = countControlled(gameState, gameState.active);
-      if (controlledCells >= 5) {
-        gameState.winner = gameState.active;
-        showNotification(`${gameState.players[gameState.active].name} побеждает!`, 'success');
-        return;
-      }
-      
-      // Очистить временные бафы, действующие «до конца хода кастера»
-      try {
-        for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
-          const u = gameState.board[rr][cc].unit; if (!u) continue;
-          if (typeof u.tempAtkBuff === 'number' && u.tempBuffOwner === gameState.active) {
-            delete u.tempAtkBuff; delete u.tempBuffOwner;
-          }
-        }
-      } catch {}
-      gameState.active = gameState.active === 0 ? 1 : 0;
-      gameState.turn += 1;
-
-      // Show start-of-turn splash reliably in offline mode before mana/draw
-      try {
-        if (window.__ui && window.__ui.banner) {
-          const b = window.__ui.banner;
-          if (typeof b.ensureTurnSplashVisible === 'function') {
-            await b.ensureTurnSplashVisible(3, gameState.turn);
-          } else if (typeof b.forceTurnSplashWithRetry === 'function') {
-            await b.forceTurnSplashWithRetry(3, gameState.turn);
-          }
-        } else if (typeof forceTurnSplashWithRetry === 'function') {
-          await forceTurnSplashWithRetry(3);
-        }
-      } catch {}
-      
-      const player = gameState.players[gameState.active];
-      const before = player.mana;
-      const manaAfter = capMana(before + 2);
-      // Карта для анимации: извлекаем
-      const drawnTpl = drawOneNoAdd(gameState, gameState.active);
-      
-      // ВАЖНО: НЕ применяем ману к gameState до анимации - это предотвратит появление орбов до вспышки
-      // Заблокировать преждевременное появление новых орбов до анимации вспышки
-      try { 
-        if (!PENDING_MANA_ANIM && !manaGainActive) {
-          PENDING_MANA_ANIM = window.PENDING_MANA_ANIM = { ownerIndex: gameState.active, startIdx: Math.max(0, Math.min(9, before)), endIdx: Math.max(-1, Math.min(9, manaAfter - 1)) }; 
-        }
-      } catch {}
-      // Clamp UI to beforeMana until animation completes
-      try { if (typeof window !== 'undefined' && window.gameState && window.gameState.players && window.gameState.players[gameState.active]) { window.gameState.players[gameState.active]._beforeMana = before; } } catch {}
-      let shouldAnimateDraw = false;
-      try {
-        const amIActiveNow = (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number')
-          ? (window.MY_SEAT === gameState.active)
-          : true;
-        shouldAnimateDraw = !!(amIActiveNow && drawnTpl);
-        if (!shouldAnimateDraw && drawnTpl) {
-          // Если это не наш клиент — добавим карту сразу (без анимации)
-          try { gameState.players[gameState.active].hand.push(drawnTpl); } catch {}
-        }
-      } catch {}
-      updateHand();
-      // Offline: locally apply state, online path returned earlier
-      try { schedulePush('endTurn-apply', { force: true }); } catch {}
-      
-      window.__interactions.resetCardSelection();
-      
-      updateHand();
-      updateUnits();
-      // updateUI выполнится вместе с анимацией маны (после заставки)
-      // Показ заставки хода: строго блокирующе (визуальная последовательность)
-      try { await forceTurnSplashWithRetry(2, gameState?.turn); } catch {}
-      // Перезапустить таймер хода на 100 сек после заставки (анимация таймера локально у обоих)
-      try { if (window.__turnTimerId) clearInterval(window.__turnTimerId); } catch {}
-      window.__turnTimerSeconds = 100;
-      (function syncBtn(){ try {
-        const btn = document.getElementById('end-turn-btn');
-        if (btn) {
-          const fill = btn.querySelector('.time-fill');
-          const txt = btn.querySelector('.sec-text');
-          if (txt) txt.textContent = `${window.__turnTimerSeconds}`;
-          if (fill) fill.style.top = `0%`;
-        }
-      } catch {} })();
-      window.__turnTimerId = setInterval(() => {
-        if (typeof window.__turnTimerSeconds !== 'number') window.__turnTimerSeconds = 100;
-        if (window.__turnTimerSeconds > 0) window.__turnTimerSeconds -= 1;
-        try {
-          const btn = document.getElementById('end-turn-btn');
-          if (btn) {
-            const fill = btn.querySelector('.time-fill');
-            const txt = btn.querySelector('.sec-text');
-            const s = Math.max(0, Math.min(100, window.__turnTimerSeconds));
-            if (txt) txt.textContent = `${s}`;
-            const percent = s / 100;
-            if (fill) fill.style.top = `${Math.round((1 - percent) * 100)}%`;
-            if (s <= 10) { btn.classList.add('urgent'); } else { btn.classList.remove('urgent'); }
-          }
-        } catch {}
-      }, 1000);
-      // Эффектная анимация маны: показываем у обоих игроков, но для активного — анимируем его панель
-      try { if (window.__turnTimerId) { clearInterval(window.__turnTimerId); window.__turnTimerId = null; } } catch {}
-      try {
-        if (window.__ui && window.__ui.turnTimer) {
-          const tt = window.__ui.turnTimer.attach('end-turn-btn');
-          const online = (typeof NET_ON === 'function') ? NET_ON() : !!(typeof NET_ACTIVE !== 'undefined' && NET_ACTIVE);
-          if (online) { tt.stop(); } else { tt.reset(100).start(); }
-        }
-      } catch {}
-      try { 
-        // Используем модульную функцию с интегрированной анимацией блесток
-        if (window.__ui && window.__ui.mana && typeof window.__ui.mana.animateTurnManaGain === 'function') {
-          await window.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 1500);
-        } else {
-          console.warn('Module mana animation not available, skipping');
-        }
-        // Применяем ману ПОСЛЕ анимации вспышки
-        player.mana = manaAfter;
-      } catch {}
-      // Минимальная задержка (<0.1с) перед началом проявления большой карты
-      await sleep(80);
-      // ВИЗУАЛ: локально проигрываем анимации добора ТОЛЬКО если это наш клиент
-      updateUI();
-      try {
-        if (shouldAnimateDraw && drawnTpl) {
-          // Скрываем «задержанную» карту из руки, пока идёт полёт
-          pendingDrawCount = 1; updateHand();
-          refreshInputLockUI();
-          await animateDrawnCardToHand(drawnTpl);
-          // После полёта добавляем карту в руку и показываем её
-          try { gameState.players[gameState.active].hand.push(drawnTpl); } catch {}
-          pendingDrawCount = 0; updateHand();
-        }
-      } catch { pendingDrawCount = 0; }
-      
-      addLog(`Ход ${gameState.turn}. ${player.name} получает +2 маны и добирает карту.`);
-      
-      // Гарантированная разблокировка ввода
-      __endTurnInProgress = false;
-      manaGainActive = false;
-      refreshInputLockUI();
     }
     
     function animate() {
@@ -843,7 +557,7 @@
     
     // Обработчики UI
     document.getElementById('end-turn-btn').addEventListener('click', () => {
-      try { if (typeof window.endTurn === 'function') window.endTurn(); } catch {}
+      try { window.__ui?.actions?.endTurn(); } catch {}
     });
     refreshInputLockUI();
     document.getElementById('new-game-btn').addEventListener('click', () => location.reload());
@@ -1166,46 +880,6 @@
       splashActive = false; refreshInputLockUI();
     }
 
-    async function showTurnSplash(title) {
-      splashActive = true; refreshInputLockUI();
-      const tb = document.getElementById('turn-banner');
-      if (!tb) { splashActive = false; refreshInputLockUI(); return; }
-      tb.innerHTML = '';
-      // Разметка нового экрана
-      const wrap = document.createElement('div'); wrap.className = 'ts-wrap';
-      const bg = document.createElement('div'); bg.className = 'ts-bg'; wrap.appendChild(bg);
-      const ringOuter = document.createElement('div'); ringOuter.className = 'ts-ring thin'; wrap.appendChild(ringOuter);
-      const ringInner = document.createElement('div'); ringInner.className = 'ts-ring'; wrap.appendChild(ringInner);
-      const streaks = document.createElement('div'); streaks.className = 'ts-streaks'; wrap.appendChild(streaks);
-      const txt = document.createElement('div'); txt.className = 'ts-title ts-title-solid text-4xl md:text-6xl'; txt.textContent = title; wrap.appendChild(txt);
-      const scan = document.createElement('div'); scan.className = 'ts-scan'; wrap.appendChild(scan);
-      tb.appendChild(wrap);
-      tb.style.display = 'flex'; tb.classList.remove('hidden'); tb.classList.add('flex');
-      // Анимации (ускорены на 30%)
-      const tl = gsap.timeline();
-      tl.set(txt, { scale: 0.65, opacity: 0 })
-        .set(ringOuter, { scale: 0.8, opacity: 0 })
-        .set(ringInner, { scale: 0.5, opacity: 0 })
-        .fromTo(bg, { opacity: 0 }, { opacity: 0.6, duration: 0.126, ease: 'power2.out' }, 0)
-        .to(ringOuter, { opacity: 1, scale: 1.0, duration: 0.196, ease: 'back.out(2.2)' }, 0.014)
-        .to(ringInner, { opacity: 1, scale: 1.0, duration: 0.224, ease: 'back.out(2.2)' }, 0.042)
-        .to(txt, { opacity: 1, scale: 1.08, duration: 0.252, ease: 'back.out(1.9)' }, 0.056)
-        .to(txt, { scale: 1.0, duration: 0.154, ease: 'power2.out' })
-        .to(scan, { yPercent: 200, duration: 0.49, ease: 'power1.inOut' }, 0.084)
-        .to(streaks, { opacity: 0.25, duration: 0.35 }, 0.14)
-        .to([ringOuter, ringInner], { opacity: 0.9, duration: 0.14 }, 0.315)
-        .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
-        .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
-        .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      await sleep(1330);
-      tb.classList.add('hidden'); tb.classList.remove('flex'); tb.style.display = 'none';
-      tb.style.opacity = '';
-      tb.innerHTML = '';
-      splashActive = false; refreshInputLockUI();
-      try {
-        lastSplashTurnShown = (gameState?.turn || lastSplashTurnShown);
-      } catch {}
-    }
     
     // (убраны несуществующие обработчики magic-btn и draw-btn)
   </script>

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -1,5 +1,215 @@
-// UI action helpers for rotating units and triggering attacks
-// These functions rely on existing globals to minimize coupling.
+// UI action helpers for rotating units, attacks и завершения хода
+// Функции опираются на глобальные переменные, что позволяет постепенно
+// выносить логику из index.html без полной переписки.
+
+export function isInputLocked() {
+  const splash = (typeof window !== 'undefined' && window.__ui && window.__ui.banner)
+    ? !!window.__ui.banner.getState()._splashActive : false;
+  return (typeof window.__endTurnInProgress !== 'undefined' && window.__endTurnInProgress) ||
+         (typeof window.drawAnimationActive !== 'undefined' && window.drawAnimationActive) ||
+         splash || (typeof window.manaGainActive !== 'undefined' && window.manaGainActive);
+}
+
+export function refreshInputLockUI() {
+  try {
+    const endBtn = document.getElementById('end-turn-btn');
+    if (endBtn) endBtn.disabled = isInputLocked();
+  } catch {}
+}
+
+export async function endTurn() {
+  const showNotification = window.showNotification || (() => {});
+  const gameState = window.gameState;
+  if (!gameState || gameState.winner !== null) return;
+  if (isInputLocked()) {
+    showNotification('Wait for animations to complete', 'warning');
+    return;
+  }
+  // Онлайн-гейт: не позволяем завершить ход, если сейчас не ваш ход
+  try {
+    if (typeof window.MY_SEAT === 'number' && gameState.active !== window.MY_SEAT) {
+      showNotification("Opponent's turn", 'error');
+      return;
+    }
+  } catch {}
+
+  window.__endTurnInProgress = true;
+  try { if (window.__turnTimerId) clearInterval(window.__turnTimerId); } catch {}
+  window.__turnTimerSeconds = 100;
+  (function syncBtn(){ try {
+    const btn = document.getElementById('end-turn-btn');
+    if (btn) {
+      const fill = btn.querySelector('.time-fill');
+      const txt = btn.querySelector('.sec-text');
+      if (txt) txt.textContent = `${window.__turnTimerSeconds}`;
+      if (fill) fill.style.top = `0%`;
+    }
+  } catch {} })();
+  window.__turnTimerId = setInterval(() => {
+    if (typeof window.__turnTimerSeconds !== 'number') window.__turnTimerSeconds = 100;
+    if (window.__turnTimerSeconds > 0) window.__turnTimerSeconds -= 1;
+    try {
+      const btn = document.getElementById('end-turn-btn');
+      if (btn) {
+        const fill = btn.querySelector('.time-fill');
+        const txt = btn.querySelector('.sec-text');
+        const s = Math.max(0, Math.min(100, window.__turnTimerSeconds));
+        if (txt) txt.textContent = `${s}`;
+        const percent = s / 100;
+        if (fill) fill.style.top = `${Math.round((1 - percent) * 100)}%`;
+        if (s <= 10) { btn.classList.add('urgent'); } else { btn.classList.remove('urgent'); }
+      }
+    } catch {}
+  }, 1000);
+  try { if (window.__turnTimerId) { clearInterval(window.__turnTimerId); window.__turnTimerId = null; } } catch {}
+  try {
+    if (window.__ui && window.__ui.turnTimer) {
+      const tt = window.__ui.turnTimer.attach('end-turn-btn');
+      const online = (typeof window.NET_ON === 'function') ? window.NET_ON() : !!(typeof window.NET_ACTIVE !== 'undefined' && window.NET_ACTIVE);
+      if (online) { tt.stop(); } else { tt.reset(100).start(); }
+    }
+  } catch {}
+
+  // Online: delegate authoritative turn advance to the server
+  try {
+    const online = (typeof window.NET_ON === 'function') ? window.NET_ON() : !!(typeof window.NET_ACTIVE !== 'undefined' && window.NET_ACTIVE);
+    if (online) {
+      try { (window.socket || window.socket)?.emit?.('endTurn'); } catch {}
+      refreshInputLockUI();
+      return;
+    }
+  } catch {}
+
+  const controlledCells = (typeof window.countControlled === 'function') ? window.countControlled(gameState, gameState.active) : 0;
+  if (controlledCells >= 5) {
+    gameState.winner = gameState.active;
+    showNotification(`${gameState.players[gameState.active].name} побеждает!`, 'success');
+    return;
+  }
+
+  // Очистить временные бафы, действующие «до конца хода кастера»
+  try {
+    for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
+      const u = gameState.board[rr][cc].unit; if (!u) continue;
+      if (typeof u.tempAtkBuff === 'number' && u.tempBuffOwner === gameState.active) {
+        delete u.tempAtkBuff; delete u.tempBuffOwner;
+      }
+    }
+  } catch {}
+  gameState.active = gameState.active === 0 ? 1 : 0;
+  gameState.turn += 1;
+
+  // Показ заставки хода до маны/добора
+  try {
+    const b = window.__ui?.banner;
+    const fn = b?.ensureTurnSplashVisible || b?.forceTurnSplashWithRetry;
+    if (typeof fn === 'function') await fn.call(b, 3, gameState.turn);
+  } catch {}
+
+  const player = gameState.players[gameState.active];
+  const before = player.mana;
+  const capMana = window.capMana || ((x) => x);
+  const manaAfter = capMana(before + 2);
+  const drawOneNoAdd = window.drawOneNoAdd || (() => null);
+  const drawnTpl = drawOneNoAdd(gameState, gameState.active);
+
+  try {
+    if (!window.PENDING_MANA_ANIM && !window.manaGainActive) {
+      window.PENDING_MANA_ANIM = { ownerIndex: gameState.active, startIdx: Math.max(0, Math.min(9, before)), endIdx: Math.max(-1, Math.min(9, manaAfter - 1)) };
+    }
+  } catch {}
+  try {
+    if (window.gameState?.players?.[gameState.active]) {
+      window.gameState.players[gameState.active]._beforeMana = before;
+    }
+  } catch {}
+  let shouldAnimateDraw = false;
+  try {
+    const amIActiveNow = (typeof window.MY_SEAT === 'number') ? (window.MY_SEAT === gameState.active) : true;
+    shouldAnimateDraw = !!(amIActiveNow && drawnTpl);
+    if (!shouldAnimateDraw && drawnTpl) {
+      gameState.players[gameState.active].hand.push(drawnTpl);
+    }
+  } catch {}
+
+  window.updateHand?.();
+  try { window.schedulePush?.('endTurn-apply', { force: true }); } catch {}
+
+  window.__interactions?.resetCardSelection?.();
+  window.updateHand?.();
+  window.updateUnits?.();
+
+  // Показ заставки хода: блокирующе
+  try {
+    const b = window.__ui?.banner;
+    const fn = b?.forceTurnSplashWithRetry;
+    if (typeof fn === 'function') await fn.call(b, 2, gameState.turn);
+  } catch {}
+
+  try { if (window.__turnTimerId) clearInterval(window.__turnTimerId); } catch {}
+  window.__turnTimerSeconds = 100;
+  (function syncBtn2(){ try {
+    const btn = document.getElementById('end-turn-btn');
+    if (btn) {
+      const fill = btn.querySelector('.time-fill');
+      const txt = btn.querySelector('.sec-text');
+      if (txt) txt.textContent = `${window.__turnTimerSeconds}`;
+      if (fill) fill.style.top = `0%`;
+    }
+  } catch {} })();
+  window.__turnTimerId = setInterval(() => {
+    if (typeof window.__turnTimerSeconds !== 'number') window.__turnTimerSeconds = 100;
+    if (window.__turnTimerSeconds > 0) window.__turnTimerSeconds -= 1;
+    try {
+      const btn = document.getElementById('end-turn-btn');
+      if (btn) {
+        const fill = btn.querySelector('.time-fill');
+        const txt = btn.querySelector('.sec-text');
+        const s = Math.max(0, Math.min(100, window.__turnTimerSeconds));
+        if (txt) txt.textContent = `${s}`;
+        const percent = s / 100;
+        if (fill) fill.style.top = `${Math.round((1 - percent) * 100)}%`;
+        if (s <= 10) { btn.classList.add('urgent'); } else { btn.classList.remove('urgent'); }
+      }
+    } catch {}
+  }, 1000);
+  try { if (window.__turnTimerId) { clearInterval(window.__turnTimerId); window.__turnTimerId = null; } } catch {}
+  try {
+    if (window.__ui && window.__ui.turnTimer) {
+      const tt = window.__ui.turnTimer.attach('end-turn-btn');
+      const online = (typeof window.NET_ON === 'function') ? window.NET_ON() : !!(typeof window.NET_ACTIVE !== 'undefined' && window.NET_ACTIVE);
+      if (online) { tt.stop(); } else { tt.reset(100).start(); }
+    }
+  } catch {}
+
+  try {
+    if (window.__ui && window.__ui.mana && typeof window.__ui.mana.animateTurnManaGain === 'function') {
+      await window.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 1500);
+    } else {
+      console.warn('Module mana animation not available, skipping');
+    }
+    player.mana = manaAfter;
+  } catch {}
+
+  const sleep = window.sleep || (ms => new Promise(r => setTimeout(r, ms)));
+  await sleep(80);
+  window.updateUI?.();
+  try {
+    if (shouldAnimateDraw && drawnTpl) {
+      window.pendingDrawCount = 1; window.updateHand?.();
+      refreshInputLockUI();
+      await window.animateDrawnCardToHand?.(drawnTpl);
+      try { gameState.players[gameState.active].hand.push(drawnTpl); } catch {}
+      window.pendingDrawCount = 0; window.updateHand?.();
+    }
+  } catch { window.pendingDrawCount = 0; }
+
+  window.__ui?.log?.add?.(`Ход ${gameState.turn}. ${player.name} получает +2 маны и добирает карту.`);
+
+  window.__endTurnInProgress = false;
+  window.manaGainActive = false;
+  refreshInputLockUI();
+}
 
 export function rotateUnit(unitMesh, dir) {
   try {
@@ -75,6 +285,14 @@ export function performUnitAttack(unitMesh) {
   } catch {}
 }
 
-const api = { rotateUnit, performUnitAttack };
-try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.actions = api; } } catch {}
+const api = { rotateUnit, performUnitAttack, endTurn, isInputLocked, refreshInputLockUI };
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.actions = api;
+    window.endTurn = endTurn;
+    window.isInputLocked = isInputLocked;
+    window.refreshInputLockUI = refreshInputLockUI;
+  }
+} catch {}
 export default api;


### PR DESCRIPTION
## Summary
- move endTurn, isInputLocked and refreshInputLockUI into `src/ui/actions.js`
- call end-turn logic through the UI actions module and drop inline turn-splash helpers
- expose runtime state helpers for mana/ritual handling directly on `window`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf81300688330a3bef356ed800cad