### PR TITLE
Add cancel placement option and polish animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,9 @@
       <div id="opponent-hand-count" title="Opponent has 0 cards"></div>
     </div>
 
+    <!-- Кнопка отмены действий с картой -->
+    <button id="cancel-placement-btn" class="overlay-panel px-3 py-1.5 text-xs bg-red-600 hover:bg-red-700 fixed top-3 right-4 z-20 hidden">Отмена</button>
+
     <!-- Правый нижний угол: сервисные кнопки -->
     <div id="corner-right" class="ui-panel fixed right-4 bottom-4 z-20">
       <div class="flex gap-2 opacity-90">

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,7 @@ import * as BattleSplash from './ui/battleSplash.js';
 import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
+import './ui/cancelPlacement.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {

--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -191,17 +191,18 @@ export async function animateDrawnCardToHand(cardTpl) {
     }
   } catch {}
 
+  try {
+    big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
+    big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));
+    big.rotateZ(THREE.MathUtils.degToRad(T.rollDeg || 0));
+  } catch {}
+
   await new Promise(resolve => {
     const tl = gsap.timeline({ onComplete: resolve });
     tl.to(allMaterials, { opacity: 1, duration: 0.8, ease: 'power2.out' })
       .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.7, ease: 'power2.inOut' }, 'fly')
       .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.7, ease: 'power2.inOut' }, 'fly')
       .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.7, ease: 'power2.inOut' }, 'fly');
-    try {
-      big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
-      big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));
-      big.rotateZ(THREE.MathUtils.degToRad(T.rollDeg || 0));
-    } catch {}
   });
 
   try { cardGroup.remove(big); } catch {}

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -77,8 +77,9 @@ export function performUnitAttack(unitMesh) {
       window.__ui?.updateUI?.(gameState);
       try { window.selectedUnit = null; window.__ui?.panels?.hideUnitActionPanel(); } catch {}
       if (iState) {
-        iState.magicFrom = { r, c };
+        iState.magicFrom = { r, c, cardData: tpl, handIndex: null };
         highlightTiles(cells);
+        try { window.__ui?.cancelPlacement?.show(); } catch {}
       }
       window.__ui?.log?.add?.(`${tpl.name}: select a target for the magical attack.`);
       return;
@@ -100,8 +101,11 @@ export function performUnitAttack(unitMesh) {
     window.__ui?.updateUI?.(gameState);
     try { window.selectedUnit = null; window.__ui?.panels?.hideUnitActionPanel(); } catch {}
     if (needsChoice && hitsAll.length > 1) {
-      if (iState) iState.pendingAttack = { r, c };
-      highlightTiles(hitsAll);
+      if (iState) {
+        iState.pendingAttack = { r, c, cardData: tpl, handIndex: null };
+        highlightTiles(hitsAll);
+        try { window.__ui?.cancelPlacement?.show(); } catch {}
+      }
       window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
       window.__ui?.notifications?.show('Выберите цель', 'info');
       return;
@@ -293,13 +297,13 @@ export async function endTurn() {
     } catch {}
     try {
       if (w.__ui && w.__ui.mana && typeof w.__ui.mana.animateTurnManaGain === 'function') {
-        await w.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 1500);
+        await w.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 600);
       } else {
         console.warn('Module mana animation not available, skipping');
       }
       player.mana = manaAfter;
     } catch {}
-    await w.sleep?.(80);
+    await w.sleep?.(20);
     w.updateUI?.();
     try {
       if (shouldAnimateDraw && drawnTpl) {

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -56,9 +56,9 @@ export async function showTurnSplash(title) {
         .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
         .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
         .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      await sleep(1330);
+      tl.timeScale(1.33);
+      await sleep(1000);
     } else {
-      // Fallback: simple 1s show
       await sleep(1000);
     }
   } catch {}

--- a/src/ui/battleSplash.js
+++ b/src/ui/battleSplash.js
@@ -35,7 +35,8 @@ export async function showBattleSplash() {
         .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
         .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
         .to(bb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      await sleep(1330);
+      tl.timeScale(1.33);
+      await sleep(1000);
     } catch { await sleep(1000); }
     bb.classList.add('hidden'); bb.classList.remove('flex'); bb.style.display = 'none';
     bb.style.opacity = ''; bb.innerHTML = '';

--- a/src/ui/cancelPlacement.js
+++ b/src/ui/cancelPlacement.js
@@ -1,0 +1,15 @@
+// Кнопка отмены режима постановки карты
+
+function show(){
+  const btn = document.getElementById('cancel-placement-btn');
+  if (btn) btn.classList.remove('hidden');
+}
+
+function hide(){
+  const btn = document.getElementById('cancel-placement-btn');
+  if (btn) btn.classList.add('hidden');
+}
+
+const api = { show, hide };
+try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.cancelPlacement = api; } } catch {}
+export default api;

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -54,6 +54,10 @@ export function attachUIEvents() {
     w.__ui?.panels?.hideUnitActionPanel?.();
   });
 
+  document.getElementById('cancel-placement-btn')?.addEventListener('click', () => {
+    w.__interactions?.cancelTargetSelection?.();
+  });
+
   document.getElementById('rotate-cw-btn')?.addEventListener('click', () => {
     const u = w.__interactions?.getSelectedUnit?.();
     if (u) w.__ui?.actions?.rotateUnit?.(u, 'cw');


### PR DESCRIPTION
## Summary
- preserve attack mode until valid target chosen and allow cancelling
- add top-right cancel button returning card and mana
- smooth card scaling and shorten turn/battle banners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0aa90b9c88330873f2bc365e02fb3