### PR TITLE
Fix unit target selection and reset banners

### DIFF
--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -301,5 +301,6 @@ export function magicAttack(state, fr, fc, tr, tc) {
   } catch {}
   attacker.lastAttackTurn = n1.turn;
   attacker.apSpent = (attacker.apSpent || 0) + attackCost(tplA);
-  return { n1, logLines, targets, deaths };
+  // возвращаем нанесённый урон для удобства отображения
+  return { n1, logLines, targets, deaths, dmg };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -172,6 +172,8 @@ try {
   window.queueTurnSplash = Banner.queueTurnSplash;
   window.forceTurnSplashWithRetry = Banner.forceTurnSplashWithRetry;
   window.requestTurnSplash = Banner.requestTurnSplash;
+  // сбрасываем состояние заставок на старте
+  try { Banner.resetTurnSplashState?.(); } catch {}
   window.showBattleSplash = BattleSplash.showBattleSplash;
   window.attachUIEvents = attachUIEvents;
   window.__ui.cancelButton.setupCancelButton();

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -580,18 +580,19 @@ export function placeUnitWithDirection(direction) {
         const attacks = tpl?.attacks || [];
         const needsChoice = tpl?.chooseDir || attacks.some(a => a.mode === 'ANY');
         const hitsAll = window.computeHits(gameState, row, col, { union: true });
-        const hasEnemy = hitsAll.some(h => gameState.board?.[h.r]?.[h.c]?.unit?.owner !== unit.owner);
-        if (hitsAll.length && hasEnemy) {
-          if (needsChoice && hitsAll.length > 1) {
+        // учитываем только вражеские цели, чтобы не атаковать автоматически при наличии союзников
+        const enemyHits = hitsAll.filter(h => gameState.board?.[h.r]?.[h.c]?.unit?.owner !== unit.owner);
+        if (enemyHits.length) {
+          if (needsChoice && enemyHits.length > 1) {
             interactionState.pendingAttack = { r: row, c: col };
             interactionState.autoEndTurnAfterAttack = true;
-            highlightTiles(hitsAll);
+            highlightTiles(enemyHits);
             window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
             window.__ui?.notifications?.show('Выберите цель', 'info');
           } else {
             let opts = {};
-            if (needsChoice && hitsAll.length === 1) {
-              const h = hitsAll[0];
+            if (needsChoice && enemyHits.length === 1) {
+              const h = enemyHits[0];
               const dr = h.r - row, dc = h.c - col;
               const absDir = dr < 0 ? 'N' : dr > 0 ? 'S' : dc > 0 ? 'E' : 'W';
               const ORDER = ['N', 'E', 'S', 'W'];

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -69,6 +69,20 @@ export async function showTurnSplash(title) {
   _splashInProgress = false;
 }
 
+// Сброс внутреннего состояния, чтобы заставки не "залипали" между партиями
+export function resetTurnSplashState() {
+  _lastTurnSplashPromise = Promise.resolve();
+  _splashActive = false;
+  _lastRequestedTurn = 0;
+  _lastShownTurn = 0;
+  _splashInProgress = false;
+  _lastActivePlayer = null;
+  _forceNext = false;
+  try {
+    if (typeof window !== 'undefined') window.splashActive = false;
+  } catch {}
+}
+
 export function queueTurnSplash(title){
   try {
     _lastTurnSplashPromise = _lastTurnSplashPromise.then(()=> showTurnSplash(title));
@@ -190,6 +204,6 @@ export function getState(){
   return { _splashActive, _lastRequestedTurn, _lastShownTurn };
 }
 
-const api = { showTurnSplash, queueTurnSplash, requestTurnSplash, forceTurnSplashWithRetry, ensureTurnSplashVisible, getState };
+const api = { showTurnSplash, queueTurnSplash, requestTurnSplash, forceTurnSplashWithRetry, ensureTurnSplashVisible, resetTurnSplashState, getState };
 try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.banner = api; } } catch {}
 export default api;


### PR DESCRIPTION
## Summary
- Return damage value from `magicAttack` for consistent health updates
- Ensure only enemy targets are considered when choosing attack direction
- Reset turn banner state to prevent missing splash screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c109d8e1a08330adec5d8ce6dabf86