### PR TITLE
fix: keep mana value during gain animation and modularize globals

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,26 +207,11 @@
       yawDeg: 0,    // поворот влево/вправо (ось Y)
       rollDeg: 0    // крен (ось Z)
     };
-    // Очереди догоняющих анимаций боя для наблюдателя
-    let PENDING_BATTLE_ANIMS = [];
-    let PENDING_RETALIATIONS = [];
-    // Recently shown remote damage (to avoid duplicate delta popups)
-    let RECENT_REMOTE_DAMAGE = new Map();
-    try { window.RECENT_REMOTE_DAMAGE = RECENT_REMOTE_DAMAGE; } catch {}
-    // Pending HP popups scheduled by playDeltaAnimations, so we can cancel if battleAnim shows earlier
-    // HP popup scheduling moved to src/scene/effects.js
-    let PENDING_HIDE_HAND_CARDS = [];
+    // Очереди анимаций боя и кэш урона перенесены в модули
+    // см. src/net/battleQueue.js и src/scene/recentRemoteDamage.js
     // Управление анимациями заставки хода и добора карты
     // Перенесено в ui/banner.js
 
-      var manaGainActive = false;
-      try { window.manaGainActive = manaGainActive; } catch {}
-      var PENDING_MANA_ANIM = null; // { ownerIndex, startIdx, endIdx }
-      var PENDING_MANA_BLOCK = [0,0]; // by player index
-// Ожидаемая анимация маны: диапазон новых орбов, которые должны появиться синхронно со вспышкой
-        try { window.PENDING_MANA_ANIM = PENDING_MANA_ANIM; } catch {}
-    // Блокировка появления N последних орбов маны на панели до завершения «полетевших» визуальных орбов (смерть/эффекты)
-        try { window.PENDING_MANA_BLOCK = PENDING_MANA_BLOCK; } catch {}
     // Прячет один экземпляр ритуального спелла в руке активного игрока, пока ждём выбора жертвы
     let pendingRitualSpellHandIndex = null;
     let pendingRitualSpellCard = null; // ссылка на сам объект карты-спелла, чтобы скрывать по идентичности

--- a/src/net/battleQueue.js
+++ b/src/net/battleQueue.js
@@ -1,0 +1,19 @@
+/**
+ * Очереди отложенных анимаций боя и контратак.
+ */
+export const pendingBattleAnims = [];
+export const pendingRetaliations = [];
+
+/** Полностью очистить очереди. */
+export function clearBattleQueues() {
+  pendingBattleAnims.length = 0;
+  pendingRetaliations.length = 0;
+}
+
+// Делаем доступным из консоли для отладки
+try {
+  if (typeof window !== 'undefined') {
+    window.PENDING_BATTLE_ANIMS = pendingBattleAnims;
+    window.PENDING_RETALIATIONS = pendingRetaliations;
+  }
+} catch {}

--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -1,6 +1,7 @@
 // Hand rendering and card draw animations
 import { getCtx } from './context.js';
 import { createCard3D } from './cards.js';
+import { pendingHideHandCards } from '../ui/handHide.js';
 
 function getTHREE() {
   const ctx = getCtx();
@@ -91,7 +92,7 @@ export function updateHand(gameState) {
   const indices = [];
   for (let i = 0; i < hand.length; i++) {
     if (viewerSeat === gameState.active && typeof window !== 'undefined' && typeof window.pendingRitualSpellHandIndex === 'number' && i === window.pendingRitualSpellHandIndex) continue;
-    if (typeof window !== 'undefined' && Array.isArray(window.PENDING_HIDE_HAND_CARDS) && window.PENDING_HIDE_HAND_CARDS.includes(i)) continue;
+    if (pendingHideHandCards.includes(i)) continue;
     indices.push(i);
   }
   const handSize = indices.length;

--- a/src/scene/recentRemoteDamage.js
+++ b/src/scene/recentRemoteDamage.js
@@ -1,0 +1,14 @@
+/**
+ * Кэш недавно отображённого урона, чтобы не показывать всплывающие числа дважды.
+ */
+export const recentRemoteDamage = new Map();
+
+/** Сбросить весь кэш. */
+export function clearRecentRemoteDamage() {
+  recentRemoteDamage.clear();
+}
+
+// Экспорт в window для совместимости со старым кодом
+try {
+  if (typeof window !== 'undefined') window.RECENT_REMOTE_DAMAGE = recentRemoteDamage;
+} catch {}

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -7,6 +7,7 @@ import { spendAndDiscardSpell, burnSpellCard } from '../ui/spellUtils.js';
 import { getCtx } from '../scene/context.js';
 import { interactionState, resetCardSelection } from '../scene/interactions.js';
 import { discardHandCard } from '../scene/discard.js';
+import { setPendingHideHandCards } from '../ui/handHide.js';
 
 // Общая реализация ритуала Holy Feast
 function runHolyFeast({ tpl, pl, idx, cardMesh, tileMesh }) {
@@ -61,7 +62,7 @@ function runHolyFeast({ tpl, pl, idx, cardMesh, tileMesh }) {
         ? interactionState.pendingRitualSpellHandIndex
         : pl.hand.indexOf(tpl);
       if (NET_ON()) {
-        try { PENDING_HIDE_HAND_CARDS = Array.from(new Set([handIdx, spellIdx])).filter(i => i >= 0); } catch {}
+        setPendingHideHandCards(Array.from(new Set([handIdx, spellIdx])).filter(i => i >= 0));
       }
       const before = pl.mana;
       pl.mana = capMana(pl.mana + 2);

--- a/src/ui/handHide.js
+++ b/src/ui/handHide.js
@@ -1,0 +1,20 @@
+/**
+ * Индексы карт в руке, которые временно скрываются (например, для анимаций).
+ */
+export const pendingHideHandCards = [];
+
+/** Задать список скрываемых индексов. */
+export function setPendingHideHandCards(indices) {
+  pendingHideHandCards.length = 0;
+  if (Array.isArray(indices)) pendingHideHandCards.push(...indices);
+}
+
+/** Очистить список скрываемых карт. */
+export function clearPendingHideHandCards() {
+  pendingHideHandCards.length = 0;
+}
+
+// Совместимость со старым глобальным кодом
+try {
+  if (typeof window !== 'undefined') window.PENDING_HIDE_HAND_CARDS = pendingHideHandCards;
+} catch {}


### PR DESCRIPTION
## Summary
- prevent mana bar from dropping when +1 orb flies in
- move battle animation queues and remote damage cache into modules
- centralize temporary hidden hand cards in a module to clean index.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc23e9e06483308f16caa2810199bb