### PR TITLE
Fix hp sync, target selection, and turn banners

### DIFF
--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -164,6 +164,7 @@ export function stagedAttack(state, r, c, opts = {}) {
       const B = cell?.unit; if (!B) continue;
       const before = B.currentHP ?? B.hp;
       B.currentHP = Math.max(0, before - (h.dealt || 0));
+      B.hp = B.currentHP; // синхронизируем поле hp, чтобы состояние не откатывалось
       const afterHP = B.currentHP;
       const nameA = CARDS[attacker.tplId]?.name || 'Attacker';
       const nameB = CARDS[B.tplId]?.name || 'Target';
@@ -207,6 +208,7 @@ export function stagedAttack(state, r, c, opts = {}) {
     if (A && (ret.total || 0) > 0) {
       const before = A.currentHP ?? A.hp;
       A.currentHP = Math.max(0, before - (ret.total || 0));
+      A.hp = A.currentHP; // сохраняем актуальное здоровье
       logLines.push(`Retaliation to ${CARDS[A.tplId]?.name || 'Attacker'}: ${ret.total || 0} (HP ${before}→${A.currentHP})`);
     }
 
@@ -280,6 +282,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
     if (!allowFriendly && u.owner === attacker.owner) continue;
     const before = u.currentHP ?? u.hp;
     u.currentHP = Math.max(0, before - dmg);
+    u.hp = u.currentHP; // обновляем и запасное поле hp
     targets.push({ r: cell.r, c: cell.c, dmg });
     logLines.push(`${CARDS[attacker.tplId].name} (Magic) → ${CARDS[u.tplId].name}: ${dmg} dmg (HP ${before}→${u.currentHP})`);
   }

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -165,7 +165,7 @@
         })),
         board: (state.board||[]).map(row => row.map(cell => {
           const u = cell?.unit;
-          return u ? {o:u.owner,h:u.hp,a:u.atk,f:u.facing,t:u.tplId} : null;
+          return u ? {o:u.owner,h:(u.currentHP ?? u.hp),a:u.atk,f:u.facing,t:u.tplId} : null;
         }))
       };
       return JSON.stringify(compact);

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -495,6 +495,7 @@ export function placeUnitWithDirection(direction) {
     owner: gameState.active,
     tplId: cardData.id,
     currentHP: cardData.hp,
+    hp: cardData.hp, // запасное поле для сетевой синхронизации
     facing: direction,
   };
   gameState.board[row][col].unit = unit;
