### PR TITLE
Синхронизация здоровья при нанесении урона

### DIFF
--- a/src/net/client.js
+++ b/src/net/client.js
@@ -165,7 +165,8 @@
         })),
         board: (state.board||[]).map(row => row.map(cell => {
           const u = cell?.unit;
-          return u ? {o:u.owner,h:u.hp,a:u.atk,f:u.facing,t:u.tplId} : null;
+          // включаем текущее здоровье, иначе урон не будет замечен и не синхронизируется
+          return u ? { o: u.owner, h: u.hp, ch: u.currentHP ?? u.hp, a: u.atk, f: u.facing, t: u.tplId } : null;
         }))
       };
       return JSON.stringify(compact);


### PR DESCRIPTION
## Summary
- Учитываем текущее здоровье юнитов при формировании digest для сетевого клиента
- Теперь урон от магических и физических атак синхронизируется сразу между игроками

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2235ce10c8330a91e2ab02dff8c6a