### PR TITLE
fix: sync game state and improve turn splash

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@
     
     async function initGame() {
       gameState = startGame(STARTER_FIRESET, STARTER_FIRESET);
-      try { window.gameState = gameState; } catch {}
+      try { window.applyGameState(gameState); } catch {}
       
       // Сразу строим сцену и мета-объекты, без задержки появления
       createBoard();
@@ -464,7 +464,7 @@
         // Применяем урон (этап 1) и перерисовываем юниты
         staged.step1();
         gameState = staged.n1;
-        try { window.gameState = gameState; } catch {}
+        try { window.applyGameState(gameState); } catch {}
         updateUnits();
         // Тряска и всплывающий урон — уже по актуальным мешам после обновления
         for (const h of hitsPrev) {
@@ -535,7 +535,7 @@
           // Финализация: анимация смерти и орбы перед применением состояния
           const res = staged.finish();
           gameState = res.n1;
-          try { window.gameState = gameState; } catch {}
+          try { window.applyGameState(gameState); } catch {}
           if (res.deaths && res.deaths.length) {
             for (const d of res.deaths) {
               try { gameState.players[d.owner].graveyard.push(CARDS[d.tplId]); } catch {}
@@ -654,7 +654,7 @@
           }, 400);
         }
         gameState = res.n1;
-        try { window.gameState = gameState; } catch {}
+        try { window.applyGameState(gameState); } catch {}
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         setTimeout(() => {
           updateUnits(); updateUI();
@@ -666,7 +666,7 @@
         }, 1000);
       } else {
         // Если смертей нет — применяем состояние сразу
-        gameState = res.n1; try { window.gameState = gameState; } catch {}
+        gameState = res.n1; try { window.applyGameState(gameState); } catch {}
         updateUnits(); updateUI();
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         try { schedulePush('magic-battle-finish'); } catch {}

--- a/src/main.js
+++ b/src/main.js
@@ -117,8 +117,19 @@ try { window.__store = store; } catch {}
 // Initialize only if no existing gameState is present (non-destructive)
 if (typeof window !== 'undefined' && !window.gameState) {
   const s = startGame(STARTER_FIRESET, STARTER_FIRESET);
-  try { window.gameState = s; } catch {}
+  try { applyGameState(s); } catch {}
 }
+
+// Унифицированное применение нового состояния игры
+export function applyGameState(state) {
+  try {
+    // Обновляем глобальную переменную
+    window.gameState = state;
+    // Синхронизируем стораж, чтобы состояние не откатывалось в конце хода
+    window.__store?.dispatch({ type: A.REPLACE_STATE, payload: state });
+  } catch {}
+}
+try { if (typeof window !== 'undefined') window.applyGameState = applyGameState; } catch {}
 
 // Expose new scene/board API for gradual migration from inline script
 try {

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -292,7 +292,7 @@
     APPLYING = true;
     try {
       gameState = state;
-      try { window.gameState = state; } catch {}
+      try { window.applyGameState(state); } catch {}
       lastDigest = digest(state);
       // Сразу обновим руку, чтобы скрыть добранные карты до анимации
       try { updateHand(); } catch {}

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -386,7 +386,7 @@ function performMagicAttack(from, targetMesh) {
       }, 400);
     }
     // Обновляем состояние сразу, чтобы клетка считалась свободной
-    window.gameState = res.n1;
+    try { window.applyGameState(res.n1); } catch {}
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
     setTimeout(() => {
       window.updateUnits(); window.updateUI();
@@ -397,7 +397,8 @@ function performMagicAttack(from, targetMesh) {
     }
     }, 1000);
   } else {
-    window.gameState = res.n1; window.updateUnits(); window.updateUI();
+    try { window.applyGameState(res.n1); } catch {}
+    window.updateUnits(); window.updateUI();
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
     try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
     if (interactionState.autoEndTurnAfterAttack) {
@@ -527,6 +528,8 @@ export function placeUnitWithDirection(direction) {
     window.animateManaGainFromWorld(pos, owner, true, slot);
     gameState.board[row][col].unit = null;
   }
+  // Синхронизируем состояние после призыва
+  try { window.applyGameState(gameState); } catch {}
   const ctx = getCtx();
   const targetPos = ctx.tileMeshes[row][col].position.clone();
   // Используем ту же высоту, что и при окончательной отрисовке юнита

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -78,22 +78,20 @@ export function queueTurnSplash(title){
 
 export async function requestTurnSplash(currentTurn){
   if (typeof currentTurn !== 'number') return _lastTurnSplashPromise;
-  
-  // Более умная проверка: показываем заставку если это новый ход или если активный игрок изменился
-  const shouldShow = _lastShownTurn < currentTurn || 
-    (_lastRequestedTurn === currentTurn && !_splashInProgress && _lastShownTurn < currentTurn);
-  
+
+  // Показываем заставку при новом номере хода или если выставлен принудительный показ
+  const shouldShow = _forceNext || _lastShownTurn < currentTurn;
   if (!shouldShow) {
     console.log(`[BANNER] Skipping turn splash: current=${currentTurn}, lastShown=${_lastShownTurn}, inProgress=${_splashInProgress}`);
     return _lastTurnSplashPromise;
   }
-  
-  // De-duplicate only while a splash for this turn is still in progress
+
+  // Если уже запущен показ для этого хода – просто возвращаем существующее обещание
   if (_lastRequestedTurn === currentTurn && _splashInProgress) {
     console.log(`[BANNER] Turn ${currentTurn} splash already in progress`);
     return _lastTurnSplashPromise;
   }
-  
+
   _lastRequestedTurn = currentTurn;
   let title = `Turn ${currentTurn}`;
   try {
@@ -101,10 +99,11 @@ export async function requestTurnSplash(currentTurn){
       ? window.gameState.active : null;
     if (seat !== null) title = `Turn ${currentTurn} - Player ${seat + 1}`;
   } catch {}
-  
+
   console.log(`[BANNER] Requesting turn splash: ${title}`);
-  _lastTurnSplashPromise = queueTurnSplash(title).then(()=>{ 
+  _lastTurnSplashPromise = queueTurnSplash(title).then(()=>{
     _lastShownTurn = currentTurn;
+    _forceNext = false;
     console.log(`[BANNER] Turn splash completed for turn ${currentTurn}`);
   });
   return _lastTurnSplashPromise;


### PR DESCRIPTION
## Summary
- ensure game state is saved through `applyGameState` to prevent damage rollback
- sync state after unit placement and attacks
- make turn banner display reliably at the start of a turn

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c109d8e1a08330adec5d8ce6dabf86