### PR TITLE
fix: prevent duplicate card draws after forced discard

### DIFF
--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -237,9 +237,17 @@ export async function endTurn() {
     const player = gameState.players[gameState.active];
     const before = player.mana;
     const manaAfter = (typeof w.capMana === 'function') ? w.capMana(before + 2) : before + 2;
-    const drawnTpl = (typeof w.drawOneNoAdd === 'function')
-      ? w.drawOneNoAdd(gameState, gameState.active)
-      : null;
+
+    // Простая защита от двойного добора после форс-дискарда
+    w.__lastDrawKey = w.__lastDrawKey || null;
+    const __drawKey = `${gameState.active}:${gameState.turn}`;
+    let drawnTpl = null;
+    if (w.__lastDrawKey !== __drawKey) {
+      drawnTpl = (typeof w.drawOneNoAdd === 'function')
+        ? w.drawOneNoAdd(gameState, gameState.active)
+        : null;
+      w.__lastDrawKey = __drawKey;
+    }
 
     try {
       if (!w.PENDING_MANA_ANIM && !manaGainActive) {


### PR DESCRIPTION
## Summary
- avoid repeated draws after forced discard by tracking the last draw turn

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2693a29908330be0a94a443c97e32