### PR TITLE
fix: correct mana gain animation and refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,15 +198,6 @@
       let gameState = null;
       // Tile textures are now managed by scene/board module
     // Настройки показа большой карты при доборе — можно править из консоли
-    window.DRAW_CARD_TUNE = {
-      posY: 8.5,   // высота
-      posZ: 2.4,    // дистанция к камере (чем меньше, тем ближе)
-      scale: 1.7,   // масштаб
-      // Ручная довращалка (в градусах):
-      pitchDeg: 45,  // наклон вперёд/назад (ось X)
-      yawDeg: 0,    // поворот влево/вправо (ось Y)
-      rollDeg: 0    // крен (ось Z)
-    };
     // Очереди догоняющих анимаций боя для наблюдателя
     let PENDING_BATTLE_ANIMS = [];
     let PENDING_RETALIATIONS = [];
@@ -219,14 +210,6 @@
     // Управление анимациями заставки хода и добора карты
     // Перенесено в ui/banner.js
 
-      var manaGainActive = false;
-      try { window.manaGainActive = manaGainActive; } catch {}
-      var PENDING_MANA_ANIM = null; // { ownerIndex, startIdx, endIdx }
-      var PENDING_MANA_BLOCK = [0,0]; // by player index
-// Ожидаемая анимация маны: диапазон новых орбов, которые должны появиться синхронно со вспышкой
-        try { window.PENDING_MANA_ANIM = PENDING_MANA_ANIM; } catch {}
-    // Блокировка появления N последних орбов маны на панели до завершения «полетевших» визуальных орбов (смерть/эффекты)
-        try { window.PENDING_MANA_BLOCK = PENDING_MANA_BLOCK; } catch {}
     // Прячет один экземпляр ритуального спелла в руке активного игрока, пока ждём выбора жертвы
     let pendingRitualSpellHandIndex = null;
     let pendingRitualSpellCard = null; // ссылка на сам объект карты-спелла, чтобы скрывать по идентичности

--- a/src/config/drawCardTune.js
+++ b/src/config/drawCardTune.js
@@ -1,0 +1,15 @@
+// Настройки анимации добора карты
+export const DRAW_CARD_TUNE = {
+  posY: 8.5,   // высота
+  posZ: 2.4,   // дистанция к камере (чем меньше, тем ближе)
+  scale: 1.7,  // масштаб
+  // Ручная довращалка (в градусах)
+  pitchDeg: 45, // наклон вперёд/назад (ось X)
+  yawDeg: 0,    // поворот влево/вправо (ось Y)
+  rollDeg: 0    // крен (ось Z)
+};
+
+// Совместимость со старым глобальным API
+try { if (typeof window !== 'undefined') window.DRAW_CARD_TUNE = DRAW_CARD_TUNE; } catch {}
+
+export default DRAW_CARD_TUNE;

--- a/src/scene/delta.js
+++ b/src/scene/delta.js
@@ -37,13 +37,15 @@ export function playDeltaAnimations(prevState, nextState) {
             }
             const p = tile.position.clone().add(new window.THREE.Vector3(0, 1.2, 0));
             const slot = (prevState?.players?.[pu.owner]?.mana ?? 0);
-            animateManaGainFromWorld?.(p, pu.owner, true, slot);
+            // Сначала обновляем локальное состояние маны у активного игрока,
+            // чтобы панель не показывала временное уменьшение
             try {
-              if (!NET_ACTIVE && gameState && gameState.players && typeof pu.owner === 'number') {
-                gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana||0) + 1);
-                updateUI?.(gameState);
+              if (isActivePlayer && gameState && gameState.players && typeof pu.owner === 'number') {
+                gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana || 0) + 1);
               }
             } catch {}
+            // Затем запускаем анимацию появления орба
+            animateManaGainFromWorld?.(p, pu.owner, true, slot);
           } catch {}
         } else if (!pu && nu) {
           try {

--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -1,6 +1,7 @@
 // Hand rendering and card draw animations
 import { getCtx } from './context.js';
 import { createCard3D } from './cards.js';
+import { DRAW_CARD_TUNE } from '../config/drawCardTune.js';
 
 function getTHREE() {
   const ctx = getCtx();
@@ -126,7 +127,7 @@ export async function animateDrawnCardToHand(cardTpl) {
   try { if (typeof window !== 'undefined' && window.refreshInputLockUI) window.refreshInputLockUI(); } catch {}
 
   const big = createCard3D(cardTpl, false);
-  const T = (typeof window !== 'undefined' ? window.DRAW_CARD_TUNE || {} : {});
+  const T = DRAW_CARD_TUNE;
   big.position.set(0, (T.posY ?? 10.0), (T.posZ ?? 2.4));
 
   try {


### PR DESCRIPTION
## Summary
- keep active player's mana bar stable during orb flight
- extract draw-card animation tuning into dedicated module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc23e9e06483308f16caa2810199bb