### PR TITLE
feat: add deck selection menu

### DIFF
--- a/src/core/decks.js
+++ b/src/core/decks.js
@@ -1,0 +1,27 @@
+import { STARTER_FIRESET } from './cards.js';
+
+// Описание доступных колод. Каждая колода содержит имя,
+// краткое описание и массив карт. Новые колоды можно
+// добавить простым расширением этого списка.
+export const DECKS = [
+  {
+    id: 'starter_fire',
+    name: 'Огненное пробуждение',
+    desc: 'Базовая колода огненных существ и нейтральных заклинаний.',
+    cards: STARTER_FIRESET,
+  },
+  {
+    id: 'placeholder_2',
+    name: 'Туманная загадка',
+    desc: 'Заглушка: скоро здесь появится новая колода.',
+    cards: STARTER_FIRESET,
+  },
+  {
+    id: 'placeholder_3',
+    name: 'Ледяной мираж',
+    desc: 'Заглушка: колода в разработке.',
+    cards: STARTER_FIRESET,
+  },
+];
+
+export default DECKS;

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 ﻿// Bridge file to expose core modules to existing global code progressively
 import * as Constants from './core/constants.js';
-import { CARDS, STARTER_FIRESET } from './core/cards.js';
+import { CARDS, STARTER_FIRESET as BASE_STARTER_FIRESET } from './core/cards.js';
+import { DECKS } from './core/decks.js';
 import * as Rules from './core/rules.js';
 import { reducer, A, startGame, drawOne, drawOneNoAdd, shuffle, countControlled, countUnits } from './core/state.js';
 import { netState, NET_ON } from './core/netState.js';
@@ -36,6 +37,14 @@ import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
 import * as CancelButton from './ui/cancelButton.js';
 
+// Определяем активную колоду ещё до экспонирования
+let deckIndex = 0;
+try {
+  const stored = localStorage.getItem('selectedDeck');
+  if (stored) deckIndex = parseInt(stored, 10) || 0;
+} catch {}
+const SELECTED_DECK = DECKS[deckIndex]?.cards || BASE_STARTER_FIRESET;
+
 // Expose to window to keep compatibility while refactoring incrementally
 try {
   window.DIR_VECTORS = Constants.DIR_VECTORS;
@@ -50,7 +59,8 @@ try {
   window.attackCost = Constants.attackCost;
 
   window.CARDS = CARDS;
-  window.STARTER_FIRESET = STARTER_FIRESET;
+  window.DECKS = DECKS;
+  window.STARTER_FIRESET = SELECTED_DECK;
 
   window.hasAdjacentGuard = Rules.hasAdjacentGuard;
   window.computeCellBuff = Rules.computeCellBuff;
@@ -116,7 +126,7 @@ try { window.__store = store; } catch {}
 
 // Initialize only if no existing gameState is present (non-destructive)
 if (typeof window !== 'undefined' && !window.gameState) {
-  const s = startGame(STARTER_FIRESET, STARTER_FIRESET);
+  const s = startGame(SELECTED_DECK, SELECTED_DECK);
   try { applyGameState(s); } catch {}
 }
 

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -1,6 +1,8 @@
   /* MODULE: network/multiplayer
      Purpose: handle server connection, matchmaking, state sync,
      countdowns, and input locking. */
+import { selectDeck } from '../ui/deckMenu.js';
+
 (() => {
   // ===== 0) Config =====
   const SERVER_URL = (location.hostname === "localhost")
@@ -47,7 +49,13 @@
       })();
       wrap.appendChild(btn);
     }
-    btn.addEventListener('click', onFindMatchClick);
+    btn.addEventListener('click', async () => {
+      const res = await selectDeck();
+      if (!res) return;
+      try { localStorage.setItem('selectedDeck', String(res.index)); } catch {}
+      try { window.STARTER_FIRESET = res.deck.cards; } catch {}
+      onFindMatchClick();
+    });
   }
   mountOnlineButton();
   const mo = new MutationObserver(() => mountOnlineButton());

