### PR TITLE
Fix HP sync and turn animations

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -154,6 +154,12 @@ try {
   window.__units = {
     updateUnits: Units.updateUnits,
   };
+  // Глобальная обёртка для обновления юнитов по текущему состоянию
+  window.updateUnits = () => {
+    try {
+      Units.updateUnits(window.gameState);
+    } catch {}
+  };
   window.__hand = {
     setHandCardHoverVisual: Hand.setHandCardHoverVisual,
     updateHand: Hand.updateHand,

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -426,7 +426,7 @@
             console.log(`[NETWORK] Animating mana for player ${owner}: ${beforeM} -> ${afterM}`);
             try {
               if (window.__ui && window.__ui.mana && typeof window.__ui.mana.animateTurnManaGain === 'function') {
-                await window.__ui.mana.animateTurnManaGain(owner, beforeM, afterM, 1500);
+                await window.__ui.mana.animateTurnManaGain(owner, beforeM, afterM);
               }
             } catch (e) {
               console.error('[NETWORK] Mana animation failed:', e);

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -57,10 +57,10 @@ export async function showTurnSplash(title) {
         .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
         .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
       tl.timeScale?.(0.75);
-      await sleep(1000);
+      await sleep(1300);
     } else {
-      // Fallback: simple 1s show
-      await sleep(1000);
+      // Fallback: simple 1.3s show
+      await sleep(1300);
     }
   } catch {}
   tb.classList.add('hidden'); tb.classList.remove('flex'); tb.style.display = 'none'; tb.style.opacity = '';

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -219,8 +219,7 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
         const tl = (typeof window !== 'undefined') ? window.gsap?.timeline?.({ onComplete: cleanup }) : null;
         if (tl) {
           tl.to(bar, { filter: 'brightness(2.1) drop-shadow(0 0 16px rgba(96,165,250,0.95))', duration: 0.154, ease: 'power2.out' })
-            .to(bar, { filter: 'none', duration: 0.42, ease: 'power2.inOut' })
-            .to({}, { duration: Math.max(0, (durationMs/1000) - 0.574) });
+            .to(bar, { filter: 'none', duration: 0.42, ease: 'power2.inOut' });
         } else {
           setTimeout(cleanup, durationMs);
         }
@@ -309,8 +308,7 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
         }
       }
       
-      // Добавляем паузу если анимация короче требуемой длительности
-      tl.to({}, { duration: Math.max(0, (durationMs/1000) - tl.duration()) });
+      // Завершаем без дополнительной паузы, чтобы сразу продолжать ход
       
     } catch (e) {
       console.error('Error in animateTurnManaGain:', e);


### PR DESCRIPTION
## Summary
- ensure unit health updates propagate via global wrapper
- lengthen turn splash to 1.3s and streamline mana-to-draw transition

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c13db4dddc8330aea8ad4453c9a9f1