### PR TITLE
Improve attack targeting and add cancel button

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,11 @@
       <div id="opponent-hand-count" title="Opponent has 0 cards"></div>
     </div>
 
+    <!-- Правая верхняя область для вспомогательных кнопок -->
+    <div id="top-right" class="ui-panel fixed top-3 right-3 z-50">
+      <button id="cancel-play-btn" class="overlay-panel px-4 py-2 bg-red-600 hover:bg-red-700 hidden">Отмена</button>
+    </div>
+
     <!-- Правый нижний угол: сервисные кнопки -->
     <div id="corner-right" class="ui-panel fixed right-4 bottom-4 z-20">
       <div class="flex gap-2 opacity-90">
@@ -98,9 +103,6 @@
           <div></div>
           <button data-dir="S" class="overlay-panel px-4 py-2 hover:bg-slate-700">↓</button>
           <div></div>
-        </div>
-        <div class="text-center mt-4">
-          <button id="cancel-orient-btn" class="overlay-panel px-4 py-2 bg-red-600 hover:bg-red-700">Отмена</button>
         </div>
       </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,7 @@ import * as BattleSplash from './ui/battleSplash.js';
 import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
+import * as CancelButton from './ui/cancelButton.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -161,6 +162,7 @@ try {
   window.__ui.updateUI = updateUI;
   window.__ui.inputLock = InputLock;
   window.__ui.summonLock = SummonLock;
+  window.__ui.cancelButton = CancelButton;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;
@@ -172,6 +174,7 @@ try {
   window.requestTurnSplash = Banner.requestTurnSplash;
   window.showBattleSplash = BattleSplash.showBattleSplash;
   window.attachUIEvents = attachUIEvents;
+  window.__ui.cancelButton.setupCancelButton();
   window.playDeltaAnimations = playDeltaAnimations;
   window.createMetaObjects = createMetaObjects;
 } catch {}

