### PR TITLE
Голубая подсветка целей атаки

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import * as Cards from './scene/cards.js';
 import * as Units from './scene/units.js';
 import * as Hand from './scene/hand.js';
 import * as Interactions from './scene/interactions.js';
+import * as TileHighlight from './scene/highlight.js';
 import { getCtx as getSceneCtx } from './scene/context.js';
 // UI modules
 import * as UINotifications from './ui/notifications.js';

--- a/src/scene/highlight.js
+++ b/src/scene/highlight.js
@@ -1,0 +1,63 @@
+// Подсветка доступных клеток на поле
+import { getCtx } from './context.js';
+
+// Список активных подсветок для последующей очистки
+let ACTIVE = [];
+
+// Включает подсветку для набора клеток вида [{r,c}, ...]
+export function highlightCells(cells = []) {
+  clearHighlights();
+  const ctx = getCtx();
+  const { THREE, tileFrames } = ctx;
+  const gsap = (typeof window !== 'undefined') ? window.gsap : null;
+  if (!THREE || !gsap || !tileFrames) return;
+
+  for (const { r, c } of cells) {
+    const frame = tileFrames?.[r]?.[c];
+    if (!frame) continue;
+    const mats = [];
+    frame.traverse(obj => {
+      if (obj.isMesh && obj.material) {
+        obj.material.color = new THREE.Color(0x7dd3fc); // голубая магия
+        obj.material.opacity = 0;
+        obj.material.transparent = true;
+        obj.material.depthWrite = false;
+        obj.material.blending = THREE.AdditiveBlending;
+        mats.push(obj.material);
+      }
+    });
+    const tl = gsap.to(mats, {
+      opacity: 0.9,
+      duration: 0.6,
+      yoyo: true,
+      repeat: -1,
+      ease: 'sine.inOut',
+    });
+    ACTIVE.push({ frame, tl });
+  }
+}
+
+// Отключает все подсветки
+export function clearHighlights() {
+  const ctx = getCtx();
+  const gsap = (typeof window !== 'undefined') ? window.gsap : null;
+  for (const h of ACTIVE) {
+    try { h.tl.kill(); } catch {}
+    h.frame.traverse(obj => {
+      if (obj.isMesh && obj.material) {
+        obj.material.opacity = 0;
+      }
+    });
+  }
+  ACTIVE = [];
+  if (gsap) { try { gsap.killTweensOf && gsap.killTweensOf('*'); } catch {} }
+}
+
+// Экспортируем для использования в окне
+try {
+  if (typeof window !== 'undefined') {
+    window.__tileHighlights = { highlightCells, clearHighlights };
+  }
+} catch {}
+
+export default { highlightCells, clearHighlights };

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -160,11 +160,13 @@ function onMouseDown(event) {
     if (interactionState.magicFrom) {
       performMagicAttack(interactionState.magicFrom, unit);
       interactionState.magicFrom = null;
+      try { window.__tileHighlights?.clearHighlights(); } catch {}
       return;
     }
     if (interactionState.pendingAttack) {
       performChosenAttack(interactionState.pendingAttack, unit);
       interactionState.pendingAttack = null;
+      try { window.__tileHighlights?.clearHighlights(); } catch {}
       return;
     }
     if (interactionState.selectedCard && interactionState.selectedCard.userData.cardData.type === 'SPELL') {
@@ -490,6 +492,8 @@ export function placeUnitWithDirection(direction) {
       if (hitsAll.length && hasEnemy) {
         if (needsChoice && hitsAll.length > 1) {
           interactionState.pendingAttack = { r: row, c: col };
+          // Подсветка всех доступных целей для только что призванного существа
+          try { window.__tileHighlights?.highlightCells(hitsAll); } catch {}
           window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
           window.__ui?.notifications?.show('Выберите цель', 'info');
         } else {

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -54,6 +54,17 @@ export function performUnitAttack(unitMesh) {
       window.__ui?.updateUI?.(gameState);
       try { window.selectedUnit = null; window.__ui?.panels?.hideUnitActionPanel(); } catch {}
       if (iState) iState.magicFrom = { r, c };
+      // Подсветка всех вражеских существ для магической атаки
+      try {
+        const cells = [];
+        for (let rr = 0; rr < 3; rr++) {
+          for (let cc = 0; cc < 3; cc++) {
+            const u = gameState.board?.[rr]?.[cc]?.unit;
+            if (u && u.owner !== unit.owner) cells.push({ r: rr, c: cc });
+          }
+        }
+        window.__tileHighlights?.highlightCells(cells);
+      } catch {}
       window.__ui?.log?.add?.(`${tpl.name}: select a target for the magical attack.`);
       return;
     }
@@ -75,6 +86,8 @@ export function performUnitAttack(unitMesh) {
     try { window.selectedUnit = null; window.__ui?.panels?.hideUnitActionPanel(); } catch {}
     if (needsChoice && hitsAll.length > 1) {
       if (iState) iState.pendingAttack = { r, c };
+      // Подсветка всех доступных целей
+      try { window.__tileHighlights?.highlightCells(hitsAll); } catch {}
       window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
       window.__ui?.notifications?.show('Выберите цель', 'info');
       return;


### PR DESCRIPTION
## Summary
- добавлен модуль подсветки клеток с голубым магическим эффектом
- подсветка активируется при выборе цели атаки или магической атаки
- подсветка очищается после выбора цели

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd85ec272483309665542649bff05d