### PR TITLE
fix discard flow and draw timing

### DIFF
--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -194,12 +194,10 @@ function onMouseDown(event) {
   if (interactionState.selectedCard) {
     resetCardSelection();
   }
+  // Если ожидается выбор карты для принудительного сброса,
+  // игнорируем клик по пустому месту и не скрываем окно
   if (interactionState.pendingDiscardSelection) {
-    try { window.__ui.panels.hidePrompt(); } catch {}
-    interactionState.pendingDiscardSelection = null;
-    if (interactionState.draggedCard && interactionState.draggedCard.userData && interactionState.draggedCard.userData.cardData && interactionState.draggedCard.userData.cardData.type === 'SPELL') {
-      returnCardToHand(interactionState.draggedCard);
-    }
+    return;
   }
 }
 

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -156,6 +156,9 @@ export async function endTurn() {
     w.__endTurnInProgress = true;
     w.refreshInputLockUI?.();
     await enforceHandLimit(gameState.players[gameState.active], 7);
+    // После возможного сброса сразу синхронизируем состояние,
+    // чтобы избежать расхождений и лишних доборов
+    w.applyGameState?.(gameState);
     try { if (w.__turnTimerId) clearInterval(w.__turnTimerId); } catch {}
     w.__turnTimerSeconds = 100;
     (function syncBtn(){ try {
@@ -319,6 +322,9 @@ export async function endTurn() {
     } catch { w.pendingDrawCount = 0; }
 
     w.addLog?.(`Ход ${gameState.turn}. ${player.name} получает +2 маны и добирает карту.`);
+
+    // Фиксируем окончательное состояние после всех изменений хода
+    w.applyGameState?.(gameState);
 
     w.__endTurnInProgress = false;
     w.manaGainActive = false;

--- a/src/ui/handLimit.js
+++ b/src/ui/handLimit.js
@@ -24,6 +24,8 @@ export async function enforceHandLimit(player, limit = 7) {
       };
     });
   }
+  // На всякий случай очищаем состояние выбора и скрываем окно
+  interactionState.pendingDiscardSelection = null;
   w.__ui?.panels?.hidePrompt?.();
 }
 


### PR DESCRIPTION
## Summary
- prevent closing discard popup via empty-click to ensure required cards are discarded
- reapply state after enforced discard and turn end so only the active player draws
- clear pending discard selection when hand limit enforcement finishes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c294263cd88330a6fb6c7b59d8c809