### PR TITLE
Фикс синхронизации здоровья при атаках

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,7 +558,8 @@
             setTimeout(() => {
               updateUnits(); updateUI();
               for (const l of res.logLines.reverse()) addLog(l);
-              try { schedulePush('battle-finish'); } catch {}
+              // принудительная отправка состояния после боя
+              try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -567,7 +568,8 @@
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
-              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish'); } catch {}
+              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; // синхронизируем сразу, даже если идут анимации
+              try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -646,7 +648,7 @@
       // Манасфера и кладбище для погибших от магии; обновляем состояние сразу
       if (res.deaths && res.deaths.length) {
         for (const d of res.deaths) {
-          try { gameState.players[d.owner].graveyard.push(CARDS[d.tplId]); } catch {}
+          try { res.n1.players[d.owner].graveyard.push(CARDS[d.tplId]); } catch {}
           const deadMesh = unitMeshes.find(m => m.userData.row === d.r && m.userData.col === d.c);
           if (deadMesh) { window.__fx.dissolveAndAsh(deadMesh, new THREE.Vector3(0, 0, 0.6), 0.9); }
           setTimeout(() => {
@@ -660,7 +662,8 @@
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         setTimeout(() => {
           updateUnits(); updateUI();
-          try { schedulePush('magic-battle-finish'); } catch {}
+          // аналогично форсируем синхронизацию после магической атаки
+          try { schedulePush('magic-battle-finish', { force: true }); } catch {}
           if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
             window.__interactions.interactionState.autoEndTurnAfterAttack = false;
             try { endTurn(); } catch {}
@@ -671,7 +674,8 @@
         gameState = res.n1; try { window.applyGameState(gameState); } catch {}
         updateUnits(); updateUI();
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
-        try { schedulePush('magic-battle-finish'); } catch {}
+        // отправляем обновлённое состояние без задержки
+        try { schedulePush('magic-battle-finish', { force: true }); } catch {}
         if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
           window.__interactions.interactionState.autoEndTurnAfterAttack = false;
           try { endTurn(); } catch {}

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -165,7 +165,9 @@
         })),
         board: (state.board||[]).map(row => row.map(cell => {
           const u = cell?.unit;
-          return u ? {o:u.owner,h:u.hp,a:u.atk,f:u.facing,t:u.tplId} : null;
+          // важно учитывать текущее здоровье, иначе урон не изменит digest
+          const hp = (u && typeof u.currentHP === 'number') ? u.currentHP : u?.hp;
+          return u ? { o: u.owner, h: hp, a: u.atk, f: u.facing, t: u.tplId } : null;
         }))
       };
       return JSON.stringify(compact);

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -376,12 +376,12 @@ function performMagicAttack(from, targetMesh) {
   }
   if (res.deaths && res.deaths.length) {
     for (const d of res.deaths) {
-      try { gameState.players[d.owner].graveyard.push(CARDS[d.tplId]); } catch {}
+      try { res.n1.players[d.owner].graveyard.push(CARDS[d.tplId]); } catch {}
       const deadMesh = unitMeshes.find(m => m.userData.row === d.r && m.userData.col === d.c);
       if (deadMesh) { window.__fx.dissolveAndAsh(deadMesh, new THREE.Vector3(0, 0, 0.6), 0.9); }
       setTimeout(() => {
         const p = tileMeshes[d.r][d.c].position.clone().add(new THREE.Vector3(0, 1.2, 0));
-        const slot = gameState.players?.[d.owner]?.mana || 0;
+        const slot = res.n1.players?.[d.owner]?.mana || 0;
         window.animateManaGainFromWorld(p, d.owner, true, slot);
       }, 400);
     }
@@ -390,7 +390,8 @@ function performMagicAttack(from, targetMesh) {
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
     setTimeout(() => {
       window.updateUnits(); window.updateUI();
-      try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
+      // force:true — отправляем состояние даже во время анимаций
+      try { window.schedulePush && window.schedulePush('magic-battle-finish', { force: true }); } catch {}
       if (interactionState.autoEndTurnAfterAttack) {
         interactionState.autoEndTurnAfterAttack = false;
       try { window.endTurn && window.endTurn(); } catch {}
@@ -400,7 +401,8 @@ function performMagicAttack(from, targetMesh) {
     try { window.applyGameState(res.n1); } catch {}
     window.updateUnits(); window.updateUI();
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
-    try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
+    // Немедленно синхронизируем результат магической атаки
+    try { window.schedulePush && window.schedulePush('magic-battle-finish', { force: true }); } catch {}
     if (interactionState.autoEndTurnAfterAttack) {
       interactionState.autoEndTurnAfterAttack = false;
       try { window.endTurn && window.endTurn(); } catch {}


### PR DESCRIPTION
## Summary
- Учитывать текущее здоровье юнитов в digest, чтобы урон немедленно попадал в сетевые снапшоты
- Форсировать отправку состояния после физического и магического боя, что устраняет откат здоровья
- Корректно переносить погибших юнитов в кладбище при магических атаках

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2235ce10c8330a91e2ab02dff8c6a