--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -194,9 +194,9 @@ export async function animateDrawnCardToHand(cardTpl) {
   await new Promise(resolve => {
     const tl = gsap.timeline({ onComplete: resolve });
     tl.to(allMaterials, { opacity: 1, duration: 0.8, ease: 'power2.out' })
-      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.7, ease: 'power2.inOut' }, 'fly')
-      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.7, ease: 'power2.inOut' }, 'fly')
-      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.7, ease: 'power2.inOut' }, 'fly');
+      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.7, ease: 'power2.inOut', immediateRender: false }, 'fly')
+      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.7, ease: 'power2.inOut', immediateRender: false }, 'fly')
+      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.7, ease: 'power2.inOut', immediateRender: false }, 'fly');
     try {
       big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
       big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -112,6 +112,7 @@ export const handlers = {
         interactionState.pendingSpellOrientation = { spellCardMesh: cardMesh, unitMesh };
         addLog(`${tpl.name}: выберите направление для цели.`);
         window.__ui.panels.showOrientationPanel();
+        try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
       } catch {}
     },
   },

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -79,6 +79,7 @@ export function performUnitAttack(unitMesh) {
       if (iState) {
         iState.magicFrom = { r, c };
         highlightTiles(cells);
+        try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
       }
       window.__ui?.log?.add?.(`${tpl.name}: select a target for the magical attack.`);
       return;
@@ -100,8 +101,11 @@ export function performUnitAttack(unitMesh) {
     window.__ui?.updateUI?.(gameState);
     try { window.selectedUnit = null; window.__ui?.panels?.hideUnitActionPanel(); } catch {}
     if (needsChoice && hitsAll.length > 1) {
-      if (iState) iState.pendingAttack = { r, c };
-      highlightTiles(hitsAll);
+      if (iState) {
+        iState.pendingAttack = { r, c };
+        highlightTiles(hitsAll);
+        try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
+      }
       window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
       window.__ui?.notifications?.show('Выберите цель', 'info');
       return;
@@ -293,13 +297,13 @@ export async function endTurn() {
     } catch {}
     try {
       if (w.__ui && w.__ui.mana && typeof w.__ui.mana.animateTurnManaGain === 'function') {
-        await w.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 1500);
+        await w.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 900);
       } else {
         console.warn('Module mana animation not available, skipping');
       }
       player.mana = manaAfter;
     } catch {}
-    await w.sleep?.(80);
+    await w.sleep?.(20);
     w.updateUI?.();
     try {
       if (shouldAnimateDraw && drawnTpl) {

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -56,7 +56,8 @@ export async function showTurnSplash(title) {
         .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
         .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
         .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      await sleep(1330);
+      tl.timeScale?.(0.75);
+      await sleep(1000);
     } else {
       // Fallback: simple 1s show
       await sleep(1000);

--- a/src/ui/battleSplash.js
+++ b/src/ui/battleSplash.js
@@ -35,7 +35,8 @@ export async function showBattleSplash() {
         .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
         .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
         .to(bb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      await sleep(1330);
+      tl.timeScale?.(0.75);
+      await sleep(1000);
     } catch { await sleep(1000); }
     bb.classList.add('hidden'); bb.classList.remove('flex'); bb.style.display = 'none';
     bb.style.opacity = ''; bb.innerHTML = '';

--- a/src/ui/cancelButton.js
+++ b/src/ui/cancelButton.js
@@ -1,0 +1,66 @@
+// Кнопка отмены действий при установке карты или выборе цели
+import { interactionState, returnCardToHand } from '../scene/interactions.js';
+import { clearHighlights } from '../scene/highlight.js';
+
+function refundSummon(row, col) {
+  const gs = window.gameState;
+  if (!gs) return;
+  const cell = gs.board?.[row]?.[col];
+  const unit = cell?.unit;
+  if (!unit) return;
+  const tpl = window.CARDS?.[unit.tplId];
+  if (!tpl) return;
+  const player = gs.players[unit.owner];
+  // возврат маны
+  player.mana += tpl.cost;
+  // вернуть карту из сброса в руку
+  const idx = player.discard.findIndex(c => c.id === tpl.id);
+  if (idx >= 0) player.discard.splice(idx, 1);
+  player.hand.push(tpl);
+  // убрать юнита с поля
+  cell.unit = null;
+}
+
+export function refreshCancelButton() {
+  const btn = document.getElementById('cancel-play-btn');
+  if (!btn) return;
+  const vis = interactionState.pendingPlacement || interactionState.pendingAttack || interactionState.magicFrom || interactionState.pendingSpellOrientation || interactionState.selectedCard;
+  btn.classList.toggle('hidden', !vis);
+}
+
+export function setupCancelButton() {
+  const btn = document.getElementById('cancel-play-btn');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    try {
+      if (interactionState.pendingPlacement) {
+        returnCardToHand(interactionState.pendingPlacement.card);
+        interactionState.pendingPlacement = null;
+        window.__ui?.panels?.hideOrientationPanel?.();
+      } else if (interactionState.magicFrom || interactionState.pendingAttack) {
+        const pos = interactionState.magicFrom || interactionState.pendingAttack;
+        refundSummon(pos.r, pos.c);
+        interactionState.magicFrom = null;
+        interactionState.pendingAttack = null;
+        interactionState.autoEndTurnAfterAttack = false;
+        window.updateUnits?.();
+        window.updateHand?.();
+        window.updateUI?.();
+      } else if (interactionState.pendingSpellOrientation) {
+        interactionState.pendingSpellOrientation = null;
+        window.__ui?.panels?.hideOrientationPanel?.();
+        interactionState.selectedCard && returnCardToHand(interactionState.selectedCard);
+      } else if (interactionState.selectedCard) {
+        returnCardToHand(interactionState.selectedCard);
+        interactionState.selectedCard = null;
+      }
+    } catch {}
+    clearHighlights();
+    refreshCancelButton();
+  });
+  refreshCancelButton();
+}
+
+const api = { setupCancelButton, refreshCancelButton };
+try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.cancelButton = api; } } catch {}
+export default api;

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -42,13 +42,6 @@ export function attachUIEvents() {
     w.__ui?.panels?.hidePrompt?.();
   });
 
-  document.getElementById('cancel-orient-btn')?.addEventListener('click', () => {
-    const pp = w.__interactions?.getPendingPlacement?.();
-    if (pp) { w.__interactions.returnCardToHand(pp.card); }
-    w.__ui?.panels?.hideOrientationPanel?.();
-    w.__interactions?.clearPendingPlacement?.();
-  });
-
   document.getElementById('cancel-action-btn')?.addEventListener('click', () => {
     w.__interactions?.clearSelectedUnit?.();
     w.__ui?.panels?.hideUnitActionPanel?.();
@@ -86,6 +79,7 @@ export function attachUIEvents() {
         }
         w.__interactions.clearPendingSpellOrientation();
         w.__ui.panels.hideOrientationPanel();
+        try { w.__ui.cancelButton.refreshCancelButton(); } catch {}
         return;
       }
       w.__interactions.placeUnitWithDirection(direction);

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -157,7 +157,7 @@ export function animateManaGainFromWorld(pos, ownerIndex, visualOnly = true, tar
   } catch {}
 }
 
-export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationMs = 1500) {
+export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationMs = 900) {
   return new Promise(resolve => {
     try {
       // Проверяем, не идет ли уже анимация


### PR DESCRIPTION
## Summary
- Keep attack targeting highlights active until a valid enemy is chosen
- Add global cancel button for card placement and targeting
- Smooth card draw/placement animations and shorten turn/battle splashes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0aa90b9c88330873f2bc365e02fb3