### PR TITLE
feat: enforce hand size limit with discard

### DIFF
--- a/src/scene/discard.js
+++ b/src/scene/discard.js
@@ -3,6 +3,23 @@ import { getCtx } from './context.js';
 import { updateHand } from './hand.js';
 
 /**
+ * Универсальная анимация "растворения" меша.
+ * Позволяет переиспользовать эффект для любых объектов.
+ * @param {object} mesh - трёхмерный объект, который нужно растворить.
+ * @param {object} [awayVec] - направление смещения пепла.
+ * @param {number} [duration] - длительность эффекта в секундах.
+ */
+export function discardMesh(mesh, awayVec, duration = 0.9) {
+  try {
+    const ctx = getCtx();
+    const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
+    if (!mesh || !THREE) return;
+    window.__fx?.dissolveAndAsh(mesh, awayVec || new THREE.Vector3(0, 0.6, 0), duration);
+    setTimeout(() => { try { mesh.parent?.remove(mesh); } catch {} }, duration * 1000 + 50);
+  } catch {}
+}
+
+/**
  * Сбрасывает карту из руки игрока в кладбище.
  * @param {object} player - объект игрока из gameState.
  * @param {number} handIdx - индекс карты в руке.
@@ -28,10 +45,7 @@ export function discardHandCard(player, handIdx) {
     const mesh = ctx.handCardMeshes?.find(m => m.userData?.handIndex === handIdx);
     if (mesh) {
       try { mesh.userData.isInHand = false; } catch {}
-      const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
-      if (THREE) {
-        window.__fx?.dissolveAndAsh(mesh, new THREE.Vector3(0, 0.6, 0), 0.9);
-      }
+      discardMesh(mesh);
     }
   } catch {}
 
@@ -41,7 +55,7 @@ export function discardHandCard(player, handIdx) {
   return cardTpl;
 }
 
-const api = { discardHandCard };
+const api = { discardHandCard, discardMesh };
 try { if (typeof window !== 'undefined') window.__discard = api; } catch {}
 
 export default api;

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -33,7 +33,7 @@ function isInputLocked() {
 
 // === POINTER INTERACTION HANDLERS ===
 function onMouseMove(event) {
-  if (isInputLocked()) return;
+  if (isInputLocked() && !interactionState.pendingDiscardSelection) return;
   const ctx = getCtx();
   const { renderer, mouse, raycaster, tileMeshes, unitMeshes, handCardMeshes } = ctx;
   if (!renderer) return;
@@ -128,7 +128,7 @@ function onMouseMove(event) {
 function onMouseDown(event) {
   const gameState = (typeof window !== 'undefined' ? window.gameState : null);
   if (!gameState || gameState.winner !== null) return;
-  if (isInputLocked()) return;
+  if (isInputLocked() && !interactionState.pendingDiscardSelection) return;
   const ctx = getCtx();
   const { renderer, mouse, raycaster, unitMeshes, handCardMeshes } = ctx;
   const rect = renderer.domElement.getBoundingClientRect();
@@ -204,7 +204,7 @@ function onMouseDown(event) {
 }
 
 function onMouseUp(event) {
-  if (isInputLocked()) { endCardDrag(); return; }
+  if (isInputLocked() && !interactionState.pendingDiscardSelection) { endCardDrag(); return; }
   const gameState = (typeof window !== 'undefined' ? window.gameState : null);
   const ctx = getCtx();
   const { renderer, mouse, raycaster, unitMeshes, tileMeshes, tileFrames } = ctx;

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -1,6 +1,7 @@
 // UI action helpers for rotating units and triggering attacks
 // These functions rely on existing globals to minimize coupling.
 import { highlightTiles, clearHighlights } from '../scene/highlight.js';
+import { enforceHandLimit } from './handLimit.js';
 
 export function rotateUnit(unitMesh, dir) {
   try {
@@ -153,6 +154,8 @@ export async function endTurn() {
     }
 
     w.__endTurnInProgress = true;
+    w.refreshInputLockUI?.();
+    await enforceHandLimit(gameState.players[gameState.active], 7);
     try { if (w.__turnTimerId) clearInterval(w.__turnTimerId); } catch {}
     w.__turnTimerSeconds = 100;
     (function syncBtn(){ try {

--- a/src/ui/handLimit.js
+++ b/src/ui/handLimit.js
@@ -1,0 +1,31 @@
+// Помощник для ограничения размера руки
+import { interactionState } from '../scene/interactions.js';
+import { discardHandCard } from '../scene/discard.js';
+
+/**
+ * Запрашивает у игрока сброс лишних карт до указанного лимита.
+ * @param {object} player - объект игрока из gameState.
+ * @param {number} [limit=7] - максимальное число карт в руке.
+ */
+export async function enforceHandLimit(player, limit = 7) {
+  if (typeof window === 'undefined' || !player) return;
+  const w = window;
+  while ((player.hand?.length || 0) > limit) {
+    const need = player.hand.length - limit;
+    w.__ui?.panels?.showPrompt?.(`Сбросьте ${need} карт(ы)`, () => {});
+    await new Promise(resolve => {
+      interactionState.pendingDiscardSelection = {
+        onPicked: handIdx => {
+          discardHandCard(player, handIdx);
+          interactionState.pendingDiscardSelection = null;
+          resolve();
+        }
+      };
+    });
+  }
+  w.__ui?.panels?.hidePrompt?.();
+}
+
+const api = { enforceHandLimit };
+try { if (typeof window !== 'undefined') window.enforceHandLimit = enforceHandLimit; } catch {}
+export default api;


### PR DESCRIPTION
## Summary
- add generic discardMesh animation helper
- prompt player to discard down to 7 cards at end of turn
- allow discards while input lock is active

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c25a7255f88330aa7c846298c4701e