### PR TITLE
fix: refine targeting and turn animations

### DIFF
--- a/src/scene/delta.js
+++ b/src/scene/delta.js
@@ -28,22 +28,31 @@ export function playDeltaAnimations(prevState, nextState) {
         const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
         if (pu && !nu) {
           try {
-            const tile = tileMeshes?.[r]?.[c]; if (!tile) continue;
-            const ghost = createCard3D ? createCard3D(CARDS[pu.tplId], false) : null;
-            if (ghost && window.THREE) {
-              ghost.position.copy(tile.position).add(new window.THREE.Vector3(0, 0.28, 0));
-              try { effectsGroup.add(ghost); } catch { cardGroup.add(ghost); }
-              window.__fx?.dissolveAndAsh(ghost, new window.THREE.Vector3(0,0,0.6), 0.9);
-            }
-            const p = tile.position.clone().add(new window.THREE.Vector3(0, 1.2, 0));
-            const slot = (prevState?.players?.[pu.owner]?.mana ?? 0);
-            animateManaGainFromWorld?.(p, pu.owner, true, slot);
-            try {
-              if (!NET_ACTIVE && gameState && gameState.players && typeof pu.owner === 'number') {
-                gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana||0) + 1);
-                updateUI?.(gameState);
+            const prevPl = prevState?.players?.[pu.owner];
+            const nextPl = nextState?.players?.[pu.owner];
+            const canceled = prevPl && nextPl &&
+              Array.isArray(prevPl.discard) && Array.isArray(nextPl.discard) &&
+              Array.isArray(prevPl.hand) && Array.isArray(nextPl.hand) &&
+              prevPl.discard.length > nextPl.discard.length &&
+              nextPl.hand.length > prevPl.hand.length;
+            if (!canceled) {
+              const tile = tileMeshes?.[r]?.[c]; if (!tile) continue;
+              const ghost = createCard3D ? createCard3D(CARDS[pu.tplId], false) : null;
+              if (ghost && window.THREE) {
+                ghost.position.copy(tile.position).add(new window.THREE.Vector3(0, 0.28, 0));
+                try { effectsGroup.add(ghost); } catch { cardGroup.add(ghost); }
+                window.__fx?.dissolveAndAsh(ghost, new window.THREE.Vector3(0,0,0.6), 0.9);
               }
-            } catch {}
+              const p = tile.position.clone().add(new window.THREE.Vector3(0, 1.2, 0));
+              const slot = (prevState?.players?.[pu.owner]?.mana ?? 0);
+              animateManaGainFromWorld?.(p, pu.owner, true, slot);
+              try {
+                if (!NET_ACTIVE && gameState && gameState.players && typeof pu.owner === 'number') {
+                  gameState.players[pu.owner].mana = capMana((gameState.players[pu.owner].mana||0) + 1);
+                  updateUI?.(gameState);
+                }
+              } catch {}
+            }
           } catch {}
         } else if (!pu && nu) {
           try {

--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -193,10 +193,11 @@ export async function animateDrawnCardToHand(cardTpl) {
 
   await new Promise(resolve => {
     const tl = gsap.timeline({ onComplete: resolve });
+    // Сначала проявляем карту, затем запускаем полёт в руку
     tl.to(allMaterials, { opacity: 1, duration: 0.8, ease: 'power2.out' })
-      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.7, ease: 'power2.inOut', immediateRender: false }, 'fly')
-      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.7, ease: 'power2.inOut', immediateRender: false }, 'fly')
-      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.7, ease: 'power2.inOut', immediateRender: false }, 'fly');
+      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.7, ease: 'power2.inOut' })
+      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.7, ease: 'power2.inOut' }, '<')
+      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.7, ease: 'power2.inOut' }, '<');
     try {
       big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
       big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -207,7 +207,7 @@ function onMouseUp(event) {
   if (isInputLocked()) { endCardDrag(); return; }
   const gameState = (typeof window !== 'undefined' ? window.gameState : null);
   const ctx = getCtx();
-  const { renderer, mouse, raycaster, unitMeshes } = ctx;
+  const { renderer, mouse, raycaster, unitMeshes, tileMeshes, tileFrames } = ctx;
   if (interactionState.draggedCard) {
     const cardData = interactionState.draggedCard.userData.cardData;
     const rect = renderer.domElement.getBoundingClientRect();
@@ -241,6 +241,13 @@ function onMouseUp(event) {
             col,
             handIndex: interactionState.draggedCard.userData.handIndex,
           };
+          // Сразу опускаем карту на высоту клетки, чтобы убрать резкий подъём
+          try {
+            const baseY = (tileFrames?.[row]?.[col]?.children?.[0]?.position?.y ?? 1.0) + 0.28;
+            const pos = tileMeshes[row][col].position.clone();
+            pos.y = baseY;
+            gsap.to(interactionState.draggedCard.position, { x: pos.x, y: pos.y, z: pos.z, duration: 0.15 });
+          } catch {}
           try { window.__ui.panels.showOrientationPanel(); } catch {}
           try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
         }
@@ -251,7 +258,6 @@ function onMouseUp(event) {
     endCardDrag();
     return;
   }
-  endCardDrag();
 }
 
 function startCardDrag(card) {
@@ -523,7 +529,9 @@ export function placeUnitWithDirection(direction) {
   }
   const ctx = getCtx();
   const targetPos = ctx.tileMeshes[row][col].position.clone();
-  targetPos.y = ctx.tileMeshes[row][col].position.y + 0.28;
+  // Используем ту же высоту, что и при окончательной отрисовке юнита
+  const baseY = (ctx.tileFrames?.[row]?.[col]?.children?.[0]?.position?.y ?? 1.0) + 0.28;
+  targetPos.y = baseY;
   gsap.to(card.position, {
     x: targetPos.x,
     y: targetPos.y,

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -303,7 +303,7 @@ export async function endTurn() {
       }
       player.mana = manaAfter;
     } catch {}
-    await w.sleep?.(20);
+    // После получения маны сразу запускаем добор карты без лишней паузы
     w.updateUI?.();
     try {
       if (shouldAnimateDraw && drawnTpl) {


### PR DESCRIPTION
## Summary
- keep target highlights active after misclicks and align placed cards to tile height
- skip death/mana animations when a summon is cancelled by the other player
- smooth draw and placement animations for cleaner turn transitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0ebbdcc04833092289eb3cb4b948f