### PR TITLE
Авто выбор цели и дружественный урон при массовых атаках

### DIFF
--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -67,6 +67,7 @@ export const CARDS = {
       { dir: 'W', ranges: [1] }
     ],
     blindspots: ['S'], penaltyByTargets: true,
+    splashAllies: true, // повреждает и союзников
     desc: 'If attacks 2 creatures, -2 ATK; if 3 creatures, -4 ATK.'
   },
   FIRE_PURSUER: {

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -77,6 +77,7 @@ export function computeHits(state, r, c, opts = {}) {
   const hits = [];
   const aFlying = (tplA.keywords || []).includes('FLYING');
   const allowPierce = tplA.pierce;
+  const allowFriendly = tplA.splashAllies;
   for (const cell of cells) {
     const [dr, dc] = DIR_VECTORS[cell.dirAbs];
     const nr = r + dr * cell.range;
@@ -97,8 +98,14 @@ export function computeHits(state, r, c, opts = {}) {
     if (opts.target && (opts.target.r !== nr || opts.target.c !== nc)) continue;
 
     const B = state.board?.[nr]?.[nc]?.unit;
-    if (!B || B.owner === attacker.owner) continue;
-    if (!aFlying && hasAdjacentGuard(state, nr, nc) && !(CARDS[B.tplId].keywords || []).includes('GUARD')) {
+    if (!B) continue;
+    if (B.owner === attacker.owner && !allowFriendly) continue;
+    if (
+      B.owner !== attacker.owner &&
+      !aFlying &&
+      hasAdjacentGuard(state, nr, nc) &&
+      !(CARDS[B.tplId].keywords || []).includes('GUARD')
+    ) {
       continue;
     }
     const backDir = { N: 'S', S: 'N', E: 'W', W: 'E' }[B.facing];

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -114,8 +114,14 @@ export function drawCardFace(ctx, cardData, width, height, hpOverride = null, at
     const hpToShow = (hpOverride != null) ? hpOverride : (cardData.hp || 0);
     const atkToShow = (atkOverride != null) ? atkOverride : (cardData.atk || 0);
     ctx.fillText(`\u2694${atkToShow}  \u2764${hpToShow}`, width - 16, height - 15);
-    drawAttacksGrid(ctx, cardData, width - 76, 178, 10, 2);
-    drawBlindspotGrid(ctx, cardData, width - 36, 178, 10, 2);
+    // Переносим схемы атак и слепых зон вниз по центру
+    const cell = 10, gap = 2;
+    const gridSize = cell * 3 + gap * 2;
+    const totalW = gridSize * 2 + 10; // расстояние между двумя таблицами 10px
+    const gx = (width - totalW) / 2;
+    const gy = height - 40 - gridSize - 6; // небольшой отступ от нижней панели
+    drawAttacksGrid(ctx, cardData, gx, gy, cell, gap);
+    drawBlindspotGrid(ctx, cardData, gx + gridSize + 10, gy, cell, gap);
   }
 }
 
@@ -135,6 +141,9 @@ function getElementColor(element) {
 
 function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
   const attacks = cardData.attacks || [];
+  // Определяем, требуется ли выбор направления
+  const uniqueDirs = new Set(attacks.map(a => a.dir));
+  const needDirChoice = cardData.chooseDir && uniqueDirs.size > 1;
   for (let r = 0; r < 3; r++) {
     for (let c = 0; c < 3; c++) {
       const cx = x + c * (cell + gap); const cy = y + r * (cell + gap);
@@ -169,6 +178,14 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
         ctx.strokeRect(cx+0.5, cy+0.5, cell-1, cell-1);
       }
     }
+  }
+  // Если направлений несколько и нужно выбрать одно — красная рамка спереди
+  if (needDirChoice) {
+    const cx = x + 1 * (cell + gap);
+    const cy = y + 0 * (cell + gap);
+    ctx.strokeStyle = '#ef4444';
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);
   }
 }
 

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -480,8 +480,33 @@ export function placeUnitWithDirection(direction) {
       window.updateHand();
       window.updateUnits();
       window.updateUI();
-      const hitsNow = window.computeHits(gameState, row, col);
-      if (hitsNow && hitsNow.length) window.performBattleSequence(row, col, false);
+      // После призыва проверяем, есть ли цели для атаки
+      const tpl = cardData;
+      const attacks = tpl?.attacks || [];
+      const needsChoice = tpl?.chooseDir || attacks.some(a => a.mode === 'ANY');
+      const computeHits = window.computeHits;
+      const hitsAll = typeof computeHits === 'function'
+        ? computeHits(gameState, row, col, { union: true })
+        : [];
+      if (!hitsAll.length) return;
+      if (needsChoice && hitsAll.length > 1) {
+        // Если нужно выбрать направление и есть несколько целей — ждём выбор игрока
+        interactionState.pendingAttack = { r: row, c: col };
+        window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
+        return;
+      }
+      // При единственной цели или отсутствии выбора атакуем автоматически
+      let opts = {};
+      if (needsChoice && hitsAll.length === 1) {
+        const h = hitsAll[0];
+        const dr = h.r - row, dc = h.c - col;
+        const absDir = dr < 0 ? 'N' : dr > 0 ? 'S' : dc > 0 ? 'E' : 'W';
+        const ORDER = ['N', 'E', 'S', 'W'];
+        const relDir = ORDER[(ORDER.indexOf(absDir) - ORDER.indexOf(unit.facing) + 4) % 4];
+        const dist = Math.max(Math.abs(dr), Math.abs(dc));
+        opts = { chosenDir: relDir, rangeChoices: { [relDir]: dist } };
+      }
+      window.performBattleSequence(row, col, false, opts);
     },
   });
   window.addLog(`${player.name} призывает ${cardData.name} на (${row + 1},${col + 1})`);

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -89,6 +89,17 @@ describe('guards and hits', () => {
     const coords = hits.map(h => `${h.r},${h.c}`).sort();
     expect(coords).toEqual(['0,1', '1,1']);
   });
+
+  it('computeHits: splashAllies включает союзников в зону поражения', () => {
+    const state = { board: makeBoard() };
+    state.board[1][1].unit = { owner: 0, tplId: 'FIRE_TRICEPTAUR', facing: 'N' };
+    state.board[1][0].unit = { owner: 0, tplId: 'FIRE_FLAME_LIZARD', facing: 'E' };
+    state.board[1][2].unit = { owner: 0, tplId: 'FIRE_FLAME_LIZARD', facing: 'W' };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'S' };
+    const hits = computeHits(state, 1, 1);
+    const coords = hits.map(h => `${h.r},${h.c}`).sort();
+    expect(coords).toEqual(['0,1', '1,0', '1,2']);
+  });
 });
 
 describe('magicAttack', () => {


### PR DESCRIPTION
## Summary
- Автоатака после призыва, если у существа с выбором направления единственная цель
- Карточные схемы перенесены вниз и показывают красную рамку для выбора направления
- Массовые атаки могут задевать союзников через `splashAllies`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd54d45cd4833093a27f1a1c18cf2d