### PR TITLE
Исправление синхронизации боя и анимаций

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,7 +556,7 @@
             setTimeout(() => {
               updateUnits(); updateUI();
               for (const l of res.logLines.reverse()) addLog(l);
-              try { schedulePush('battle-finish'); } catch {}
+              try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -565,7 +565,7 @@
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
-              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish'); } catch {}
+              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -658,7 +658,7 @@
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         setTimeout(() => {
           updateUnits(); updateUI();
-          try { schedulePush('magic-battle-finish'); } catch {}
+          try { schedulePush('magic-battle-finish', { force: true }); } catch {}
           if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
             window.__interactions.interactionState.autoEndTurnAfterAttack = false;
             try { endTurn(); } catch {}
@@ -669,7 +669,7 @@
         gameState = res.n1; try { window.applyGameState(gameState); } catch {}
         updateUnits(); updateUI();
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
-        try { schedulePush('magic-battle-finish'); } catch {}
+        try { schedulePush('magic-battle-finish', { force: true }); } catch {}
         if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
           window.__interactions.interactionState.autoEndTurnAfterAttack = false;
           try { endTurn(); } catch {}

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -390,7 +390,7 @@ function performMagicAttack(from, targetMesh) {
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
     setTimeout(() => {
       window.updateUnits(); window.updateUI();
-      try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
+      try { window.schedulePush && window.schedulePush('magic-battle-finish', { force: true }); } catch {}
       if (interactionState.autoEndTurnAfterAttack) {
         interactionState.autoEndTurnAfterAttack = false;
       try { window.endTurn && window.endTurn(); } catch {}
@@ -400,7 +400,7 @@ function performMagicAttack(from, targetMesh) {
     try { window.applyGameState(res.n1); } catch {}
     window.updateUnits(); window.updateUI();
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
-    try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
+    try { window.schedulePush && window.schedulePush('magic-battle-finish', { force: true }); } catch {}
     if (interactionState.autoEndTurnAfterAttack) {
       interactionState.autoEndTurnAfterAttack = false;
       try { window.endTurn && window.endTurn(); } catch {}

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -57,10 +57,10 @@ export async function showTurnSplash(title) {
         .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
         .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
       tl.timeScale?.(0.75);
-      await sleep(1000);
+      await sleep(1300);
     } else {
-      // Fallback: simple 1s show
-      await sleep(1000);
+      // Fallback: простое отображение 1.3s
+      await sleep(1300);
     }
   } catch {}
   tb.classList.add('hidden'); tb.classList.remove('flex'); tb.style.display = 'none'; tb.style.opacity = '';

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -219,8 +219,9 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
         const tl = (typeof window !== 'undefined') ? window.gsap?.timeline?.({ onComplete: cleanup }) : null;
         if (tl) {
           tl.to(bar, { filter: 'brightness(2.1) drop-shadow(0 0 16px rgba(96,165,250,0.95))', duration: 0.154, ease: 'power2.out' })
-            .to(bar, { filter: 'none', duration: 0.42, ease: 'power2.inOut' })
-            .to({}, { duration: Math.max(0, (durationMs/1000) - 0.574) });
+            .to(bar, { filter: 'none', duration: 0.42, ease: 'power2.inOut' });
+          const base = tl.duration();
+          if (base > 0) tl.timeScale((durationMs / 1000) / base);
         } else {
           setTimeout(cleanup, durationMs);
         }
@@ -309,8 +310,9 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
         }
       }
       
-      // Добавляем паузу если анимация короче требуемой длительности
-      tl.to({}, { duration: Math.max(0, (durationMs/1000) - tl.duration()) });
+      // Подгоняем длительность без дополнительной паузы
+      const base = tl.duration();
+      if (base > 0) tl.timeScale((durationMs / 1000) / base);
       
     } catch (e) {
       console.error('Error in animateTurnManaGain:', e);


### PR DESCRIPTION
## Summary
- исправлена передача урона: магия и обычные атаки сразу синхронизируют здоровье на клиентах
- увеличена длительность баннера начала хода до 1.3с
- убрана пауза между появлением маны и добором карты

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c13db4dddc8330aea8ad4453c9a9f1