### PR TITLE
fix: correct draw logic after forced discard

### DIFF
--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -195,11 +195,8 @@ function onMouseDown(event) {
     resetCardSelection();
   }
   if (interactionState.pendingDiscardSelection) {
-    try { window.__ui.panels.hidePrompt(); } catch {}
-    interactionState.pendingDiscardSelection = null;
-    if (interactionState.draggedCard && interactionState.draggedCard.userData && interactionState.draggedCard.userData.cardData && interactionState.draggedCard.userData.cardData.type === 'SPELL') {
-      returnCardToHand(interactionState.draggedCard);
-    }
+    // Если требуется сброс карт, клики вне руки не должны закрывать окно сброса
+    return;
   }
 }
 

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -153,6 +153,9 @@ export async function endTurn() {
       return;
     }
 
+    // Сбрасываем возможный авто-завершитель хода, чтобы избежать повторного добора карт
+    try { w.__interactions?.interactionState && (w.__interactions.interactionState.autoEndTurnAfterAttack = false); } catch {}
+
     w.__endTurnInProgress = true;
     w.refreshInputLockUI?.();
     await enforceHandLimit(gameState.players[gameState.active], 7);


### PR DESCRIPTION
## Summary
- prevent automatic turn ending from previous attack when ending turn
- block closing discard prompt by outside clicks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c294263cd88330a6fb6c7b59d8c809