### PR TITLE
Исправлен импорт postprocessing для эффекта лучей

### DIFF
--- a/src/scene/highlight.js
+++ b/src/scene/highlight.js
@@ -22,8 +22,11 @@ async function ensureComposer() {
   if (!renderer || !scene || !camera) return;
   state.composerPromise = (async () => {
     try {
-      const mod = await import('https://cdn.jsdelivr.net/npm/postprocessing@6.33.3/build/postprocessing.esm.js');
-      const { EffectComposer, RenderPass, EffectPass, GodRaysEffect } = mod;
+      // Подгружаем модуль postprocessing как ES-модуль
+      const mod = await import('https://cdn.jsdelivr.net/npm/postprocessing@6.33.3/+esm');
+      // Некоторые CDN возвращают объект в свойстве default
+      const lib = mod.default ?? mod;
+      const { EffectComposer, RenderPass, EffectPass, GodRaysEffect } = lib;
       const composer = new EffectComposer(renderer);
       composer.addPass(new RenderPass(scene, camera));
       ctx.composer = composer;


### PR DESCRIPTION
## Summary
- загружён ES-модуль postprocessing через CDN с поддержкой fallback
- корректно инициируется EffectComposer для эффекта godrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be2ef5f8608330bf0a6f56ced51719