### PR TITLE
refactor: extract meta objects and banners

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,75 +216,6 @@
     // Pending HP popups scheduled by playDeltaAnimations, so we can cancel if battleAnim shows earlier
     // HP popup scheduling moved to src/scene/effects.js
     let PENDING_HIDE_HAND_CARDS = [];
-    // Управление анимациями заставки хода и добора карты
-    let lastTurnSplashPromise = Promise.resolve();
-    let lastSplashTurnRequested = 0;
-    let lastSplashTurnShown = 0;
-    let turnSplashTurnQueued = 0;
-    function queueTurnSplash(title) {
-      try {
-        lastTurnSplashPromise = lastTurnSplashPromise.then(() => showTurnSplash(title));
-      } catch {}
-      return lastTurnSplashPromise;
-    }
-    
-    // Функция показа заставки хода
-    async function showTurnSplash(title) {
-      splashActive = true;
-      refreshInputLockUI();
-      
-      const banner = document.getElementById('turn-banner');
-      if (banner) {
-        banner.innerHTML = `<div class="text-4xl font-bold bg-gradient-to-br from-blue-600/80 to-purple-500/80 px-8 py-4 rounded-2xl shadow-2xl ring-4 ring-blue-400/40">${title}</div>`;
-        banner.classList.remove('hidden');
-        banner.classList.add('flex');
-        
-        // Показываем заставку на 1 секунду <-- важно - длительность заставки боя!
-        setTimeout(() => {
-          banner.classList.add('hidden');
-          banner.classList.remove('flex');
-          splashActive = false;
-          refreshInputLockUI();
-        }, 1000);
-      }
-      
-      return new Promise(resolve => setTimeout(resolve, 1000));
-    }
-    // Резерв: гарантированно показать заставку с повтором, если вдруг не отрисовалась
-    async function forceTurnSplashWithRetry(maxRetries = 2) {
-      let tries = 0;
-      let shown = false;
-      while (tries <= maxRetries && !shown) {
-        tries += 1;
-        await requestTurnSplash();
-        // ждем 2 кадра, чтобы DOM успел применить display:flex
-        await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
-        try {
-          const tb = document.getElementById('turn-banner');
-          shown = !!tb && (tb.classList.contains('flex') || tb.style.display === 'flex');
-        } catch {}
-      }
-      // Страховка от зависания блокировки ввода
-      setTimeout(() => { splashActive = false; refreshInputLockUI(); }, 1000);
-    }
-    async function requestTurnSplash() {
-      if (!gameState) return;
-      const currentTurn = gameState.turn;
-      // если уже показали в этом ходу — ничего не делаем
-      if (lastSplashTurnShown >= currentTurn) return lastTurnSplashPromise;
-      // если уже стоит в очереди на этот ход — возвращаем существующий промис
-      if (turnSplashTurnQueued === currentTurn) return lastTurnSplashPromise;
-      lastSplashTurnRequested = currentTurn;
-      turnSplashTurnQueued = currentTurn;
-      const title = `Ход ${currentTurn} - Игрок ${gameState.active + 1}`;
-      // Оборачиваем в промис, который по завершении отмечает ход показанным
-      lastTurnSplashPromise = queueTurnSplash(title).then(() => {
-        try { lastSplashTurnShown = currentTurn; } catch {}
-        if (turnSplashTurnQueued === currentTurn) turnSplashTurnQueued = 0;
-      });
-      return lastTurnSplashPromise;
-    }
-    
     let manaGainActive = false;
     let PENDING_MANA_ANIM = null; // { ownerIndex, startIdx, endIdx }
     let PENDING_MANA_BLOCK = [0,0]; // by player index
@@ -312,11 +243,7 @@
     }
     // Отступ руки по оси Z (положительное — дальше от камеры)
     const HAND_Z_OFFSET = 1.0;
