### PR TITLE
Добавлен пульсирующий водный шейдер подсветки клеток

### DIFF
--- a/src/scene/highlight.js
+++ b/src/scene/highlight.js
@@ -1,38 +1,38 @@
-// Подсветка клеток на поле для выбора цели
-// Использует шейдерный материал с простым "магическим" сиянием
-// вокруг границ клетки.
+// Подсветка клеток на поле для выбора цели.
+// Теперь вся поверхность клетки покрывается пульсирующим "водным" свечением,
+// которое проявляется и затухает каждые пару секунд.
 import { getCtx } from './context.js';
 
 // Внутреннее состояние активной подсветки
 const state = {
-  frames: [],
+  tiles: [],
   uniforms: [],
   rafId: 0,
 };
 
-// Создаёт материал для рамки с анимированными лучами
-function createMagicMaterial(THREE) {
-  const mat = new THREE.MeshBasicMaterial({
-    color: 0x7dd3fc,
-    transparent: true,
-    opacity: 0.9,
-    depthTest: true,
-    depthWrite: false,
-  });
+// Создаёт материал с пульсирующим водным эффектом на основе исходного
+// материала клетки. За счёт этого текстура клетки остаётся видимой, а сверху
+// накладывается анимированная подсветка.
+function createPulseMaterial(origMat, THREE) {
+  const mat = origMat.clone();
+  mat.transparent = true;
   mat.onBeforeCompile = (shader) => {
     shader.uniforms.uTime = { value: 0 };
     shader.vertexShader = shader.vertexShader
       .replace('#include <common>', '#include <common>\nvarying vec2 vUv;')
       .replace('#include <uv_vertex>', '#include <uv_vertex>\n vUv = uv;');
-    const fragHead = `\n varying vec2 vUv;\n uniform float uTime;\n`;
+    const head = `\n varying vec2 vUv;\n uniform float uTime;\n`;
     shader.fragmentShader = shader.fragmentShader
-      .replace('#include <common>', '#include <common>' + fragHead)
+      .replace('#include <common>', '#include <common>' + head)
       .replace(
         '#include <dithering_fragment>',
         `#include <dithering_fragment>\n{
-          float wave = sin((vUv.x + vUv.y + uTime*2.0)*10.0)*0.5 + 0.5;
-          vec3 glow = vec3(0.5,0.8,1.0) * wave;
-          gl_FragColor.rgb = mix(gl_FragColor.rgb, glow, 0.7);
+          float pulse = sin(uTime*2.5)*0.5 + 0.5; // цикл ~2.5 секунды
+          vec2 uv = vUv * 2.0 - 1.0;
+          float wave = sin((uv.x + uTime*0.2)*10.0) * sin((uv.y + uTime*0.3)*10.0);
+          vec3 water = vec3(0.3,0.6,1.0) * (0.6 + 0.4*wave) * pulse;
+          gl_FragColor.rgb += water;
+          gl_FragColor.a = max(gl_FragColor.a, pulse*0.8);
         }`
       );
     state.uniforms.push(shader.uniforms.uTime);
@@ -56,25 +56,23 @@ function startAnim() {
 // Подсветка переданных координат {r,c}
 export function highlightTiles(cells = []) {
   const ctx = getCtx();
-  const { tileFrames, THREE } = ctx;
-  if (!tileFrames || !THREE) return;
+  const { tileMeshes, THREE } = ctx;
+  if (!tileMeshes || !THREE) return;
 
   clearHighlights();
 
-  const baseMat = createMagicMaterial(THREE);
-
   for (const { r, c } of cells) {
-    const frame = tileFrames?.[r]?.[c];
-    if (!frame) continue;
-    frame.traverse(obj => {
+    const tile = tileMeshes?.[r]?.[c];
+    if (!tile) continue;
+    tile.traverse(obj => {
       if (obj.isMesh) {
         obj.userData._origMat = obj.material;
-        obj.material = baseMat.clone();
+        obj.material = createPulseMaterial(obj.material, THREE);
       }
     });
-    state.frames.push(frame);
+    state.tiles.push(tile);
   }
-  startAnim();
+  if (state.tiles.length) startAnim();
 }
 
 // Сброс подсветки
@@ -85,8 +83,8 @@ export function clearHighlights() {
     state.rafId = 0;
   }
   state.uniforms = [];
-  state.frames.forEach(frame => {
-    frame.traverse(obj => {
+  state.tiles.forEach(tile => {
+    tile.traverse(obj => {
       if (obj.isMesh && obj.userData._origMat) {
         try { obj.material.dispose(); } catch {}
         obj.material = obj.userData._origMat;
@@ -94,7 +92,7 @@ export function clearHighlights() {
       }
     });
   });
-  state.frames = [];
+  state.tiles = [];
 }
 
 // Экспорт в глобальную область для отладки


### PR DESCRIPTION
## Summary
- Расширена подсветка: клетки покрываются анимированным водным шейдером, который пульсирует каждые ~2.5 секунды
- Обновлены функции highlightTiles и clearHighlights для работы с новыми материалами

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3c636454833081e06a3254708393