### PR TITLE
Fix double card draw after forced discard

### DIFF
--- a/src/core/board.js
+++ b/src/core/board.js
@@ -69,8 +69,9 @@ export function startGame(deck0 = STARTER_FIRESET, deck1 = STARTER_FIRESET) {
   const state = {
     board: randomBoard(),
     players: [
-      { name: 'Player 1', deck: shuffle(deck0.filter(Boolean)), hand: [], discard: [], graveyard: [], mana: 2, maxMana: 10 },
-      { name: 'Player 2', deck: shuffle(deck1.filter(Boolean)), hand: [], discard: [], graveyard: [], mana: 0, maxMana: 10 },
+      // lastDrawTurn — номер хода, в который игрок последний раз получал карту в начале хода
+      { name: 'Player 1', deck: shuffle(deck0.filter(Boolean)), hand: [], discard: [], graveyard: [], mana: 2, maxMana: 10, lastDrawTurn: 0 },
+      { name: 'Player 2', deck: shuffle(deck1.filter(Boolean)), hand: [], discard: [], graveyard: [], mana: 0, maxMana: 10, lastDrawTurn: 0 },
     ],
     active: 0,
     turn: 1,

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -34,14 +34,20 @@ export function reducer(state, action) {
       s.turn += 1;
       const pl = s.players[s.active];
       const before = pl.mana || 0;
-      
+
       // ВАЖНО: Сохраняем предыдущее значение маны для правильной анимации
       pl._beforeMana = before;
       pl.mana = capMana(before + 2);
-      
-      // Optional draw: only enqueue for animation elsewhere; here push straight for logic
-      const drawn = drawOneNoAdd(s, s.active);
-      if (drawn) pl.hand.push(drawn);
+
+      // Добор карты только один раз за ход
+      const currentTurn = s.turn;
+      if (pl.lastDrawTurn !== currentTurn) {
+        const drawn = drawOneNoAdd(s, s.active);
+        if (drawn) {
+          pl.hand.push(drawn);
+          pl.lastDrawTurn = currentTurn;
+        }
+      }
       s.__ver = (s.__ver || 0) + 1;
       return s;
     }

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -237,9 +237,14 @@ export async function endTurn() {
     const player = gameState.players[gameState.active];
     const before = player.mana;
     const manaAfter = (typeof w.capMana === 'function') ? w.capMana(before + 2) : before + 2;
-    const drawnTpl = (typeof w.drawOneNoAdd === 'function')
-      ? w.drawOneNoAdd(gameState, gameState.active)
-      : null;
+    const currentTurn = gameState.turn;
+    let drawnTpl = null;
+    if (player.lastDrawTurn !== currentTurn) {
+      drawnTpl = (typeof w.drawOneNoAdd === 'function')
+        ? w.drawOneNoAdd(gameState, gameState.active)
+        : null;
+      if (drawnTpl) player.lastDrawTurn = currentTurn;
+    }
 
     try {
       if (!w.PENDING_MANA_ANIM && !manaGainActive) {


### PR DESCRIPTION
## Summary
- track lastDrawTurn for each player
- ensure only current active player draws a card once per turn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2693a29908330be0a94a443c97e32