### PR TITLE
Исправлен добор после принудительного сброса

### DIFF
--- a/src/core/board.js
+++ b/src/core/board.js
@@ -74,6 +74,7 @@ export function startGame(deck0 = STARTER_FIRESET, deck1 = STARTER_FIRESET) {
     ],
     active: 0,
     turn: 1,
+    lastDrawTurn: 1, // номер хода, для которого добор уже выполнен
     winner: null,
     __ver: 0,
     summoningUnlocked: false, // поле по умолчанию заблокировано

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -34,14 +34,17 @@ export function reducer(state, action) {
       s.turn += 1;
       const pl = s.players[s.active];
       const before = pl.mana || 0;
-      
+
       // ВАЖНО: Сохраняем предыдущее значение маны для правильной анимации
       pl._beforeMana = before;
       pl.mana = capMana(before + 2);
-      
-      // Optional draw: only enqueue for animation elsewhere; here push straight for logic
-      const drawn = drawOneNoAdd(s, s.active);
-      if (drawn) pl.hand.push(drawn);
+
+      // Добор карты выполняем только один раз за ход
+      if (s.lastDrawTurn !== s.turn) {
+        const drawn = drawOneNoAdd(s, s.active);
+        if (drawn) pl.hand.push(drawn);
+        s.lastDrawTurn = s.turn;
+      }
       s.__ver = (s.__ver || 0) + 1;
       return s;
     }

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -237,9 +237,13 @@ export async function endTurn() {
     const player = gameState.players[gameState.active];
     const before = player.mana;
     const manaAfter = (typeof w.capMana === 'function') ? w.capMana(before + 2) : before + 2;
-    const drawnTpl = (typeof w.drawOneNoAdd === 'function')
-      ? w.drawOneNoAdd(gameState, gameState.active)
-      : null;
+    let drawnTpl = null;
+    if (gameState.lastDrawTurn !== gameState.turn) {
+      drawnTpl = (typeof w.drawOneNoAdd === 'function')
+        ? w.drawOneNoAdd(gameState, gameState.active)
+        : null;
+      gameState.lastDrawTurn = gameState.turn;
+    }
 
     try {
       if (!w.PENDING_MANA_ANIM && !manaGainActive) {

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -90,6 +90,7 @@ describe('reducer', () => {
       turn: 1,
       winner: null,
       __ver: 0,
+      lastDrawTurn: 1,
     };
     const next = reducer(state, { type: A.END_TURN });
     expect(next.active).toBe(1);
@@ -99,6 +100,29 @@ describe('reducer', () => {
     expect(next.players[1].hand).toEqual(['X']);
     expect(next.players[1].deck).toEqual([]);
     expect(next.__ver).toBeGreaterThan(state.__ver);
+    expect(next.lastDrawTurn).toBe(2);
+  });
+
+  it('A.END_TURN: skips draw if already drawn this turn', () => {
+    const board = makeEmptyBoard();
+    const state = {
+      board,
+      players: [
+        { deck: ['A'], hand: [], mana: 0 },
+        { deck: ['B'], hand: [], mana: 0 }
+      ],
+      active: 0,
+      turn: 1,
+      winner: null,
+      __ver: 0,
+      lastDrawTurn: 2, // считаем, что добор для следующего хода уже произошёл
+    };
+    const next = reducer(state, { type: A.END_TURN });
+    expect(next.active).toBe(1);
+    expect(next.turn).toBe(2);
+    expect(next.players[1].hand).toEqual([]); // карты не добираются повторно
+    expect(next.players[1].deck).toEqual(['B']);
+    expect(next.lastDrawTurn).toBe(2);
   });
 
   it('A.END_TURN: declares winner if 5+ controlled by active', () => {


### PR DESCRIPTION
## Summary
- предотвратить добор карты в начале хода противника
- учесть `lastDrawTurn` в логике окончания хода
- добавить тесты на пропуск добора

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2693a29908330be0a94a443c97e32