@@ -513,6 +514,7 @@ export function placeUnitWithDirection(direction) {
   if (buff.hp !== 0) {
     const before = unit.currentHP;
     unit.currentHP = Math.max(0, unit.currentHP + buff.hp);
+    unit.hp = unit.currentHP;
     if (buff.hp > 0) window.addLog(`Элемент усиливает ${cardData.name}: HP ${before}→${unit.currentHP}`);
     else window.addLog(`Элемент ослабляет ${cardData.name}: HP ${before}→${unit.currentHP}`);
   }
@@ -580,18 +582,18 @@ export function placeUnitWithDirection(direction) {
         const attacks = tpl?.attacks || [];
         const needsChoice = tpl?.chooseDir || attacks.some(a => a.mode === 'ANY');
         const hitsAll = window.computeHits(gameState, row, col, { union: true });
-        const hasEnemy = hitsAll.some(h => gameState.board?.[h.r]?.[h.c]?.unit?.owner !== unit.owner);
-        if (hitsAll.length && hasEnemy) {
-          if (needsChoice && hitsAll.length > 1) {
+        const enemyHits = hitsAll.filter(h => gameState.board?.[h.r]?.[h.c]?.unit?.owner !== unit.owner);
+        if (enemyHits.length) {
+          if (needsChoice && enemyHits.length > 1) {
             interactionState.pendingAttack = { r: row, c: col };
             interactionState.autoEndTurnAfterAttack = true;
-            highlightTiles(hitsAll);
+            highlightTiles(enemyHits);
             window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
             window.__ui?.notifications?.show('Выберите цель', 'info');
           } else {
             let opts = {};
-            if (needsChoice && hitsAll.length === 1) {
-              const h = hitsAll[0];
+            if (needsChoice && enemyHits.length === 1) {
+              const h = enemyHits[0];
               const dr = h.r - row, dc = h.c - col;
               const absDir = dr < 0 ? 'N' : dr > 0 ? 'S' : dc > 0 ? 'E' : 'W';
               const ORDER = ['N', 'E', 'S', 'W'];

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -256,6 +256,7 @@ export const handlers = {
       if (u) {
         const before = u.currentHP;
         u.currentHP = Math.max(0, u.currentHP - 1);
+        u.hp = u.currentHP;
         addLog(
           `${tpl.name}: ${CARDS[u.tplId].name} получает 1 урона (HP ${before}→${u.currentHP})`
         );
@@ -304,6 +305,7 @@ export const handlers = {
       }
       const before = u.currentHP;
       u.currentHP += 2;
+      u.hp = u.currentHP;
       addLog(
         `${tpl.name}: ${CARDS[u.tplId].name} получает +2 HP (HP ${before}→${u.currentHP})`
       );
@@ -365,6 +367,7 @@ export const handlers = {
         if (deltaHp !== 0) {
           const before = u.currentHP;
           u.currentHP = Math.max(0, before + deltaHp);
+          u.hp = u.currentHP;
           const tMesh = unitMeshes.find(m => m.userData.row === r && m.userData.col === c);
           if (tMesh)
             window.__fx.spawnDamageText(

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -88,8 +88,8 @@ export function performUnitAttack(unitMesh) {
     const attacks = tpl?.attacks || [];
     const needsChoice = tpl?.chooseDir || attacks.some(a => a.mode === 'ANY');
     const hitsAll = typeof computeHits === 'function' ? computeHits(gameState, r, c, { union: true }) : [];
-    const hasEnemy = hitsAll.some(h => gameState.board?.[h.r]?.[h.c]?.unit?.owner !== unit.owner);
-    if (!hitsAll.length || !hasEnemy) {
+    const enemyHits = hitsAll.filter(h => gameState.board?.[h.r]?.[h.c]?.unit?.owner !== unit.owner);
+    if (!enemyHits.length) {
       window.__ui?.notifications?.show('No available targets for attack', 'error');
       return;
     }
@@ -100,10 +100,10 @@ export function performUnitAttack(unitMesh) {
     gameState.players[gameState.active].mana -= cost;
     window.__ui?.updateUI?.(gameState);
     try { window.selectedUnit = null; window.__ui?.panels?.hideUnitActionPanel(); } catch {}
-    if (needsChoice && hitsAll.length > 1) {
+    if (needsChoice && enemyHits.length > 1) {
       if (iState) {
         iState.pendingAttack = { r, c };
-        highlightTiles(hitsAll);
+        highlightTiles(enemyHits);
         try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
       }
       window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
@@ -112,8 +112,8 @@ export function performUnitAttack(unitMesh) {
     }
     // если выбор не нужен или доступна единственная цель, атакуем сразу
     let opts = {};
-    if (needsChoice && hitsAll.length === 1) {
-      const h = hitsAll[0];
+    if (needsChoice && enemyHits.length === 1) {
+      const h = enemyHits[0];
       const dr = h.r - r, dc = h.c - c;
       const absDir = dr < 0 ? 'N' : dr > 0 ? 'S' : dc > 0 ? 'E' : 'W';
       const ORDER = ['N', 'E', 'S', 'W'];
@@ -221,13 +221,13 @@ export async function endTurn() {
     try {
       if (w.__ui && w.__ui.banner) {
         const b = w.__ui.banner;
-        if (typeof b.ensureTurnSplashVisible === 'function') {
-          await b.ensureTurnSplashVisible(3, gameState.turn);
-        } else if (typeof b.forceTurnSplashWithRetry === 'function') {
+        if (typeof b.forceTurnSplashWithRetry === 'function') {
           await b.forceTurnSplashWithRetry(3, gameState.turn);
+        } else if (typeof b.ensureTurnSplashVisible === 'function') {
+          await b.ensureTurnSplashVisible(3, gameState.turn);
         }
       } else if (typeof w.forceTurnSplashWithRetry === 'function') {
-        await w.forceTurnSplashWithRetry(3);
+        await w.forceTurnSplashWithRetry(3, gameState.turn);
       }
     } catch {}
 

--- a/src/ui/sync.js
+++ b/src/ui/sync.js
@@ -31,7 +31,7 @@ export function attachSocketUIRefresh() {
           const turn = (typeof window !== 'undefined' && window.gameState && typeof window.gameState.turn === 'number') ? window.gameState.turn : null;
           if (turn && window.__ui && window.__ui.banner) {
             const b = window.__ui.banner;
-            const fn = (typeof b.ensureTurnSplashVisible === 'function') ? b.ensureTurnSplashVisible : b.forceTurnSplashWithRetry;
+            const fn = (typeof b.forceTurnSplashWithRetry === 'function') ? b.forceTurnSplashWithRetry : b.ensureTurnSplashVisible;
             fn.call(b, 2, turn).catch(e => {
               console.warn('[SYNC] Failed to show turn splash:', e);
             });


### PR DESCRIPTION
## Summary
- Исправлено восстановление здоровья: урон теперь всегда синхронизирует поля `currentHP` и `hp`
- Hellfire Spitter и другие юниты с выбором направления теперь корректно запрашивают цель, если их несколько
- Заставка начала хода отображается надёжно благодаря принудительному `forceTurnSplashWithRetry`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c109d8e1a08330adec5d8ce6dabf86