### PR TITLE
Ограничение руки до 7 карт и универсальный дискард

### DIFF
--- a/src/scene/discard.js
+++ b/src/scene/discard.js
@@ -13,7 +13,7 @@ export function discardHandCard(player, handIdx) {
   const cardTpl = player.hand?.[handIdx];
   if (!cardTpl) return null;
 
-  // Перемещение карты в кладбище
+  // Перемещаем карту в кладбище
   try {
     player.graveyard = Array.isArray(player.graveyard) ? player.graveyard : [];
     player.graveyard.push(cardTpl);
@@ -28,10 +28,7 @@ export function discardHandCard(player, handIdx) {
     const mesh = ctx.handCardMeshes?.find(m => m.userData?.handIndex === handIdx);
     if (mesh) {
       try { mesh.userData.isInHand = false; } catch {}
-      const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
-      if (THREE) {
-        window.__fx?.dissolveAndAsh(mesh, new THREE.Vector3(0, 0.6, 0), 0.9);
-      }
+      dissolveMesh(mesh);
     }
   } catch {}
 
@@ -41,7 +38,23 @@ export function discardHandCard(player, handIdx) {
   return cardTpl;
 }
 
-const api = { discardHandCard };
+/**
+ * Универсальный шейдерный эффект растворения, пригодный для любых объектов.
+ * @param {THREE.Object3D} mesh - цель для эффекта.
+ * @param {THREE.Vector3} [offset] - смещение точки происхождения эффекта.
+ * @param {number} [duration] - длительность анимации.
+ */
+export function dissolveMesh(mesh, offset, duration = 0.9) {
+  try {
+    const ctx = getCtx();
+    const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
+    if (!mesh || !THREE) return;
+    const off = offset || new THREE.Vector3(0, 0.6, 0);
+    window.__fx?.dissolveAndAsh(mesh, off, duration);
+  } catch {}
+}
+
+const api = { discardHandCard, dissolveMesh };
 try { if (typeof window !== 'undefined') window.__discard = api; } catch {}
 
 export default api;

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -1,6 +1,7 @@
 // UI action helpers for rotating units and triggering attacks
 // These functions rely on existing globals to minimize coupling.
 import { highlightTiles, clearHighlights } from '../scene/highlight.js';
+import { enforceHandLimit } from './handLimit.js';
 
 export function rotateUnit(unitMesh, dir) {
   try {
@@ -150,6 +151,13 @@ export async function endTurn() {
     if (isInputLocked() || manaGainActive || drawAnimationActive || splashActive) {
       w.showNotification?.('Wait for animations to complete', 'warning');
       return;
+    }
+
+    // Принудительный сброс карт сверх лимита перед завершением хода
+    const player = gameState.players[gameState.active];
+    if (player.hand.length > 7) {
+      const ok = await enforceHandLimit(gameState, 7);
+      if (!ok || player.hand.length > 7) return;
     }
 
     w.__endTurnInProgress = true;

--- a/src/ui/handLimit.js
+++ b/src/ui/handLimit.js
@@ -1,0 +1,44 @@
+// Проверка и соблюдение лимита карт в руке
+import { discardHandCard } from '../scene/discard.js';
+import { interactionState } from '../scene/interactions.js';
+
+/**
+ * Предлагает игроку сбрасывать лишние карты до заданного лимита.
+ * @param {object} gameState - текущее состояние игры.
+ * @param {number} limit - максимально допустимое число карт.
+ * @returns {Promise<boolean>} - true, если лимит соблюдён; false при отмене.
+ */
+export async function enforceHandLimit(gameState, limit = 7) {
+  if (typeof window === 'undefined') return true;
+  const w = window;
+  const pl = gameState?.players?.[gameState.active];
+  if (!pl) return true;
+
+  while (pl.hand.length > limit) {
+    const excess = pl.hand.length - limit;
+    const msg = excess === 1
+      ? 'В руке больше 7 карт. Выберите карту для сброса.'
+      : `В руке больше 7 карт. Сбросьте ${excess} карты.`;
+    const canceled = await new Promise(resolve => {
+      w.__ui?.panels?.showPrompt(msg, () => {
+        w.__ui?.panels?.hidePrompt();
+        interactionState.pendingDiscardSelection = null;
+        resolve(true);
+      });
+      interactionState.pendingDiscardSelection = {
+        onPicked: idx => {
+          discardHandCard(pl, idx);
+          w.__ui?.panels?.hidePrompt();
+          interactionState.pendingDiscardSelection = null;
+          w.updateHand?.(gameState);
+          w.updateUI?.(gameState);
+          resolve(false);
+        },
+      };
+    });
+    if (canceled) return false;
+  }
+  return true;
+}
+
+export default { enforceHandLimit };


### PR DESCRIPTION
## Summary
- Добавлен универсальный эффект `dissolveMesh` и переработан сброс карты из руки
- Реализована проверка лимита в 7 карт перед завершением хода
- Создан модуль `handLimit` для последовательного сброса лишних карт

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c25a7255f88330aa7c846298c4701e