### PR TITLE
Ограничение руки до 7 карт и универсальный дискард

### DIFF
--- a/src/scene/discard.js
+++ b/src/scene/discard.js
@@ -3,6 +3,23 @@ import { getCtx } from './context.js';
 import { updateHand } from './hand.js';
 
 /**
+ * Универсально применяет эффект исчезновения к переданному мешу.
+ * Можно использовать как для карт в руке, так и для существ на поле.
+ * @param {THREE.Object3D} mesh - объект, который нужно "растворить".
+ * @param {THREE.Vector3} [awayVec=new THREE.Vector3(0, 0.6, 0)] - направление вылета пепла.
+ */
+export function discardMesh(mesh, awayVec) {
+  try {
+    if (!mesh) return;
+    const ctx = getCtx();
+    const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
+    if (!THREE) return;
+    const vec = awayVec || new THREE.Vector3(0, 0.6, 0);
+    window.__fx?.dissolveAndAsh(mesh, vec, 0.9);
+  } catch {}
+}
+
+/**
  * Сбрасывает карту из руки игрока в кладбище.
  * @param {object} player - объект игрока из gameState.
  * @param {number} handIdx - индекс карты в руке.
@@ -28,10 +45,7 @@ export function discardHandCard(player, handIdx) {
     const mesh = ctx.handCardMeshes?.find(m => m.userData?.handIndex === handIdx);
     if (mesh) {
       try { mesh.userData.isInHand = false; } catch {}
-      const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
-      if (THREE) {
-        window.__fx?.dissolveAndAsh(mesh, new THREE.Vector3(0, 0.6, 0), 0.9);
-      }
+      discardMesh(mesh);
     }
   } catch {}
 
@@ -41,7 +55,7 @@ export function discardHandCard(player, handIdx) {
   return cardTpl;
 }
 
-const api = { discardHandCard };
+const api = { discardHandCard, discardMesh };
 try { if (typeof window !== 'undefined') window.__discard = api; } catch {}
 
 export default api;

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -194,7 +194,7 @@ function onMouseDown(event) {
   if (interactionState.selectedCard) {
     resetCardSelection();
   }
-  if (interactionState.pendingDiscardSelection) {
+  if (interactionState.pendingDiscardSelection && !interactionState.pendingDiscardSelection.force) {
     try { window.__ui.panels.hidePrompt(); } catch {}
     interactionState.pendingDiscardSelection = null;
     if (interactionState.draggedCard && interactionState.draggedCard.userData && interactionState.draggedCard.userData.cardData && interactionState.draggedCard.userData.cardData.type === 'SPELL') {

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -1,6 +1,7 @@
 // UI action helpers for rotating units and triggering attacks
 // These functions rely on existing globals to minimize coupling.
 import { highlightTiles, clearHighlights } from '../scene/highlight.js';
+import { enforceHandLimit } from './handLimit.js';
 
 export function rotateUnit(unitMesh, dir) {
   try {
@@ -206,6 +207,8 @@ export async function endTurn() {
       w.showNotification?.(`${gameState.players[gameState.active].name} побеждает!`, 'success');
       return;
     }
+
+    await enforceHandLimit(gameState.players[gameState.active], 7);
 
     try {
       for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {

--- a/src/ui/handLimit.js
+++ b/src/ui/handLimit.js
@@ -1,0 +1,42 @@
+// Принудительное ограничение размера руки
+import { interactionState } from '../scene/interactions.js';
+import { discardHandCard } from '../scene/discard.js';
+
+/**
+ * Заставляет игрока сбросить лишние карты, пока в руке не останется limit.
+ * Возвращает Promise, который завершается после окончания сбросов.
+ * @param {object} player - объект игрока из gameState.
+ * @param {number} [limit=7] - максимальный размер руки.
+ */
+export function enforceHandLimit(player, limit = 7) {
+  return new Promise(resolve => {
+    if (!player) { resolve(); return; }
+    const w = typeof window !== 'undefined' ? window : {};
+
+    function step() {
+      const excess = (player.hand?.length || 0) - limit;
+      if (excess <= 0) {
+        try { w.__ui?.panels?.hidePrompt(); } catch {}
+        resolve();
+        return;
+      }
+      const msg = `Выберите карту для сброса (лишних: ${excess})`;
+      try {
+        w.__ui?.panels?.showPrompt(msg, () => {
+          discardHandCard(player, 0);
+          setTimeout(step, 0);
+        });
+      } catch {}
+      interactionState.pendingDiscardSelection = {
+        force: true,
+        onPicked: idx => { discardHandCard(player, idx); setTimeout(step, 0); },
+      };
+    }
+
+    step();
+  });
+}
+
+const api = { enforceHandLimit };
+try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.handLimit = api; } } catch {}
+export default api;


### PR DESCRIPTION
## Summary
- Добавлен модуль `enforceHandLimit`, заставляющий игрока сбросить карты сверх 7 в конце хода
- Механика завершения хода вызывает ограничение и использует существующую анимацию дискарда
- Расширен модуль `discard` универсальной функцией `discardMesh`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25a7255f88330aa7c846298c4701e