### PR TITLE
Исправлен URL для динамической загрузки postprocessing

### DIFF
--- a/src/scene/highlight.js
+++ b/src/scene/highlight.js
@@ -22,7 +22,7 @@ async function ensureComposer() {
   if (!renderer || !scene || !camera) return;
   state.composerPromise = (async () => {
     try {
-      const mod = await import('https://cdn.jsdelivr.net/npm/postprocessing@6.33.3/build/postprocessing.esm.js');
+      const mod = await import('https://cdn.jsdelivr.net/npm/postprocessing@6.33.3/build/postprocessing.js');
       const { EffectComposer, RenderPass, EffectPass, GodRaysEffect } = mod;
       const composer = new EffectComposer(renderer);
       composer.addPass(new RenderPass(scene, camera));


### PR DESCRIPTION
## Summary
- исправлен адрес при динамическом импорте postprocessing, что устраняет ошибку 404 и возвращает эффект godrays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2ef5f8608330bf0a6f56ced51719