### PR TITLE
feat: улучшить эффект разблокировки

### DIFF
--- a/src/ui/summonLock.js
+++ b/src/ui/summonLock.js
@@ -64,15 +64,20 @@ export async function playUnlockAnimation() {
   // Вспышка
   const flash = document.createElement('div');
   flash.style.position = 'fixed';
-  const fSize = Math.max(window.innerWidth, window.innerHeight) / 3;
+  // делаем вспышку на 50% меньше
+  const fSize = Math.max(window.innerWidth, window.innerHeight) / 6;
   flash.style.left = `${cx - fSize / 2}px`;
   flash.style.top = `${cy - fSize / 2}px`;
   flash.style.width = `${fSize}px`;
   flash.style.height = `${fSize}px`;
-  flash.style.background = 'white';
+  // круг с градиентом для плавного затухания к краям
+  flash.style.background = 'radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(255,255,255,0) 70%)';
+  flash.style.borderRadius = '50%';
   flash.style.opacity = '0';
   flash.style.pointerEvents = 'none';
   flash.style.zIndex = '1000';
+  flash.style.transformOrigin = 'center center';
+  flash.style.transform = 'scale(0.1)';
   document.body.appendChild(flash);
   // Эффект удара мечом
   const slash = document.createElement('div');
@@ -81,7 +86,9 @@ export async function playUnlockAnimation() {
   slash.style.top = `${cy}px`;
   slash.style.width = '3px';
   slash.style.height = `${rect.height * 2}px`;
-  slash.style.background = 'white';
+  // яркий цвет для эффекта разреза
+  slash.style.background = '#ff0';
+  slash.style.boxShadow = '0 0 6px 3px #ff0';
   slash.style.transformOrigin = 'center center';
   slash.style.transform = 'translate(-50%, -50%) rotate(45deg)';
   slash.style.opacity = '0';
@@ -89,8 +96,9 @@ export async function playUnlockAnimation() {
   slash.style.zIndex = '1001';
   document.body.appendChild(slash);
   const tl = gsap.timeline({ onComplete: () => { flash.remove(); slash.remove(); } });
-  tl.to(flash, { opacity: 1, duration: 0.25 })
-    .to(flash, { opacity: 0, duration: 0.25 })
+  // быстрая вспышка с увеличением и затуханием
+  tl.to(flash, { opacity: 0.8, scale: 1, duration: 0.1, ease: 'power2.out' })
+    .to(flash, { opacity: 0, scale: 1.5, duration: 0.15, ease: 'power2.in' }, '-=0.02')
     .to(slash, { opacity: 1, duration: 0.25 }, 0)
     .to(slash, { opacity: 0, duration: 0.25 }, 0.25);
   // Раскалывание замка


### PR DESCRIPTION
## Summary
- добавить круглую вспышку с градиентом и быстрым затуханием при разломе замка
- выделить эффект разреза ярким жёлтым цветом с подсветкой

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c00e08e3288330b45d61fbb0e4f880