### PR TITLE
Enforce mandatory hand discard

### DIFF
--- a/src/ui/handLimit.js
+++ b/src/ui/handLimit.js
@@ -12,7 +12,8 @@ export async function enforceHandLimit(player, limit = 7) {
   const w = window;
   while ((player.hand?.length || 0) > limit) {
     const need = player.hand.length - limit;
-    w.__ui?.panels?.showPrompt?.(`Сбросьте ${need} карт(ы)`, () => {});
+    // Вызываем промпт без возможности отмены
+    w.__ui?.panels?.showPrompt?.(`Сбросьте ${need} карт(ы)`, null, false);
     await new Promise(resolve => {
       interactionState.pendingDiscardSelection = {
         onPicked: handIdx => {

--- a/src/ui/panels.js
+++ b/src/ui/panels.js
@@ -45,11 +45,17 @@ export function showUnitActionPanel(unitMesh){
 }
 export function hideUnitActionPanel(){ try { document.getElementById('unit-action-panel')?.classList.add('hidden'); if (typeof window !== 'undefined') window.selectedUnit = null; } catch {} }
 
-// Minimal prompt helpers (used by spells)
-export function showPrompt(text, onCancel){
+// Минималистичные промпты (используются в разных местах UI)
+// showCancel отвечает за показ кнопки "отмена"; по умолчанию она видима
+export function showPrompt(text, onCancel, showCancel = true){
   try {
     const panel = document.getElementById('prompt-panel'); if (!panel) return;
     const t = document.getElementById('prompt-text'); if (t) t.textContent = text || '';
+    const cancelBtn = document.getElementById('cancel-prompt-btn');
+    if (cancelBtn) {
+      if (showCancel) cancelBtn.classList.remove('hidden');
+      else cancelBtn.classList.add('hidden');
+    }
     panel.classList.remove('hidden');
     if (typeof window !== 'undefined') window.activePrompt = { text, onCancel };
   } catch {}


### PR DESCRIPTION
## Summary
- hide cancel button in hand limit prompt to force discards
- allow prompting API to toggle cancel button visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c262479c188330944bef52f8980e75