### PR TITLE
Fix mana refund animation and Holy Feast flow

### DIFF
--- a/src/scene/delta.js
+++ b/src/scene/delta.js
@@ -36,13 +36,12 @@ export function playDeltaAnimations(prevState, nextState) {
               window.__fx?.dissolveAndAsh(ghost, new window.THREE.Vector3(0,0,0.6), 0.9);
             }
             const p = tile.position.clone().add(new window.THREE.Vector3(0, 1.2, 0));
-            animateManaGainFromWorld?.(p, pu.owner, true);
             try {
               if (!NET_ACTIVE && gameState && gameState.players && typeof pu.owner === 'number') {
                 gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana||0) + 1);
-                updateUI?.(gameState);
               }
             } catch {}
+            animateManaGainFromWorld?.(p, pu.owner, true);
           } catch {}
         } else if (!pu && nu) {
           try {

--- a/src/scene/meta.js
+++ b/src/scene/meta.js
@@ -10,7 +10,8 @@ export function createMetaObjects(gameState) {
     deckMeshes.forEach(m => m.parent && m.parent.remove(m));
     graveyardMeshes.forEach(m => m.parent && m.parent.remove(m));
     deckMeshes = []; graveyardMeshes = [];
-    if (!gameState || !THREE || !metaGroup) return;
+    const gs = gameState || window.gameState;
+    if (!gs || !THREE || !metaGroup) return;
 
     const CARD_TEX = window.CARD_TEX || {};
     const baseX = (6.2 + 0.2) * 1 + 6.6;

--- a/src/ui/discard.js
+++ b/src/ui/discard.js
@@ -1,0 +1,34 @@
+// Общие функции для сброса карт из руки
+import { getCtx } from '../scene/context.js';
+
+// Сбрасывает карту из руки игрока в указанное место (по умолчанию в кладбище)
+// и воспроизводит анимацию исчезновения карты.
+export function discardHandCard(player, handIndex, pile = 'graveyard') {
+  try {
+    if (!player || typeof handIndex !== 'number') return null;
+    const card = player.hand?.[handIndex];
+    if (!card) return null;
+    const ctx = getCtx();
+    const mesh = ctx?.handCardMeshes?.find(m => m.userData?.handIndex === handIndex);
+    if (mesh) {
+      try { mesh.userData.isInHand = false; } catch {}
+      try { window.__fx?.dissolveAndAsh(mesh, new window.THREE.Vector3(0, 0.6, 0), 0.9); } catch {}
+    }
+    try { (player[pile] = player[pile] || []).push(card); } catch {}
+    player.hand.splice(handIndex, 1);
+    try { if (typeof window.updateHand === 'function') window.updateHand(); } catch {}
+    return card;
+  } catch {
+    return null;
+  }
+}
+
+const api = { discardHandCard };
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.discard = api;
+  }
+} catch {}
+
+export default api;

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -92,14 +92,9 @@ export function animateManaGainFromWorld(pos, ownerIndex, visualOnly = true) {
     // и лететь в правильную позицию с учетом реального количества орбов на экране
     let targetIdx;
     if (visualOnly) {
-      // Показываем визуально в следующем свободном слоте, учитывая существующие блокировки
-      try {
-        const filledNow = Array.from(barEl.children).filter(el => el && el.classList && el.classList.contains('mana-orb')).length;
-        targetIdx = Math.min(9, Math.max(0, filledNow));
-      } catch {
-        const visibleMana = Math.max(0, currentMana - currentBlocks);
-        targetIdx = Math.min(9, visibleMana);
-      }
+      // Для визуальной анимации слота необходимо учесть новое количество маны
+      // и существующие блокировки, чтобы орб летел в первую свободную ячейку.
+      targetIdx = Math.max(0, Math.min(9, currentMana - currentBlocks - 1));
     } else {
       // Состояние уже обновлено, целимся в последний заполненный орб
       targetIdx = Math.max(0, Math.min(9, currentMana - 1));


### PR DESCRIPTION
## Summary
- ensure mana from destroyed units flies into the owner's first empty slot on both clients
- restore deck and graveyard models after module move
- refactor Holy Feast ritual with reusable discard helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc13104e6c83308391527e7203875a