### PR TITLE
Fix health sync and tune turn animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,15 +284,18 @@
     }
 
     // Build or rebuild the 3D board tiles.
-    function createBoard() {
+    function createBoard(state) {
+      // Берём актуальное состояние игры из window
+      const gs = state || window.gameState || gameState;
       try { window.__cards.preloadCardTextures(); } catch {}
       if (window.__board && window.__scene) {
-        window.__board.createBoard(gameState);
+        window.__board.createBoard(gs);
         const ctx = window.__scene.getCtx();
         tileMeshes = ctx.tileMeshes || [];
         tileFrames = ctx.tileFrames || [];
         try { window.tileMeshes = tileMeshes; window.tileFrames = tileFrames; } catch {}
       }
+      gameState = gs;
     }
     
     // Delegator: module cards implementation
@@ -314,8 +317,10 @@
     
     // ====== HAND RENDERING AND LAYOUT ======
     function updateHand() {
+      // Всегда работаем с самым свежим состоянием
+      const gs = window.gameState || gameState;
       if (window.__hand && typeof window.__hand.updateHand === 'function') {
-        window.__hand.updateHand(gameState);
+        window.__hand.updateHand(gs);
         const ctx = window.__scene && typeof window.__scene.getCtx === 'function'
           ? window.__scene.getCtx() : null;
         if (ctx && ctx.handCardMeshes) {
@@ -323,6 +328,7 @@
         }
       }
       hoveredHandCard = null;
+      gameState = gs;
     }
 
     function setHandCardHoverVisual(mesh, hovered) {
@@ -339,8 +345,10 @@
 
     // Синхронизирует 3D-модели юнитов с текущим состоянием gameState
     function updateUnits() {
+      // Синхронизируемся с актуальным состоянием из window
+      const gs = window.gameState || gameState;
       if (window.__units && typeof window.__units.updateUnits === 'function') {
-        window.__units.updateUnits(gameState);
+        window.__units.updateUnits(gs);
         const ctx = window.__scene && typeof window.__scene.getCtx === 'function'
           ? window.__scene.getCtx() : null;
         if (ctx && ctx.unitMeshes) {
@@ -348,6 +356,7 @@
           try { window.unitMeshes = unitMeshes; } catch {}
         }
       }
+      gameState = gs;
     }
 
     // Визуализировать изменения между предыдущим и новым состоянием (для наблюдателя/оппонента)

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -426,7 +426,8 @@
             console.log(`[NETWORK] Animating mana for player ${owner}: ${beforeM} -> ${afterM}`);
             try {
               if (window.__ui && window.__ui.mana && typeof window.__ui.mana.animateTurnManaGain === 'function') {
-                await window.__ui.mana.animateTurnManaGain(owner, beforeM, afterM, 1500);
+                // Не ждём завершения анимации маны, чтобы сразу начать добор
+                window.__ui.mana.animateTurnManaGain(owner, beforeM, afterM, 1500);
               }
             } catch (e) {
               console.error('[NETWORK] Mana animation failed:', e);

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -297,13 +297,14 @@ export async function endTurn() {
     } catch {}
     try {
       if (w.__ui && w.__ui.mana && typeof w.__ui.mana.animateTurnManaGain === 'function') {
-        await w.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 900);
+        // Запускаем анимацию прироста маны без ожидания
+        w.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 900);
       } else {
         console.warn('Module mana animation not available, skipping');
       }
       player.mana = manaAfter;
     } catch {}
-    // После получения маны сразу запускаем добор карты без лишней паузы
+    // Сразу после старта анимации маны переходим к добору карты
     w.updateUI?.();
     try {
       if (shouldAnimateDraw && drawnTpl) {

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -56,11 +56,12 @@ export async function showTurnSplash(title) {
         .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
         .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
         .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      tl.timeScale?.(0.75);
-      await sleep(1000);
+      // Заставка хода длится дольше
+      tl.timeScale?.(1);
+      await sleep(1300);
     } else {
-      // Fallback: simple 1s show
-      await sleep(1000);
+      // Fallback: show for 1.3s if анимация недоступна
+      await sleep(1300);
     }
   } catch {}
   tb.classList.add('hidden'); tb.classList.remove('flex'); tb.style.display = 'none'; tb.style.opacity = '';


### PR DESCRIPTION
## Summary
- sync local functions with global game state to correctly apply damage on both clients
- extend turn banner to 1.3s and start card draw immediately after mana gain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c13db4dddc8330aea8ad4453c9a9f1