### PR TITLE
feat: expand magic attack mechanics

### DIFF
--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -231,6 +231,30 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
       ctx.fillRect(cx, cy, cell, cell);
     }
   }
+
+  // Для магической атаки подсвечиваем все клетки поля,
+  // а красной рамкой обозначаем только клетку спереди.
+  if (cardData.attackType === 'MAGIC') {
+    for (let r = 0; r < 3; r++) {
+      for (let c = 0; c < 3; c++) {
+        if (r === 1 && c === 1) continue; // центр — сам атакующий
+        const cx = x + c * (cell + gap);
+        const cy = y + r * (cell + gap);
+        ctx.fillStyle = 'rgba(56,189,248,0.35)';
+        ctx.fillRect(cx, cy, cell, cell);
+        ctx.strokeStyle = 'rgba(56,189,248,0.6)';
+        ctx.lineWidth = 1.5;
+        ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);
+      }
+    }
+    const cx = x + 1 * (cell + gap);
+    const cy = y + 0 * (cell + gap);
+    ctx.strokeStyle = '#ef4444';
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);
+    return;
+  }
+
   const map = { N: [-1,0], E:[0,1], S:[1,0], W:[0,-1] };
   for (const a of attacks) {
     const isChoice = cardData.chooseDir || a.mode === 'ANY';

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -102,13 +102,37 @@ describe('guards and hits', () => {
 describe('magicAttack', () => {
   it('applies damage and does not trigger retaliation', () => {
     const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
-    // Use a magic attacker template: FIRE_FLAME_MAGUS
     state.board[1][1].unit = { owner: 0, tplId: 'FIRE_FLAME_MAGUS', facing: 'E', hp: 1 };
     state.board[1][2].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'W', hp: 2 };
     const res = magicAttack(state, 1, 1, 1, 2);
     expect(res).toBeTruthy();
     expect(res.n1.board[1][2].unit.currentHP).toBeLessThanOrEqual(2);
-    expect(res.dmg).toBeGreaterThanOrEqual(1);
+    expect(res.targets[0].dmg).toBeGreaterThanOrEqual(1);
+  });
+
+  it('allows friendly fire when template permits', () => {
+    CARDS.TEST_MAGIC_FF = { id: 'TEST_MAGIC_FF', name: 'Test Mage', type: 'UNIT', cost: 0, element: 'FIRE', atk: 1, hp: 1, attackType: 'MAGIC', friendlyFire: true };
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][1].unit = { owner: 0, tplId: 'TEST_MAGIC_FF', facing: 'N', hp: 1 };
+    state.board[0][0].unit = { owner: 0, tplId: 'FIRE_FLAME_LIZARD', facing: 'S', hp: 2 };
+    const res = magicAttack(state, 1, 1, 0, 0);
+    expect(res).toBeTruthy();
+    expect(res.targets.some(t => t.r === 0 && t.c === 0)).toBe(true);
+    delete CARDS.TEST_MAGIC_FF;
+  });
+
+  it('applies splash damage around target', () => {
+    CARDS.TEST_MAGIC_SPLASH = { id: 'TEST_MAGIC_SPLASH', name: 'Splash Mage', type: 'UNIT', cost: 0, element: 'FIRE', atk: 1, hp: 1, attackType: 'MAGIC', splash: 1, friendlyFire: true };
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][1].unit = { owner: 0, tplId: 'TEST_MAGIC_SPLASH', facing: 'N', hp: 1 };
+    state.board[0][0].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'S', hp: 2 };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_FLAME_LIZARD', facing: 'S', hp: 2 };
+    const res = magicAttack(state, 1, 1, 0, 0);
+    expect(res.targets.length).toBeGreaterThan(1);
+    const hitCoords = res.targets.map(t => `${t.r},${t.c}`);
+    expect(hitCoords).toContain('0,0');
+    expect(hitCoords).toContain('0,1');
+    delete CARDS.TEST_MAGIC_SPLASH;
   });
 });
 


### PR DESCRIPTION
## Summary
- allow magic attacks to hit any cell with optional friendly fire and splash radius
- unify magic attack UI: board-wide highlighting, global FX, and card diagram updates
- cover new behaviors with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c013f2dda8833091bb749e6ddc4a38