### PR TITLE
Fix discard dialog persistence and draw after hand limit

### DIFF
--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -194,10 +194,15 @@ function onMouseDown(event) {
   if (interactionState.selectedCard) {
     resetCardSelection();
   }
-  if (interactionState.pendingDiscardSelection) {
+  if (interactionState.pendingDiscardSelection && !interactionState.pendingDiscardSelection.forced) {
     try { window.__ui.panels.hidePrompt(); } catch {}
     interactionState.pendingDiscardSelection = null;
-    if (interactionState.draggedCard && interactionState.draggedCard.userData && interactionState.draggedCard.userData.cardData && interactionState.draggedCard.userData.cardData.type === 'SPELL') {
+    if (
+      interactionState.draggedCard &&
+      interactionState.draggedCard.userData &&
+      interactionState.draggedCard.userData.cardData &&
+      interactionState.draggedCard.userData.cardData.type === 'SPELL'
+    ) {
       returnCardToHand(interactionState.draggedCard);
     }
   }

--- a/src/ui/handLimit.js
+++ b/src/ui/handLimit.js
@@ -16,8 +16,12 @@ export async function enforceHandLimit(player, limit = 7) {
     w.__ui?.panels?.showPrompt?.(`Сбросьте ${need} карт(ы)`, null, false);
     await new Promise(resolve => {
       interactionState.pendingDiscardSelection = {
+        forced: true,
         onPicked: handIdx => {
+          // локально сбрасываем карту
           discardHandCard(player, handIdx);
+          // сообщаем серверу об изменении руки сразу, чтобы избежать рассинхронизации
+          try { w.schedulePush?.('hand-limit-discard', { force: true }); } catch {}
           interactionState.pendingDiscardSelection = null;
           resolve();
         }


### PR DESCRIPTION
## Summary
- stop drawing cards on opponent's turns after forced discard
- prevent closing discard prompt by clicking outside
- sync forced discard state with server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c294263cd88330a6fb6c7b59d8c809