### PR TITLE
Исправления отображения схем и анимаций

### DIFF
--- a/index.html
+++ b/index.html
@@ -460,7 +460,9 @@
         // Убраны жёлтые лучи/стрелки под картами
         // Применяем урон (этап 1) и перерисовываем юниты
         staged.step1();
-        gameState = staged.n1; updateUnits();
+        gameState = staged.n1;
+        try { window.gameState = gameState; } catch {}
+        updateUnits();
         // Тряска и всплывающий урон — уже по актуальным мешам после обновления
         for (const h of hitsPrev) {
           const tMesh = unitMeshes.find(m => m.userData.row === h.r && m.userData.col === h.c);
@@ -529,6 +531,8 @@
           }
           // Финализация: анимация смерти и орбы перед применением состояния
           const res = staged.finish();
+          gameState = res.n1;
+          try { window.gameState = gameState; } catch {}
           if (res.deaths && res.deaths.length) {
             for (const d of res.deaths) {
               try { gameState.players[d.owner].graveyard.push(CARDS[d.tplId]); } catch {}
@@ -545,7 +549,6 @@
                 animateManaGainFromWorld(p, d.owner, true);
               }, 400);
             }
-            gameState = res.n1;
             if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
             setTimeout(() => {
               updateUnits(); updateUI();
@@ -553,9 +556,9 @@
               try { schedulePush('battle-finish'); } catch {}
             }, 1000);
           } else {
-            // Если смертей нет — подождём, пока анимация контратаки завершится, затем применим состояние
+            // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
-              gameState = res.n1; updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish'); } catch {}
+              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish'); } catch {}
             }, Math.max(0, animDelayMs));
           }
         }, 420);
@@ -638,6 +641,7 @@
           }, 400);
         }
         gameState = res.n1;
+        try { window.gameState = gameState; } catch {}
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         setTimeout(() => {
           updateUnits(); updateUI();
@@ -645,7 +649,8 @@
         }, 1000);
       } else {
         // Если смертей нет — применяем состояние сразу
-        gameState = res.n1; updateUnits(); updateUI();
+        gameState = res.n1; try { window.gameState = gameState; } catch {}
+        updateUnits(); updateUI();
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         try { schedulePush('magic-battle-finish'); } catch {}
       }

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -224,6 +224,25 @@
   socket.on('state', async (state)=>{
     if (!state) return;
     const prev = APPLYING ? null : (gameState ? JSON.parse(JSON.stringify(gameState)) : null);
+    // Предварительно определяем добор карты, чтобы скрыть её до окончания анимации
+    let __drawDelta = 0;
+    let __drawCards = [];
+    try {
+      const mySeat = (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number') ? window.MY_SEAT : null;
+      if (mySeat !== null && prev && prev.players && state.players) {
+        const prevHand = prev.players[mySeat]?.hand || [];
+        const nextHand = state.players[mySeat]?.hand || [];
+        __drawDelta = Math.max(0, nextHand.length - prevHand.length);
+        if (__drawDelta > 0) {
+          __drawCards = nextHand.slice(-__drawDelta);
+          pendingDrawCount = __drawDelta;
+          try { window.pendingDrawCount = __drawDelta; } catch {}
+        } else {
+          pendingDrawCount = 0;
+          try { window.pendingDrawCount = 0; } catch {}
+        }
+      }
+    } catch {}
     // Robust previous snapshot even if prev is null due to concurrent APPLYING
     let __lastTurnSeen = 0;
     try { __lastTurnSeen = (typeof window !== 'undefined' && typeof window.__lastTurnSeen === 'number') ? window.__lastTurnSeen : (gameState?.turn || 0); } catch {}
@@ -275,6 +294,8 @@
       gameState = state;
       try { window.gameState = state; } catch {}
       lastDigest = digest(state);
+      // Сразу обновим руку, чтобы скрыть добранные карты до анимации
+      try { updateHand(); } catch {}
       // Immediately reflect active seat and mana bars before any animations
         const leftSide = document.getElementById('left-side');
         const rightSide = document.getElementById('right-side');
@@ -418,29 +439,26 @@
       // Анимация добора у приёмника (только для своей руки)
       try {
         const mySeat = (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number') ? window.MY_SEAT : null;
-        if (mySeat !== null && prev && prev.players && state.players) {
-          const prevHand = (prev.players[mySeat]?.hand) || [];
-          const nextHand = (state.players[mySeat]?.hand) || [];
-          const delta = Math.max(0, nextHand.length - prevHand.length);
-          if (delta > 0) {
-            // Спрячем последние delta карт на время анимации
-            pendingDrawCount = delta; updateHand();
-            // Определим какие именно шаблоны анимировать — возьмём последние delta карт
-            const newCards = nextHand.slice(-delta);
-            for (let i = 0; i < newCards.length; i++) {
-              const tpl = newCards[i];
-              await animateDrawnCardToHand(tpl);
-              // По одной открываем карту в руке
-              pendingDrawCount = Math.max(0, pendingDrawCount - 1);
-              updateHand();
-            }
-          } else {
+        if (mySeat !== null && __drawDelta > 0 && __drawCards.length === __drawDelta) {
+          for (let i = 0; i < __drawCards.length; i++) {
+            const tpl = __drawCards[i];
+            await animateDrawnCardToHand(tpl);
+            // После каждой анимации показываем карту в руке
+            pendingDrawCount = Math.max(0, pendingDrawCount - 1);
+            // синхронизируем глобальный счётчик скрытых карт
+            try { window.pendingDrawCount = pendingDrawCount; } catch {}
             updateHand();
           }
         } else {
+          pendingDrawCount = 0;
+          try { window.pendingDrawCount = 0; } catch {}
           updateHand();
         }
-      } catch { updateHand(); }
+      } catch {
+        pendingDrawCount = 0;
+        try { window.pendingDrawCount = 0; } catch {}
+        updateHand();
+      }
     __endTurnInProgress = false;
     updateIndicator();
     updateInputLock();

--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -83,7 +83,7 @@ export function updateHand(gameState) {
     : [];
 
   try {
-    if (viewerSeat === (typeof window !== 'undefined' ? window.MY_SEAT : viewerSeat) && (typeof window !== 'undefined' && window.pendingDrawCount > 0)) {
+    if (typeof window !== 'undefined' && window.pendingDrawCount > 0) {
       hand = hand.slice(0, Math.max(0, hand.length - window.pendingDrawCount));
     }
   } catch {}

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -31,9 +31,9 @@ export function renderBars(gameState) {
       continue;
     }
     
-    // Если идет анимация получения маны в начале хода и есть _beforeMana, используем его
+    // Используем _beforeMana только во время анимации прироста хода
     let displayMana = currentMana;
-    if (typeof beforeMana === 'number' && beforeMana < currentMana) {
+    if (getManaGainActive() && typeof beforeMana === 'number' && beforeMana < currentMana) {
       displayMana = beforeMana; // Показываем старое значение во время анимации
     }
     


### PR DESCRIPTION
## Summary
- скорректированы схемы атак и подсветка направлений
- добавлены иконки маны и запуска вместо текстовых символов
- синхронизировано состояние после атак, исправлены панели маны и добор карт
- скрыт преждевременный показ добранной карты до завершения анимации
- устранено исчезновение карты после анимации за счёт обновления счётчика добора

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be60abf1bc8330b671d5bf77383ebb