--- a/src/ui/deckMenu.js
+++ b/src/ui/deckMenu.js
@@ -1,0 +1,101 @@
+import { DECKS } from '../core/decks.js';
+
+// Промпт выбора колоды. Возвращает промис с объектом
+// выбранной колоды { index, deck }, либо null при отмене.
+export function selectDeck() {
+  return new Promise(resolve => {
+    // Создаём затемнённый фон
+    const overlay = document.createElement('div');
+    overlay.className = 'fixed inset-0 bg-black/50 flex items-center justify-center z-50';
+
+    // Каркас окна
+    const panel = document.createElement('div');
+    panel.className = 'overlay-panel p-6 w-96 max-h-[80vh] flex flex-col';
+    overlay.appendChild(panel);
+
+    const title = document.createElement('h3');
+    title.className = 'text-xl font-semibold mb-4 text-center';
+    title.textContent = 'Выберите колоду';
+    panel.appendChild(title);
+
+    // Список колод
+    const list = document.createElement('div');
+    list.className = 'flex-1 overflow-y-auto space-y-3 mb-4';
+    panel.appendChild(list);
+
+    // Текущий выбор
+    let current = 0;
+
+    DECKS.forEach((d, i) => {
+      const item = document.createElement('div');
+      item.className = 'flex gap-4 p-2 rounded cursor-pointer bg-slate-800 hover:bg-slate-700';
+      item.dataset.index = String(i);
+
+      // Иллюстрация: карта с максимальной стоимостью
+      const imgWrap = document.createElement('div');
+      imgWrap.className = 'relative w-24 h-16 flex-shrink-0 rounded overflow-hidden';
+      const maxCost = Math.max(...d.cards.map(c => c.cost || 0));
+      const candidates = d.cards.filter(c => (c.cost || 0) === maxCost);
+      const card = candidates[Math.floor(Math.random() * candidates.length)] || {};
+      const img = document.createElement('img');
+      img.src = `card images/${card.id || ''}.png`;
+      img.className = 'w-full h-full object-cover';
+      imgWrap.appendChild(img);
+      // Градиент для плавного перехода
+      const fade = document.createElement('div');
+      fade.className = 'absolute inset-0 bg-gradient-to-r from-transparent to-slate-800';
+      imgWrap.appendChild(fade);
+      item.appendChild(imgWrap);
+
+      const info = document.createElement('div');
+      info.className = 'flex-1';
+      const name = document.createElement('div');
+      name.className = 'font-semibold';
+      name.textContent = d.name;
+      const desc = document.createElement('div');
+      desc.className = 'text-xs text-slate-300';
+      desc.textContent = d.desc;
+      info.appendChild(name);
+      info.appendChild(desc);
+      item.appendChild(info);
+
+      item.addEventListener('click', () => {
+        current = i;
+        // Подсветка выбора
+        [...list.children].forEach(el => el.classList.remove('ring-2', 'ring-yellow-500'));
+        item.classList.add('ring-2', 'ring-yellow-500');
+      });
+
+      if (i === current) item.classList.add('ring-2', 'ring-yellow-500');
+      list.appendChild(item);
+    });
+
+    // Кнопки подтверждения
+    const btnRow = document.createElement('div');
+    btnRow.className = 'flex justify-end gap-2';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'overlay-panel px-4 py-2 bg-gray-600 hover:bg-gray-700';
+    cancelBtn.textContent = 'Отмена';
+    cancelBtn.addEventListener('click', () => {
+      overlay.remove();
+      resolve(null);
+    });
+
+    const okBtn = document.createElement('button');
+    okBtn.className = 'overlay-panel px-4 py-2 bg-green-600 hover:bg-green-700';
+    okBtn.textContent = 'Выбрать';
+    okBtn.addEventListener('click', () => {
+      overlay.remove();
+      resolve({ index: current, deck: DECKS[current] });
+    });
+
+    btnRow.appendChild(cancelBtn);
+    btnRow.appendChild(okBtn);
+    panel.appendChild(btnRow);
+
+    document.body.appendChild(overlay);
+  });
+}
+
+export default { selectDeck };

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -1,6 +1,7 @@
 // Навешивание обработчиков UI элементов
 
 import { refreshInputLockUI } from './inputLock.js';
+import { selectDeck } from './deckMenu.js';
 
 export function attachUIEvents() {
   if (typeof document === 'undefined') return;
@@ -11,7 +12,12 @@ export function attachUIEvents() {
   });
   refreshInputLockUI();
 
-  document.getElementById('new-game-btn')?.addEventListener('click', () => location.reload());
+  document.getElementById('new-game-btn')?.addEventListener('click', async () => {
+    const res = await selectDeck();
+    if (!res) return;
+    try { localStorage.setItem('selectedDeck', String(res.index)); } catch {}
+    location.reload();
+  });
 
   document.getElementById('log-btn')?.addEventListener('click', () => {
     const lp = document.getElementById('log-panel');


### PR DESCRIPTION
## Summary
- implement deck definitions and expose them via global state
- add deck selection modal with preview, gradient fade and confirm/cancel
- hook deck selection before starting online or offline game

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b41f98e48330916c2168859908c2