### PR TITLE
fix: improve board interactions and UI visuals

### DIFF
--- a/src/scene/delta.js
+++ b/src/scene/delta.js
@@ -37,13 +37,13 @@ export function playDeltaAnimations(prevState, nextState) {
             }
             const p = tile.position.clone().add(new window.THREE.Vector3(0, 1.2, 0));
             const slot = (prevState?.players?.[pu.owner]?.mana ?? 0);
+            // Сначала обновляем количество маны, но не трогаем UI
+            if (!NET_ACTIVE && gameState && gameState.players && typeof pu.owner === 'number') {
+              gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana || 0) + 1);
+            }
+            // Затем запускаем анимацию, которая сама пересоберёт панель
             animateManaGainFromWorld?.(p, pu.owner, true, slot);
-            try {
-              if (!NET_ACTIVE && gameState && gameState.players && typeof pu.owner === 'number') {
-                gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana||0) + 1);
-                updateUI?.(gameState);
-              }
-            } catch {}
+            try { updateUI?.(gameState); } catch {}
           } catch {}
         } else if (!pu && nu) {
           try {

--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -82,9 +82,18 @@ export function updateHand(gameState) {
     ? gameState.players[viewerSeat].hand.slice()
     : [];
 
+  // Автоматически скрываем вновь пришедшие карты до проигрывания анимации
   try {
-    if (viewerSeat === (typeof window !== 'undefined' ? window.MY_SEAT : viewerSeat) && (typeof window !== 'undefined' && window.pendingDrawCount > 0)) {
-      hand = hand.slice(0, Math.max(0, hand.length - window.pendingDrawCount));
+    if (typeof window !== 'undefined' && viewerSeat === window.MY_SEAT) {
+      const fullLen = hand.length;
+      const prevLen = window.__prevHandLen ?? fullLen;
+      if (!window.pendingDrawCount && !drawAnimationActive && fullLen > prevLen) {
+        window.pendingDrawCount = fullLen - prevLen;
+      }
+      window.__prevHandLen = fullLen;
+      if (window.pendingDrawCount > 0) {
+        hand = hand.slice(0, Math.max(0, hand.length - window.pendingDrawCount));
+      }
     }
   } catch {}
 

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -219,7 +219,12 @@ function onMouseUp(event) {
       if (interactionState.hoveredTile) {
         const row = interactionState.hoveredTile.userData.row;
         const col = interactionState.hoveredTile.userData.col;
-        if (gameState.board[row][col].unit) {
+        const cell = gameState.board[row][col];
+        // Если в клетке висит "мертвый" юнит, убираем его сразу
+        if (cell.unit && (cell.unit.currentHP ?? cell.unit.hp) <= 0) {
+          cell.unit = null;
+        }
+        if (cell.unit) {
           showNotification('Cell is already occupied!', 'error');
           returnCardToHand(interactionState.draggedCard);
         } else {


### PR DESCRIPTION
## Summary
- draw mana orb and play icon on cards
- refine attack grid highlighting and lower schemes
- fix cell reuse after death and mana flicker
- hide drawn card until animation completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be60abf1bc8330b671d5bf77383ebb