-    // Смещение колод/кладбищ от камеры вдоль оси Z (положительное значение — дальше от камеры)
-    const META_Z_AWAY = 1.5;
-    // 3D объекты справа (колоды/кладбища)
-    let deckMeshes = [];
-    let graveyardMeshes = [];
+    // 3D объекты справа (колоды/кладбища) создаёт модуль scene/meta.js
 
     // === THREE.JS SCENE INITIALIZATION ===
     function initThreeJS() {
@@ -529,18 +456,15 @@
       
       // Сразу строим сцену и мета-объекты, без задержки появления
       createBoard();
-      createMetaObjects();
+      window.__meta.createMetaObjects(gameState);
       updateUnits();
       updateHand();
       updateUI();
       // Заставка хода при старте игры с резервом (ускорена)
-      try { 
-        if (window.__ui && window.__ui.banner) {
-          const b = window.__ui.banner; const t = gameState?.turn;
-          const fn = (typeof b.ensureTurnSplashVisible === 'function') ? b.ensureTurnSplashVisible : b.forceTurnSplashWithRetry;
-          await fn.call(b, 2, t);
-        } else {
-          await forceTurnSplashWithRetry(2, gameState?.turn);
+      try {
+        const b = window.__ui?.banner;
+        if (b && typeof b.ensureTurnSplashVisible === 'function') {
+          await b.ensureTurnSplashVisible(2, gameState?.turn);
         }
       } catch {}
       // Запуск таймера на первом ходу
@@ -606,35 +530,7 @@
     // animateTurnManaGain теперь вызывается напрямую через модуль
       
 
-    function createMetaObjects() {
-      // Очистить предыдущие
-      deckMeshes.forEach(m => m.parent && m.parent.remove(m));
-      graveyardMeshes.forEach(m => m.parent && m.parent.remove(m));
-      deckMeshes = []; graveyardMeshes = [];
-      if (!gameState) return;
-      const baseX = (6.2 + 0.2) * 1 + 6.6; // правее поля
-      const zA = -5.2 - META_Z_AWAY; const zB = 0.2 + META_Z_AWAY; // Важно (смещение колоды/кладбища от камеры)
-      function buildDeck(player, z) {
-        const g = new THREE.Group(); g.position.set(baseX, 0.5, z); g.userData = { metaType: 'deck', player };
-        const sideMap = (CARD_TEX && CARD_TEX.deckSide) ? CARD_TEX.deckSide : window.__cards.getCachedTexture('textures/card_deck_side_view.jpeg');
-        const backMap = (CARD_TEX && CARD_TEX.back) ? CARD_TEX.back : window.__cards.getCachedTexture('textures/card_back_main.jpeg');
-        const sideMat = new THREE.MeshStandardMaterial({ map: sideMap, color: 0xffffff, metalness: 0.3, roughness: 0.85 });
-        const body = new THREE.Mesh(new THREE.BoxGeometry(3.6, 0.8, 5.0), sideMat);
-        body.castShadow = true; body.receiveShadow = true; body.userData = { metaType: 'deck', player };
-        const top = new THREE.Mesh(new THREE.BoxGeometry(3.62, 0.04, 5.02), new THREE.MeshStandardMaterial({ map: backMap, color: 0xffffff }));
-        top.position.y = 0.42; top.userData = { metaType: 'deck', player };
-        g.add(body); g.add(top); metaGroup.add(g); deckMeshes.push(g);
-      }
-      function buildGrave(player, z) {
-        const g = new THREE.Group(); g.position.set(baseX + 4.2, 0.5, z); g.userData = { metaType: 'grave', player };
-        const base = new THREE.Mesh(new THREE.CylinderGeometry(1.2, 1.2, 0.3, 20), new THREE.MeshStandardMaterial({ color: 0x334155 }));
-        base.userData = { metaType: 'grave', player };
-        const icon = new THREE.Mesh(new THREE.BoxGeometry(1.0, 1.2, 0.1), new THREE.MeshStandardMaterial({ color: 0x64748b }));
-        icon.position.y = 0.9; icon.rotation.y = Math.PI / 8; icon.userData = { metaType: 'grave', player };
-        g.add(base); g.add(icon); metaGroup.add(g); graveyardMeshes.push(g);
-      }
-      buildDeck(0, zA); buildDeck(1, zB); buildGrave(0, zA); buildGrave(1, zB);
-    }
+    // createMetaObjects перенесена в scene/meta.js
     
     // Обработчики UI
     document.getElementById('end-turn-btn').addEventListener('click', () => {
@@ -728,7 +624,7 @@
       const staged = stagedAttack(gameState, r, c);
       if (!staged || staged.empty) return;
       // flashy заставка BATTLE (сокращённая)
-      await showBattleSplash();
+      await window.__ui.battleBanner.showBattleSplash();
       // небольшая анимация выпада/толчка
       const aMesh = unitMeshes.find(m => m.userData.row === r && m.userData.col === c);
       const hitsPrev = (staged.targetsPreview || computeHits(gameState, r, c));
@@ -749,7 +645,7 @@
         }
         setTimeout(async () => {
           // Сокращённая пауза перед контратакой
-          await sleep(700);
+          await window.__ui.banner.sleep(700);
           const ret = staged.step2() || { total: 0, retaliators: [] };
           const retaliation = typeof ret === 'number' ? ret : (ret.total || 0);
           let animDelayMs = 0;
@@ -923,85 +819,6 @@
         try { schedulePush('magic-battle-finish'); } catch {}
       }
     }
-    // Вспомогательные утилиты: задержка и яркая заставка BATTLE на 3 секунды
-    function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
-    async function showBattleSplash() {
-      splashActive = true; refreshInputLockUI();
-      const bb = document.getElementById('battle-banner');
-      if (!bb) { splashActive = false; refreshInputLockUI(); return; }
-      bb.innerHTML = '';
-      const wrap = document.createElement('div'); wrap.className = 'ts-wrap';
-      const bg = document.createElement('div'); bg.className = 'ts-bg'; wrap.appendChild(bg);
-      const ringOuter = document.createElement('div'); ringOuter.className = 'ts-ring thin'; wrap.appendChild(ringOuter);
-      const ringInner = document.createElement('div'); ringInner.className = 'ts-ring'; wrap.appendChild(ringInner);
-      const streaks = document.createElement('div'); streaks.className = 'ts-streaks'; wrap.appendChild(streaks);
-      const txt = document.createElement('div'); txt.className = 'ts-title ts-title-solid text-6xl md:text-8xl'; txt.textContent = 'BATTLE'; wrap.appendChild(txt);
-      const scan = document.createElement('div'); scan.className = 'ts-scan'; wrap.appendChild(scan);
-      bb.appendChild(wrap);
-      bb.style.display = 'flex'; bb.classList.remove('hidden'); bb.classList.add('flex');
-      const tl = gsap.timeline();
-      tl.set(txt, { scale: 0.65, opacity: 0 })
-        .set(ringOuter, { scale: 0.8, opacity: 0 })
-        .set(ringInner, { scale: 0.5, opacity: 0 })
-        .fromTo(bg, { opacity: 0 }, { opacity: 0.6, duration: 0.126, ease: 'power2.out' }, 0)
-        .to(ringOuter, { opacity: 1, scale: 1.0, duration: 0.196, ease: 'back.out(2.2)' }, 0.014)
-        .to(ringInner, { opacity: 1, scale: 1.0, duration: 0.224, ease: 'back.out(2.2)' }, 0.042)
-        .to(txt, { opacity: 1, scale: 1.08, duration: 0.252, ease: 'back.out(1.9)' }, 0.056)
-        .to(txt, { scale: 1.0, duration: 0.154, ease: 'power2.out' })
-        .to(scan, { yPercent: 200, duration: 0.49, ease: 'power1.inOut' }, 0.084)
-        .to(streaks, { opacity: 0.25, duration: 0.35 }, 0.14)
-        .to([ringOuter, ringInner], { opacity: 0.9, duration: 0.14 }, 0.315)
-        .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
-        .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
-        .to(bb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      await sleep(1330);
-      bb.classList.add('hidden'); bb.classList.remove('flex'); bb.style.display = 'none';
-      bb.style.opacity = '';
-      bb.innerHTML = '';
-      splashActive = false; refreshInputLockUI();
-    }
-
-    async function showTurnSplash(title) {
-      splashActive = true; refreshInputLockUI();
-      const tb = document.getElementById('turn-banner');
-      if (!tb) { splashActive = false; refreshInputLockUI(); return; }
-      tb.innerHTML = '';
-      // Разметка нового экрана
-      const wrap = document.createElement('div'); wrap.className = 'ts-wrap';
-      const bg = document.createElement('div'); bg.className = 'ts-bg'; wrap.appendChild(bg);
-      const ringOuter = document.createElement('div'); ringOuter.className = 'ts-ring thin'; wrap.appendChild(ringOuter);
-      const ringInner = document.createElement('div'); ringInner.className = 'ts-ring'; wrap.appendChild(ringInner);
-      const streaks = document.createElement('div'); streaks.className = 'ts-streaks'; wrap.appendChild(streaks);
-      const txt = document.createElement('div'); txt.className = 'ts-title ts-title-solid text-4xl md:text-6xl'; txt.textContent = title; wrap.appendChild(txt);
-      const scan = document.createElement('div'); scan.className = 'ts-scan'; wrap.appendChild(scan);
-      tb.appendChild(wrap);
-      tb.style.display = 'flex'; tb.classList.remove('hidden'); tb.classList.add('flex');
-      // Анимации (ускорены на 30%)
-      const tl = gsap.timeline();
-      tl.set(txt, { scale: 0.65, opacity: 0 })
-        .set(ringOuter, { scale: 0.8, opacity: 0 })
-        .set(ringInner, { scale: 0.5, opacity: 0 })
-        .fromTo(bg, { opacity: 0 }, { opacity: 0.6, duration: 0.126, ease: 'power2.out' }, 0)
-        .to(ringOuter, { opacity: 1, scale: 1.0, duration: 0.196, ease: 'back.out(2.2)' }, 0.014)
-        .to(ringInner, { opacity: 1, scale: 1.0, duration: 0.224, ease: 'back.out(2.2)' }, 0.042)
-        .to(txt, { opacity: 1, scale: 1.08, duration: 0.252, ease: 'back.out(1.9)' }, 0.056)
-        .to(txt, { scale: 1.0, duration: 0.154, ease: 'power2.out' })
-        .to(scan, { yPercent: 200, duration: 0.49, ease: 'power1.inOut' }, 0.084)
-        .to(streaks, { opacity: 0.25, duration: 0.35 }, 0.14)
-        .to([ringOuter, ringInner], { opacity: 0.9, duration: 0.14 }, 0.315)
-        .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
-        .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
-        .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      await sleep(1330);
-      tb.classList.add('hidden'); tb.classList.remove('flex'); tb.style.display = 'none';
-      tb.style.opacity = '';
-      tb.innerHTML = '';
-      splashActive = false; refreshInputLockUI();
-      try {
-        lastSplashTurnShown = (gameState?.turn || lastSplashTurnShown);
-      } catch {}
-    }
-    
     // (убраны несуществующие обработчики magic-btn и draw-btn)
   </script>
 <!-- MODULE: network/multiplayer (socket.io sync, queue, indicator) -->

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import * as Units from './scene/units.js';
 import * as Hand from './scene/hand.js';
 import * as Interactions from './scene/interactions.js';
 import { getCtx as getSceneCtx } from './scene/context.js';
+import * as Meta from './scene/meta.js';
 // UI modules
 import * as UINotifications from './ui/notifications.js';
 import * as UILog from './ui/log.js';
@@ -21,6 +22,7 @@ import * as UIPanels from './ui/panels.js';
 // UI modules
 import * as TurnTimer from './ui/turnTimer.js';
 import * as Banner from './ui/banner.js';
+import * as BattleBanner from './ui/battleBanner.js';
 import * as HandCount from './ui/handCount.js';
 import { updateUI } from './ui/update.js';
 import * as UIActions from './ui/actions.js';
@@ -141,10 +143,12 @@ try {
     updateHand: Hand.updateHand,
     animateDrawnCardToHand: Hand.animateDrawnCardToHand,
   };
+  window.__meta = Meta;
   window.__interactions = Interactions;
   window.__ui = window.__ui || {};
   window.__ui.turnTimer = TurnTimer;
   window.__ui.banner = Banner;
+  window.__ui.battleBanner = BattleBanner;
   window.__ui.notifications = UINotifications;
   window.__ui.log = UILog;
   window.__ui.mana = UIMana;
@@ -158,6 +162,8 @@ try {
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;
   window.burnSpellCard = UISpellUtils.burnSpellCard;
   window.__spells = Spells;
+  window.deckMeshes = Meta.deckMeshes;
+  window.graveyardMeshes = Meta.graveyardMeshes;
 } catch {}
 
 import * as UISync from './ui/sync.js';

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -1,6 +1,7 @@
 // Pointer and drag interactions for Three.js scene
 import { getCtx } from './context.js';
 import { setHandCardHoverVisual } from './hand.js';
+import { deckMeshes, graveyardMeshes } from './meta.js';
 
 // Centralized interaction state
 export const interactionState = {
@@ -94,8 +95,6 @@ function onMouseMove(event) {
 
   // Tooltip for decks/graveyards
   raycaster.setFromCamera(mouse, ctx.camera);
-  const deckMeshes = (typeof window !== 'undefined' && window.deckMeshes) || [];
-  const graveyardMeshes = (typeof window !== 'undefined' && window.graveyardMeshes) || [];
   const metaHits = raycaster.intersectObjects([...deckMeshes, ...graveyardMeshes], true);
   const tip = document.getElementById('hover-tooltip');
   if (metaHits.length > 0) {

--- a/src/scene/meta.js
+++ b/src/scene/meta.js
@@ -1,0 +1,83 @@
+import { getCtx } from './context.js';
+import { getCachedTexture, CARD_TEX } from './cards.js';
+
+export let deckMeshes = [];
+export let graveyardMeshes = [];
+
+const META_Z_AWAY = 1.5;
+
+export function createMetaObjects(gameState) {
+  const ctx = getCtx();
+  const { THREE, metaGroup } = ctx;
+  if (!THREE || !metaGroup) return;
+
+  // Очистка предыдущих
+  deckMeshes.forEach(m => m.parent && m.parent.remove(m));
+  graveyardMeshes.forEach(m => m.parent && m.parent.remove(m));
+  deckMeshes = [];
+  graveyardMeshes = [];
+  if (!gameState) return;
+
+  const baseX = (6.2 + 0.2) * 1 + 6.6;
+  const zA = -5.2 - META_Z_AWAY;
+  const zB = 0.2 + META_Z_AWAY;
+
+  function buildDeck(player, z) {
+    const g = new THREE.Group();
+    g.position.set(baseX, 0.5, z);
+    g.userData = { metaType: 'deck', player };
+    const sideMap = (CARD_TEX && CARD_TEX.deckSide)
+      ? CARD_TEX.deckSide
+      : getCachedTexture('textures/card_deck_side_view.jpeg');
+    const backMap = (CARD_TEX && CARD_TEX.back)
+      ? CARD_TEX.back
+      : getCachedTexture('textures/card_back_main.jpeg');
+    const sideMat = new THREE.MeshStandardMaterial({
+      map: sideMap,
+      color: 0xffffff,
+      metalness: 0.3,
+      roughness: 0.85,
+    });
+    const body = new THREE.Mesh(new THREE.BoxGeometry(3.6, 0.8, 5.0), sideMat);
+    body.castShadow = true;
+    body.receiveShadow = true;
+    body.userData = { metaType: 'deck', player };
+    const top = new THREE.Mesh(
+      new THREE.BoxGeometry(3.62, 0.04, 5.02),
+      new THREE.MeshStandardMaterial({ map: backMap, color: 0xffffff })
+    );
+    top.position.y = 0.42;
+    top.userData = { metaType: 'deck', player };
+    g.add(body);
+    g.add(top);
+    metaGroup.add(g);
+    deckMeshes.push(g);
+  }
+
+  function buildGrave(player, z) {
+    const g = new THREE.Group();
+    g.position.set(baseX + 4.2, 0.5, z);
+    g.userData = { metaType: 'grave', player };
+    const base = new THREE.Mesh(
+      new THREE.CylinderGeometry(1.2, 1.2, 0.3, 20),
+      new THREE.MeshStandardMaterial({ color: 0x334155 })
+    );
+    base.userData = { metaType: 'grave', player };
+    const icon = new THREE.Mesh(
+      new THREE.BoxGeometry(1.0, 1.2, 0.1),
+      new THREE.MeshStandardMaterial({ color: 0x64748b })
+    );
+    icon.position.y = 0.9;
+    icon.rotation.y = Math.PI / 8;
+    icon.userData = { metaType: 'grave', player };
+    g.add(base);
+    g.add(icon);
+    metaGroup.add(g);
+    graveyardMeshes.push(g);
+  }
+
+  buildDeck(0, zA);
+  buildDeck(1, zB);
+  buildGrave(0, zA);
+  buildGrave(1, zB);
+}

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -16,7 +16,7 @@ function setSplashActive(v) {
   } catch {}
 }
 
-function sleep(ms){ return new Promise(r=>setTimeout(r, ms)); }
+export function sleep(ms){ return new Promise(r=>setTimeout(r, ms)); }
 
 export async function showTurnSplash(title) {
   if (_splashInProgress) {
@@ -189,6 +189,6 @@ export function getState(){
   return { _splashActive, _lastRequestedTurn, _lastShownTurn };
 }
 
-const api = { showTurnSplash, queueTurnSplash, requestTurnSplash, forceTurnSplashWithRetry, ensureTurnSplashVisible, getState };
+const api = { showTurnSplash, queueTurnSplash, requestTurnSplash, forceTurnSplashWithRetry, ensureTurnSplashVisible, getState, sleep };
 try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.banner = api; } } catch {}
 export default api;

--- a/src/ui/battleBanner.js
+++ b/src/ui/battleBanner.js
@@ -1,0 +1,51 @@
+import { sleep } from './banner.js';
+
+function setSplashActive(v) {
+  try {
+    window.splashActive = !!v;
+    if (typeof window.refreshInputLockUI === 'function') window.refreshInputLockUI();
+  } catch {}
+}
+
+export async function showBattleSplash() {
+  setSplashActive(true);
+  const bb = (typeof document !== 'undefined') ? document.getElementById('battle-banner') : null;
+  if (!bb) { setSplashActive(false); return; }
+  bb.innerHTML = '';
+  const wrap = document.createElement('div'); wrap.className = 'ts-wrap';
+  const bg = document.createElement('div'); bg.className = 'ts-bg'; wrap.appendChild(bg);
+  const ringOuter = document.createElement('div'); ringOuter.className = 'ts-ring thin'; wrap.appendChild(ringOuter);
+  const ringInner = document.createElement('div'); ringInner.className = 'ts-ring'; wrap.appendChild(ringInner);
+  const streaks = document.createElement('div'); streaks.className = 'ts-streaks'; wrap.appendChild(streaks);
+  const txt = document.createElement('div'); txt.className = 'ts-title ts-title-solid text-5xl md:text-8xl'; txt.textContent = 'BATTLE'; wrap.appendChild(txt);
+  const scan = document.createElement('div'); scan.className = 'ts-scan'; wrap.appendChild(scan);
+  bb.appendChild(wrap);
+  bb.style.display = 'flex'; bb.classList.remove('hidden'); bb.classList.add('flex');
+  const tl = window.gsap?.timeline?.();
+  try {
+    if (tl) {
+      tl.set(txt, { scale: 0.65, opacity: 0 })
+        .set(ringOuter, { scale: 0.8, opacity: 0 })
+        .set(ringInner, { scale: 0.5, opacity: 0 })
+        .fromTo(bg, { opacity: 0 }, { opacity: 0.6, duration: 0.126, ease: 'power2.out' }, 0)
+        .to(ringOuter, { opacity: 1, scale: 1.0, duration: 0.196, ease: 'back.out(2.2)' }, 0.014)
+        .to(ringInner, { opacity: 1, scale: 1.0, duration: 0.224, ease: 'back.out(2.2)' }, 0.042)
+        .to(txt, { opacity: 1, scale: 1.08, duration: 0.252, ease: 'back.out(1.9)' }, 0.056)
+        .to(txt, { scale: 1.0, duration: 0.154, ease: 'power2.out' })
+        .to(scan, { yPercent: 200, duration: 0.49, ease: 'power1.inOut' }, 0.084)
+        .to(streaks, { opacity: 0.25, duration: 0.35 }, 0.14)
+        .to([ringOuter, ringInner], { opacity: 0.9, duration: 0.14 }, 0.315)
+        .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
+        .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
+        .to(bb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
+      await sleep(1330);
+    } else {
+      await sleep(1000);
+    }
+  } catch {}
+  bb.classList.add('hidden'); bb.classList.remove('flex'); bb.style.display = 'none'; bb.style.opacity = '';
+  bb.innerHTML = '';
+  setSplashActive(false);
+}
+
+export default { showBattleSplash };


### PR DESCRIPTION
## Summary
- extract deck & graveyard 3D objects into `scene/meta.js`
- move battle banner and sleep helper to UI modules
- remove inline splash logic from `index.html` and wire modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc09cb7b5883309483385528c3b750