### PR TITLE
Fix attack HP sync and turn splash

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,7 +556,10 @@
             setTimeout(() => {
               updateUnits(); updateUI();
               for (const l of res.logLines.reverse()) addLog(l);
-              try { schedulePush('battle-finish'); } catch {}
+              try {
+                // Форсируем отправку состояния после боя
+                schedulePush('battle-finish', { force: true });
+              } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -565,7 +568,10 @@
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
-              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish'); } catch {}
+              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try {
+                // Отправляем состояние немедленно, чтобы оппонент увидел урон
+                schedulePush('battle-finish', { force: true });
+              } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -658,7 +664,10 @@
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         setTimeout(() => {
           updateUnits(); updateUI();
-          try { schedulePush('magic-battle-finish'); } catch {}
+          try {
+            // Принудительно делимся итогом магической атаки
+            schedulePush('magic-battle-finish', { force: true });
+          } catch {}
           if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
             window.__interactions.interactionState.autoEndTurnAfterAttack = false;
             try { endTurn(); } catch {}
@@ -669,7 +678,10 @@
         gameState = res.n1; try { window.gameState = gameState; } catch {}
         updateUnits(); updateUI();
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
-        try { schedulePush('magic-battle-finish'); } catch {}
+        try {
+          // Без force сервер может не получить новое здоровье целей
+          schedulePush('magic-battle-finish', { force: true });
+        } catch {}
         if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
           window.__interactions.interactionState.autoEndTurnAfterAttack = false;
           try { endTurn(); } catch {}

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -506,9 +506,12 @@
     } catch {}
     updateIndicator();
     updateInputLock();
-    // Show splash reliably; state event will drive full UI/mana sync
+    // Надёжно показываем заставку начала хода один раз
     try {
-      if (typeof forceTurnSplashWithRetry === 'function') forceTurnSplashWithRetry(2);
+      if (typeof forceTurnSplashWithRetry === 'function') {
+        const nextTurn = (gameState && typeof gameState.turn === 'number') ? gameState.turn + 1 : 1;
+        forceTurnSplashWithRetry(2, nextTurn);
+      }
     } catch {}
   });
 

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -390,7 +390,10 @@ function performMagicAttack(from, targetMesh) {
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
     setTimeout(() => {
       window.updateUnits(); window.updateUI();
-      try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
+      try {
+        // Принудительно отправляем состояние, иначе сервер может не узнать об уроне
+        window.schedulePush && window.schedulePush('magic-battle-finish', { force: true });
+      } catch {}
       if (interactionState.autoEndTurnAfterAttack) {
         interactionState.autoEndTurnAfterAttack = false;
       try { window.endTurn && window.endTurn(); } catch {}
@@ -399,7 +402,10 @@ function performMagicAttack(from, targetMesh) {
   } else {
     window.gameState = res.n1; window.updateUnits(); window.updateUI();
     const attacker = window.gameState.board[from.r][from.c]?.unit; if (attacker) attacker.lastAttackTurn = window.gameState.turn;
-    try { window.schedulePush && window.schedulePush('magic-battle-finish'); } catch {}
+    try {
+      // Без принудительной отправки урон может "откатиться" при сетевой синхронизации
+      window.schedulePush && window.schedulePush('magic-battle-finish', { force: true });
+    } catch {}
     if (interactionState.autoEndTurnAfterAttack) {
       interactionState.autoEndTurnAfterAttack = false;
       try { window.endTurn && window.endTurn(); } catch {}

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -80,6 +80,12 @@ export function queueTurnSplash(title){
 export async function requestTurnSplash(currentTurn){
   if (typeof currentTurn !== 'number') return _lastTurnSplashPromise;
 
+  // Если уже запрошена или проигрывается заставка для этого хода,
+  // не ставим ещё одну в очередь
+  if (_lastRequestedTurn === currentTurn && (_splashActive || _splashInProgress)) {
+    return _lastTurnSplashPromise;
+  }
+
   _lastRequestedTurn = currentTurn;
   let title = `Turn ${currentTurn}`;
   try {


### PR DESCRIPTION
## Summary
- force state push after battles and magic attacks so HP changes are synced
- avoid queuing duplicate turn splash displays and pass turn info to splash trigger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2256a88a8833096244d967559fc1d