### PR TITLE
feat: add deck selection menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,18 @@
         // Взаимодействия с 3D-сценой вынесены в модуль src/scene/interactions.js
     
     async function initGame() {
-      gameState = startGame(STARTER_FIRESET, STARTER_FIRESET);
+      const decks = window.DECKS || [];
+      let chosen = window.__selectedDeckObj;
+      if (!chosen) {
+        try {
+          const id = localStorage.getItem('selectedDeckId');
+          chosen = decks.find(d => d.id === id) || decks[0];
+        } catch {
+          chosen = decks[0];
+        }
+      }
+      const d = chosen ? chosen.cards : STARTER_FIRESET;
+      gameState = startGame(d, d);
       try { window.applyGameState(gameState); } catch {}
       
       // Сразу строим сцену и мета-объекты, без задержки появления

--- a/src/core/decks.js
+++ b/src/core/decks.js
@@ -1,0 +1,29 @@
+// Определение доступных колод
+// Каждая колода включает id, имя, описание и список карт
+
+import { STARTER_FIRESET } from './cards.js';
+
+export const DECKS = [
+  {
+    id: 'FIRE_STARTER',
+    name: 'Огненное пробуждение',
+    description: 'Базовый набор огненных заклинаний и существ.',
+    cards: STARTER_FIRESET,
+  },
+  {
+    id: 'PLACEHOLDER_2',
+    name: 'Заготовка 2',
+    description: 'В разработке — скоро здесь появится колода.',
+    cards: STARTER_FIRESET,
+  },
+  {
+    id: 'PLACEHOLDER_3',
+    name: 'Заготовка 3',
+    description: 'Ещё одна будущая колода.',
+    cards: STARTER_FIRESET,
+  },
+];
+
+const api = { DECKS };
+try { if (typeof window !== 'undefined') { window.DECKS = DECKS; } } catch {}
+export default api;

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 ﻿// Bridge file to expose core modules to existing global code progressively
 import * as Constants from './core/constants.js';
 import { CARDS, STARTER_FIRESET } from './core/cards.js';
+import { DECKS } from './core/decks.js';
 import * as Rules from './core/rules.js';
 import { reducer, A, startGame, drawOne, drawOneNoAdd, shuffle, countControlled, countUnits } from './core/state.js';
 import { netState, NET_ON } from './core/netState.js';
@@ -31,6 +32,7 @@ import './ui/statusChip.js';
 import * as InputLock from './ui/inputLock.js';
 import { attachUIEvents } from './ui/domEvents.js';
 import * as BattleSplash from './ui/battleSplash.js';
+import * as DeckSelect from './ui/deckSelect.js';
 import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
@@ -51,6 +53,7 @@ try {
 
   window.CARDS = CARDS;
   window.STARTER_FIRESET = STARTER_FIRESET;
+  window.DECKS = DECKS;
 
   window.hasAdjacentGuard = Rules.hasAdjacentGuard;
   window.computeCellBuff = Rules.computeCellBuff;
@@ -177,6 +180,7 @@ try {
   window.__ui.inputLock = InputLock;
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
+  window.__ui.deckSelect = DeckSelect;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -47,7 +47,18 @@
       })();
       wrap.appendChild(btn);
     }
