### PR TITLE
feat: автоатака и дружественный урон

### DIFF
--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -67,6 +67,7 @@ export const CARDS = {
       { dir: 'W', ranges: [1] }
     ],
     blindspots: ['S'], penaltyByTargets: true,
+    friendlyFire: true, // задевает и своих
     desc: 'If attacks 2 creatures, -2 ATK; if 3 creatures, -4 ATK.'
   },
   FIRE_PURSUER: {

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -114,8 +114,12 @@ export function drawCardFace(ctx, cardData, width, height, hpOverride = null, at
     const hpToShow = (hpOverride != null) ? hpOverride : (cardData.hp || 0);
     const atkToShow = (atkOverride != null) ? atkOverride : (cardData.atk || 0);
     ctx.fillText(`\u2694${atkToShow}  \u2764${hpToShow}`, width - 16, height - 15);
-    drawAttacksGrid(ctx, cardData, width - 76, 178, 10, 2);
-    drawBlindspotGrid(ctx, cardData, width - 36, 178, 10, 2);
+    const cell = 10, gap = 2, spacing = 8;
+    const gridW = cell * 3 + gap * 2;
+    const startX = (width - (gridW * 2 + spacing)) / 2;
+    const gridY = 220; // нижняя центральная область
+    drawAttacksGrid(ctx, cardData, startX, gridY, cell, gap);
+    drawBlindspotGrid(ctx, cardData, startX + gridW + spacing, gridY, cell, gap);
   }
 }
 
@@ -169,6 +173,14 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
         ctx.strokeRect(cx+0.5, cy+0.5, cell-1, cell-1);
       }
     }
+  }
+  // Если направлений несколько и нужно выбрать одно — подсвечиваем клетку перед существом
+  if (cardData.chooseDir && (attacks.length > 1)) {
+    const cx = x + 1 * (cell + gap);
+    const cy = y + 0 * (cell + gap);
+    ctx.strokeStyle = '#ef4444';
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);
   }
 }
 

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -480,8 +480,29 @@ export function placeUnitWithDirection(direction) {
       window.updateHand();
       window.updateUnits();
       window.updateUI();
-      const hitsNow = window.computeHits(gameState, row, col);
-      if (hitsNow && hitsNow.length) window.performBattleSequence(row, col, false);
+      const tpl = window.CARDS?.[cardData.id];
+      const attacks = tpl?.attacks || [];
+      const needsChoice = tpl?.chooseDir || attacks.some(a => a.mode === 'ANY');
+      const hitsAll = window.computeHits(gameState, row, col, { union: true });
+      if (hitsAll.length) {
+        if (needsChoice && hitsAll.length > 1) {
+          interactionState.pendingAttack = { r: row, c: col };
+          window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
+          window.__ui?.notifications?.show('Выберите цель', 'info');
+        } else {
+          let opts = {};
+          if (needsChoice && hitsAll.length === 1) {
+            const h = hitsAll[0];
+            const dr = h.r - row, dc = h.c - col;
+            const absDir = dr < 0 ? 'N' : dr > 0 ? 'S' : dc > 0 ? 'E' : 'W';
+            const ORDER = ['N', 'E', 'S', 'W'];
+            const relDir = ORDER[(ORDER.indexOf(absDir) - ORDER.indexOf(unit.facing) + 4) % 4];
+            const dist = Math.max(Math.abs(dr), Math.abs(dc));
+            opts = { chosenDir: relDir, rangeChoices: { [relDir]: dist } };
+          }
+          window.performBattleSequence(row, col, false, opts);
+        }
+      }
     },
   });
   window.addLog(`${player.name} призывает ${cardData.name} на (${row + 1},${col + 1})`);

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -75,6 +75,7 @@ export function performUnitAttack(unitMesh) {
     if (needsChoice && hitsAll.length > 1) {
       if (iState) iState.pendingAttack = { r, c };
       window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
+      window.__ui?.notifications?.show('Выберите цель', 'info');
       return;
     }
     // если выбор не нужен или доступна единственная цель, атакуем сразу

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -89,6 +89,14 @@ describe('guards and hits', () => {
     const coords = hits.map(h => `${h.r},${h.c}`).sort();
     expect(coords).toEqual(['0,1', '1,1']);
   });
+
+  it('computeHits: friendlyFire позволяет бить своих', () => {
+    const state = { board: makeBoard() };
+    state.board[1][1].unit = { owner: 0, tplId: 'FIRE_TRICEPTAUR', facing: 'N' };
+    state.board[0][1].unit = { owner: 0, tplId: 'FIRE_FLAME_LIZARD', facing: 'S' };
+    const hits = computeHits(state, 1, 1);
+    expect(hits.some(h => h.r === 0 && h.c === 1)).toBe(true);
+  });
 });
 
 describe('magicAttack', () => {


### PR DESCRIPTION
## Summary
- автоатака при единственной цели и уведомление о выборе
- поддержка friendly fire и переработка подсказок атак
- перенос сеток атак и слепых зон вниз по центру карты

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd54d45cd4833093a27f1a1c18cf2d