### PR TITLE
Исправлен импорт postprocessing для эффекта лучей

### DIFF
--- a/src/scene/highlight.js
+++ b/src/scene/highlight.js
@@ -22,8 +22,13 @@ async function ensureComposer() {
   if (!renderer || !scene || !camera) return;
   state.composerPromise = (async () => {
     try {
-      const mod = await import('https://cdn.jsdelivr.net/npm/postprocessing@6.33.3/build/postprocessing.esm.js');
-      const { EffectComposer, RenderPass, EffectPass, GodRaysEffect } = mod;
+      // Загружаем ESM-версию postprocessing с jsDelivr
+      const mod = await import('https://cdn.jsdelivr.net/npm/postprocessing@6.33.3/+esm');
+      const pp = mod?.default ?? mod; // подстраховка на случай различий экспорта
+      const { EffectComposer, RenderPass, EffectPass, GodRaysEffect } = pp;
+      if (!EffectComposer || !RenderPass || !EffectPass || !GodRaysEffect) {
+        throw new Error('postprocessing не содержит нужных классов');
+      }
       const composer = new EffectComposer(renderer);
       composer.addPass(new RenderPass(scene, camera));
       ctx.composer = composer;


### PR DESCRIPTION
## Summary
- подключена ESM-версия postprocessing с jsDelivr и добавлена проверка экспортов

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2ef5f8608330bf0a6f56ced51719