### PR TITLE
Fix postprocessing import for godrays effect

### DIFF
--- a/src/scene/highlight.js
+++ b/src/scene/highlight.js
@@ -22,7 +22,9 @@ async function ensureComposer() {
   if (!renderer || !scene || !camera) return;
   state.composerPromise = (async () => {
     try {
-      const mod = await import('https://cdn.jsdelivr.net/npm/postprocessing@6.33.3/build/postprocessing.esm.js');
+      // Загружаем ESM-версию postprocessing с CDN; прежний путь давал 404
+      // Использование суффикса +esm гарантирует корректный модульный билд
+      const mod = await import('https://cdn.jsdelivr.net/npm/postprocessing@6.33.3/+esm');
       const { EffectComposer, RenderPass, EffectPass, GodRaysEffect } = mod;
       const composer = new EffectComposer(renderer);
       composer.addPass(new RenderPass(scene, camera));


### PR DESCRIPTION
## Summary
- use jsdelivr +esm endpoint for postprocessing to avoid 404

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2ef5f8608330bf0a6f56ced51719