### PR TITLE
fix: sync HP after attacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,7 +558,10 @@
             setTimeout(() => {
               updateUnits(); updateUI();
               for (const l of res.logLines.reverse()) addLog(l);
-              try { schedulePush('battle-finish'); } catch {}
+              try {
+                // форсируем отправку состояния после боя
+                schedulePush('battle-finish', { force: true });
+              } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -567,7 +570,7 @@
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
-              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish'); } catch {}
+              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -165,7 +165,10 @@
         })),
         board: (state.board||[]).map(row => row.map(cell => {
           const u = cell?.unit;
-          return u ? {o:u.owner,h:u.hp,a:u.atk,f:u.facing,t:u.tplId} : null;
+          // фикс: учитываем текущие HP, иначе изменения здоровья не
+          // участвуют в дайджесте и не отправляются на сервер
+          const hp = (typeof u?.currentHP === 'number') ? u.currentHP : u?.hp;
+          return u ? { o: u.owner, h: hp, a: u.atk, f: u.facing, t: u.tplId } : null;
         }))
       };
       return JSON.stringify(compact);

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -390,7 +390,10 @@ function performMagicAttack(from, targetMesh) {
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
     setTimeout(() => {
       window.updateUnits(); window.updateUI();
-      try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
+      try {
+        // принудительно отправляем снапшот, даже если идёт анимация
+        window.schedulePush && window.schedulePush('magic-battle-finish', { force: true });
+      } catch {}
       if (interactionState.autoEndTurnAfterAttack) {
         interactionState.autoEndTurnAfterAttack = false;
       try { window.endTurn && window.endTurn(); } catch {}
@@ -400,7 +403,10 @@ function performMagicAttack(from, targetMesh) {
     try { window.applyGameState(res.n1); } catch {}
     window.updateUnits(); window.updateUI();
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
-    try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
+    try {
+      // аналогично форсим отправку после мгновенной магической атаки
+      window.schedulePush && window.schedulePush('magic-battle-finish', { force: true });
+    } catch {}
     if (interactionState.autoEndTurnAfterAttack) {
       interactionState.autoEndTurnAfterAttack = false;
       try { window.endTurn && window.endTurn(); } catch {}


### PR DESCRIPTION
## Summary
- include current unit HP in multiplayer digest
- force push updated state after magic and physical battles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2235ce10c8330a91e2ab02dff8c6a