### PR TITLE
Перенос мини-сеток на карты и уточнение friendly fire

### DIFF
--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -126,6 +126,9 @@ export function computeHits(state, r, c, opts = {}) {
     const dmg = Math.max(0, atk + extraTotal);
     hits.push({ r: nr, c: nc, dmg, backstab: isBack });
   }
+  // Если среди потенциальных целей нет врагов, атака с FriendlyFire не выполняется
+  const hasEnemy = hits.some(h => state.board?.[h.r]?.[h.c]?.unit?.owner !== attacker.owner);
+  if (hits.length && !hasEnemy) return [];
   return hits;
 }
 

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -114,10 +114,12 @@ export function drawCardFace(ctx, cardData, width, height, hpOverride = null, at
     const hpToShow = (hpOverride != null) ? hpOverride : (cardData.hp || 0);
     const atkToShow = (atkOverride != null) ? atkOverride : (cardData.atk || 0);
     ctx.fillText(`\u2694${atkToShow}  \u2764${hpToShow}`, width - 16, height - 15);
-    const cell = 10, gap = 2, spacing = 8;
+    // Параметры мини-сеток 3x3: ячейка, промежуток и расстояние между сетками
+    const cell = 10, gap = 2, spacing = 24; // spacing увеличен, чтобы слева можно было дорисовать ещё клетку
     const gridW = cell * 3 + gap * 2;
     const startX = (width - (gridW * 2 + spacing)) / 2;
-    const gridY = 220; // нижняя центральная область
+    // Опускаем схемы к нижней части карты
+    const gridY = height - 90;
     drawAttacksGrid(ctx, cardData, startX, gridY, cell, gap);
     drawBlindspotGrid(ctx, cardData, startX + gridW + spacing, gridY, cell, gap);
   }
@@ -158,19 +160,23 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
       const cy = y + rr * (cell + gap);
       const inGrid = rr >= 0 && rr < 3 && cc >= 0 && cc < 3;
       if (inGrid) {
-        // Возможные клетки — голубое заполнение
+        // Возможные клетки внутри 3x3 — голубое заполнение
         ctx.fillStyle = 'rgba(56,189,248,0.35)';
         ctx.fillRect(cx, cy, cell, cell);
         // Обязательные атаки помечаем красной рамкой
         if (!isChoice) {
           ctx.strokeStyle = '#ef4444';
           ctx.lineWidth = 1.5;
-          ctx.strokeRect(cx+0.5, cy+0.5, cell-1, cell-1);
+          ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);
         }
       } else {
+        // Клетки за пределами 3x3: тоже заливаем синим,
+        // а рамку выбираем по ситуации (красная — обязательная цель)
+        ctx.fillStyle = 'rgba(56,189,248,0.35)';
+        ctx.fillRect(cx, cy, cell, cell);
         ctx.strokeStyle = isChoice ? 'rgba(56,189,248,0.6)' : '#ef4444';
         ctx.lineWidth = 1.5;
-        ctx.strokeRect(cx+0.5, cy+0.5, cell-1, cell-1);
+        ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);
       }
     }
   }

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -216,7 +216,10 @@ function onMouseUp(event) {
       if (interactionState.hoveredTile) {
         const row = interactionState.hoveredTile.userData.row;
         const col = interactionState.hoveredTile.userData.col;
-        if (gameState.board[row][col].unit) {
+        const cellUnit = gameState.board[row][col].unit;
+        // Считаем клетку свободной, если в ней остался только "труп" (HP ≤ 0)
+        const alive = cellUnit && ((cellUnit.currentHP ?? cellUnit.hp) > 0);
+        if (alive) {
           showNotification('Cell is already occupied!', 'error');
           returnCardToHand(interactionState.draggedCard);
         } else {

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -90,12 +90,17 @@ describe('guards and hits', () => {
     expect(coords).toEqual(['0,1', '1,1']);
   });
 
-  it('computeHits: friendlyFire позволяет бить своих', () => {
+  it('computeHits: friendlyFire бьёт союзников только при наличии врага', () => {
     const state = { board: makeBoard() };
     state.board[1][1].unit = { owner: 0, tplId: 'FIRE_TRICEPTAUR', facing: 'N' };
-    state.board[0][1].unit = { owner: 0, tplId: 'FIRE_FLAME_LIZARD', facing: 'S' };
+    state.board[0][1].unit = { owner: 0, tplId: 'FIRE_FLAME_LIZARD', facing: 'S' }; // союзник спереди
+    // Нет врагов — атака не происходит
+    expect(computeHits(state, 1, 1)).toEqual([]);
+    // Добавляем врага сбоку, теперь удар заденет и союзника
+    state.board[1][2].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'W' };
     const hits = computeHits(state, 1, 1);
-    expect(hits.some(h => h.r === 0 && h.c === 1)).toBe(true);
+    const coords = hits.map(h => `${h.r},${h.c}`).sort();
+    expect(coords).toEqual(['0,1', '1,2']);
   });
 });
 


### PR DESCRIPTION
## Summary
- Опустил 3×3 схемы атак/блайндспотов в нижнюю часть карты и увеличил расстояние между ними
- Изменил отображение дальних атак: клетки вне 3×3 теперь с синей заливкой
- Исправил проверку занятости клетки после смерти юнита
- Friendly fire теперь срабатывает только при наличии вражеской цели

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6a2680f08330a03bd613d1165a94