### PR TITLE
fix: prevent extra draws after forced discard

### DIFF
--- a/src/core/board.js
+++ b/src/core/board.js
@@ -69,8 +69,26 @@ export function startGame(deck0 = STARTER_FIRESET, deck1 = STARTER_FIRESET) {
   const state = {
     board: randomBoard(),
     players: [
-      { name: 'Player 1', deck: shuffle(deck0.filter(Boolean)), hand: [], discard: [], graveyard: [], mana: 2, maxMana: 10 },
-      { name: 'Player 2', deck: shuffle(deck1.filter(Boolean)), hand: [], discard: [], graveyard: [], mana: 0, maxMana: 10 },
+      {
+        name: 'Player 1',
+        deck: shuffle(deck0.filter(Boolean)),
+        hand: [],
+        discard: [],
+        graveyard: [],
+        mana: 2,
+        maxMana: 10,
+        lastDrawTurn: 0,
+      },
+      {
+        name: 'Player 2',
+        deck: shuffle(deck1.filter(Boolean)),
+        hand: [],
+        discard: [],
+        graveyard: [],
+        mana: 0,
+        maxMana: 10,
+        lastDrawTurn: 0,
+      },
     ],
     active: 0,
     turn: 1,

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -191,15 +191,12 @@ function onMouseDown(event) {
     return;
   }
 
+  // Если ждём сброса карт, клики вне руки игнорируются
+  if (interactionState.pendingDiscardSelection) {
+    return;
+  }
   if (interactionState.selectedCard) {
     resetCardSelection();
-  }
-  if (interactionState.pendingDiscardSelection) {
-    try { window.__ui.panels.hidePrompt(); } catch {}
-    interactionState.pendingDiscardSelection = null;
-    if (interactionState.draggedCard && interactionState.draggedCard.userData && interactionState.draggedCard.userData.cardData && interactionState.draggedCard.userData.cardData.type === 'SPELL') {
-      returnCardToHand(interactionState.draggedCard);
-    }
   }
 }
 

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -237,9 +237,15 @@ export async function endTurn() {
     const player = gameState.players[gameState.active];
     const before = player.mana;
     const manaAfter = (typeof w.capMana === 'function') ? w.capMana(before + 2) : before + 2;
-    const drawnTpl = (typeof w.drawOneNoAdd === 'function')
-      ? w.drawOneNoAdd(gameState, gameState.active)
-      : null;
+
+    // Добор карты выполняем один раз за ход
+    let drawnTpl = null;
+    if (player.lastDrawTurn !== gameState.turn) {
+      drawnTpl = (typeof w.drawOneNoAdd === 'function')
+        ? w.drawOneNoAdd(gameState, gameState.active)
+        : null;
+      try { player.lastDrawTurn = gameState.turn; } catch {}
+    }
 
     try {
       if (!w.PENDING_MANA_ANIM && !manaGainActive) {


### PR DESCRIPTION
## Summary
- ensure players draw only once at start of their own turn using `lastDrawTurn`
- ignore outside clicks while discarding to keep discard prompt visible
- track draw turn in game state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c294263cd88330a6fb6c7b59d8c809