-    btn.addEventListener('click', onFindMatchClick);
+    btn.addEventListener('click', () => {
+      const ds = window.__ui?.deckSelect;
+      if (ds && typeof ds.open === 'function') {
+        ds.open(deck => {
+          try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+          window.__selectedDeckObj = deck;
+          onFindMatchClick();
+        });
+      } else {
+        onFindMatchClick();
+      }
+    });
   }
   mountOnlineButton();
   const mo = new MutationObserver(() => mountOnlineButton());

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -1,0 +1,94 @@
+// Меню выбора колоды
+import { DECKS } from '../core/decks.js';
+
+function pickDeckImage(deck) {
+  // выбираем самую дорогую по мане карту; при равенстве — случайная
+  const costs = deck.cards.map(c => c.cost || 0);
+  const max = Math.max(...costs);
+  const candidates = deck.cards.filter(c => (c.cost || 0) === max);
+  const card = candidates[Math.floor(Math.random() * candidates.length)];
+  return `card images/${card.id}.png`;
+}
+
+export function open(onConfirm, onCancel) {
+  if (typeof document === 'undefined') return;
+  let selected = 0;
+  const overlay = document.createElement('div');
+  overlay.id = 'deck-select-overlay';
+  overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60';
+
+  const panel = document.createElement('div');
+  panel.className = 'bg-slate-800 p-4 rounded-lg w-80 max-h-[90vh] flex flex-col';
+  overlay.appendChild(panel);
+
+  const title = document.createElement('div');
+  title.className = 'text-lg font-semibold mb-3';
+  title.textContent = 'Выберите колоду';
+  panel.appendChild(title);
+
+  const list = document.createElement('div');
+  list.className = 'flex-1 overflow-y-auto space-y-3 pr-1';
+  panel.appendChild(list);
+
+  DECKS.forEach((d, idx) => {
+    const item = document.createElement('div');
+    item.className = 'relative flex h-24 cursor-pointer rounded-md border border-slate-700 overflow-hidden';
+    if (idx === selected) item.classList.add('ring-2', 'ring-yellow-500');
+
+    const imgWrap = document.createElement('div');
+    imgWrap.className = 'relative w-32 h-full flex-shrink-0 overflow-hidden';
+    const img = document.createElement('img');
+    img.src = pickDeckImage(d);
+    img.className = 'w-full h-full object-cover';
+    imgWrap.appendChild(img);
+    const fade = document.createElement('div');
+    fade.className = 'absolute inset-0 bg-gradient-to-r from-transparent to-slate-800';
+    imgWrap.appendChild(fade);
+    item.appendChild(imgWrap);
+
+    const text = document.createElement('div');
+    text.className = 'pl-4 pr-2 flex flex-col justify-center';
+    const nm = document.createElement('div');
+    nm.className = 'font-semibold';
+    nm.textContent = d.name;
+    const ds = document.createElement('div');
+    ds.className = 'text-sm text-slate-300';
+    ds.textContent = d.description;
+    text.appendChild(nm); text.appendChild(ds);
+    item.appendChild(text);
+
+    item.addEventListener('click', () => {
+      selected = idx;
+      [...list.children].forEach((el, i) => {
+        el.classList.toggle('ring-2', i === selected);
+        el.classList.toggle('ring-yellow-500', i === selected);
+      });
+    });
+    list.appendChild(item);
+  });
+
+  const btnWrap = document.createElement('div');
+  btnWrap.className = 'flex justify-end gap-2 mt-4';
+  panel.appendChild(btnWrap);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700';
+  cancelBtn.textContent = 'Отмена';
+  cancelBtn.addEventListener('click', () => { document.body.removeChild(overlay); onCancel && onCancel(); });
+  btnWrap.appendChild(cancelBtn);
+
+  const okBtn = document.createElement('button');
+  okBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700';
+  okBtn.textContent = 'Подтвердить';
+  okBtn.addEventListener('click', () => {
+    try { document.body.removeChild(overlay); } catch {}
+    onConfirm && onConfirm(DECKS[selected]);
+  });
+  btnWrap.appendChild(okBtn);
+
+  document.body.appendChild(overlay);
+}
+
+const api = { open };
+try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.deckSelect = api; } } catch {}
+export default api;

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -11,7 +11,18 @@ export function attachUIEvents() {
   });
   refreshInputLockUI();
 
-  document.getElementById('new-game-btn')?.addEventListener('click', () => location.reload());
+  document.getElementById('new-game-btn')?.addEventListener('click', () => {
+    const ds = w.__ui?.deckSelect;
+    if (ds && typeof ds.open === 'function') {
+      ds.open(deck => {
+        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+        w.__selectedDeckObj = deck;
+        location.reload();
+      });
+    } else {
+      location.reload();
+    }
+  });
 
   document.getElementById('log-btn')?.addEventListener('click', () => {
     const lp = document.getElementById('log-panel');


### PR DESCRIPTION
## Summary
- add dynamic deck registry and deck selection UI
- hook offline and online start buttons to choose deck
- allow initGame to use selected deck

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2b41f98e48330916c2168859908c2