### PR TITLE
feat: поддержка выбора направления атаки и улучшенная визуализация

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,14 +446,14 @@
        Combines combat resolution, animations and network sync.
        Split into logic (src/core/battle.js), FX (src/scene/battleFx.js)
        and net sync (src/net/battleSync.js). */
-    async function performBattleSequence(r, c, markAttackTurn) {
-      const staged = stagedAttack(gameState, r, c);
+    async function performBattleSequence(r, c, markAttackTurn, opts = {}) {
+      const staged = stagedAttack(gameState, r, c, opts);
       if (!staged || staged.empty) return;
       // flashy заставка BATTLE (сокращённая)
       await showBattleSplash();
       // небольшая анимация выпада/толчка
       const aMesh = unitMeshes.find(m => m.userData.row === r && m.userData.col === c);
-      const hitsPrev = (staged.targetsPreview || computeHits(gameState, r, c));
+      const hitsPrev = (staged.targetsPreview || computeHits(gameState, r, c, opts));
       const fromPos = (aMesh ? aMesh.position.clone() : tileMeshes[r][c].position.clone().add(new THREE.Vector3(0, 0.8, 0)));
 
       const doStep1 = () => {

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -14,6 +14,7 @@ export const CARDS = {
     id: 'FIRE_HELLFIRE_SPITTER', name: 'Hellfire Spitter', type: 'UNIT', cost: 1, activation: 1,
     element: 'FIRE', atk: 1, hp: 1,
     attackType: 'STANDARD', firstStrike: true,
+    chooseDir: true, // выбирает одно направление атаки
     attacks: [
       { dir: 'N', ranges: [1] },
       { dir: 'E', ranges: [1] },
@@ -43,7 +44,8 @@ export const CARDS = {
     id: 'FIRE_GREAT_MINOS', name: 'Great Minos of Sciondar', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 2, hp: 1,
     attackType: 'STANDARD',
-    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY' } ], // выбор клетки на 1 или 2 вперёд
+    attacks: [ { dir: 'N', ranges: [1, 2] } ], // бьёт сразу на 1 и 2 клетки вперёд
+    pierce: true, // игнорирует стоящих на пути
     blindspots: ['S'], dodge50: true, diesOffElement: 'FIRE',
     desc: 'Dodge 50% (non-magic). Destroy if not on Fire tile.'
   },

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -145,16 +145,28 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
   }
   const map = { N: [-1,0], E:[0,1], S:[1,0], W:[0,-1] };
   for (const a of attacks) {
-    const color = a.mode === 'ANY' ? 'rgba(71,85,105,0.4)' : 'rgba(71,85,105,0.8)';
+    const isChoice = cardData.chooseDir || a.mode === 'ANY';
     for (const dist of a.ranges || []) {
       const vec = map[a.dir]; if (!vec) continue;
       const rr = 1 + vec[0] * dist;
       const cc = 1 + vec[1] * dist;
-      const cx = x + cc * (cell + gap); const cy = y + rr * (cell + gap);
-      if (rr >= 0 && rr < 3 && cc >= 0 && cc < 3) {
-        ctx.fillStyle = color; ctx.fillRect(cx, cy, cell, cell);
+      const cx = x + cc * (cell + gap);
+      const cy = y + rr * (cell + gap);
+      const inGrid = rr >= 0 && rr < 3 && cc >= 0 && cc < 3;
+      if (inGrid) {
+        // Возможные клетки — голубое заполнение
+        ctx.fillStyle = 'rgba(56,189,248,0.35)';
+        ctx.fillRect(cx, cy, cell, cell);
+        // Обязательные атаки помечаем красной рамкой
+        if (!isChoice) {
+          ctx.strokeStyle = '#ef4444';
+          ctx.lineWidth = 1.5;
+          ctx.strokeRect(cx+0.5, cy+0.5, cell-1, cell-1);
+        }
       } else {
-        ctx.strokeStyle = color; ctx.lineWidth = 1.5; ctx.strokeRect(cx+0.5, cy+0.5, cell-1, cell-1);
+        ctx.strokeStyle = isChoice ? 'rgba(56,189,248,0.6)' : '#ef4444';
+        ctx.lineWidth = 1.5;
+        ctx.strokeRect(cx+0.5, cy+0.5, cell-1, cell-1);
       }
     }
   }

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -63,6 +63,32 @@ describe('guards and hits', () => {
     expect(h).toBeTruthy();
     expect(h.dmg).toBeGreaterThan(0);
   });
+
+  it('computeHits: chooseDir attacks only selected direction', () => {
+    const state = { board: makeBoard() };
+    state.board[1][1].unit = { owner: 0, tplId: 'FIRE_HELLFIRE_SPITTER', facing: 'N' };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'S' };
+    state.board[1][2].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'W' };
+    // без выбранного направления ничего не происходит
+    expect(computeHits(state, 1, 1)).toEqual([]);
+    // union=true возвращает все возможные цели
+    const allHits = computeHits(state, 1, 1, { union: true });
+    expect(allHits.length).toBe(2);
+    // выбираем север
+    const northHits = computeHits(state, 1, 1, { chosenDir: 'N' });
+    expect(northHits.length).toBe(1);
+    expect(northHits[0]).toMatchObject({ r: 0, c: 1 });
+  });
+
+  it('computeHits: unit hits both adjacent and next cell', () => {
+    const state = { board: makeBoard() };
+    state.board[2][1].unit = { owner: 0, tplId: 'FIRE_GREAT_MINOS', facing: 'N' };
+    state.board[1][1].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'S' };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'S' };
+    const hits = computeHits(state, 2, 1);
+    const coords = hits.map(h => `${h.r},${h.c}`).sort();
+    expect(coords).toEqual(['0,1', '1,1']);
+  });
 });
 
 describe('magicAttack', () => {


### PR DESCRIPTION
## Summary
- добавлен выбор направления атаки для карт вроде Hellfire Spitter
- Great Minos теперь поражает цели на 1 и 2 клетки вперёд, игнорируя преграды
- сетка атак на картах показывает возможные клетки голубым, а гарантированные атаки красной рамкой

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd2640ab7483308e02e95460b165ae