### PR TITLE
feat: add deck selection menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,18 @@
         // Взаимодействия с 3D-сценой вынесены в модуль src/scene/interactions.js
     
     async function initGame() {
-      gameState = startGame(STARTER_FIRESET, STARTER_FIRESET);
+      const decks = window.DECKS || [];
+      let chosen = window.__selectedDeckObj;
+      if (!chosen) {
+        try {
+          const id = localStorage.getItem('selectedDeckId');
+          chosen = decks.find(d => d.id === id) || decks[0];
+        } catch {
+          chosen = decks[0];
+        }
+      }
+      const d = chosen ? chosen.cards : STARTER_FIRESET;
+      gameState = startGame(d, d);
       try { window.applyGameState(gameState); } catch {}
       
       // Сразу строим сцену и мета-объекты, без задержки появления

--- a/src/core/decks.js
+++ b/src/core/decks.js
@@ -1,0 +1,54 @@
+// Определение доступных колод
+// Каждая колода включает id, имя, описание и список карт
+
+import { CARDS, STARTER_FIRESET } from './cards.js';
+
+// Колода, состоящая только из существ — без заклинаний
+const CREATURE_ONLY = [
+  CARDS.FIRE_FLAME_MAGUS,
+  CARDS.FIRE_HELLFIRE_SPITTER,
+  CARDS.FIRE_FREEDONIAN,
+  CARDS.FIRE_FLAME_LIZARD,
+  CARDS.FIRE_GREAT_MINOS,
+  CARDS.FIRE_FLAME_ASCETIC,
+  CARDS.FIRE_TRICEPTAUR,
+  CARDS.FIRE_PURSUER,
+  CARDS.FIRE_FLAME_MAGUS,
+  CARDS.FIRE_HELLFIRE_SPITTER,
+  CARDS.FIRE_FLAME_LIZARD,
+  CARDS.FIRE_FREEDONIAN,
+].filter(Boolean);
+
+// Экспериментальная колода — пока использует стартовый набор
+const ARCANE_MIX = STARTER_FIRESET.slice();
+
+export const DECKS = [
+  {
+    id: 'FIRE_STARTER',
+    name: 'Fire Awakening',
+    description: 'Baseline set of fiery spells and units.',
+    cards: STARTER_FIRESET,
+  },
+  {
+    id: 'ARCANE_MIX',
+    name: 'Arcane Arsenal',
+    description: 'Balanced mix of creatures and tricks.',
+    cards: ARCANE_MIX,
+  },
+  {
+    id: 'BEAST_HORDE',
+    name: 'Beast Horde',
+    description: 'All creature rush with no spells.',
+    cards: CREATURE_ONLY,
+  },
+  {
+    id: 'COMING_SOON',
+    name: 'Coming Soon',
+    description: 'Another deck is on the way.',
+    cards: STARTER_FIRESET,
+  },
+];
+
+const api = { DECKS };
+try { if (typeof window !== 'undefined') { window.DECKS = DECKS; } } catch {}
+export default api;

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 ﻿// Bridge file to expose core modules to existing global code progressively
 import * as Constants from './core/constants.js';
 import { CARDS, STARTER_FIRESET } from './core/cards.js';
+import { DECKS } from './core/decks.js';
 import * as Rules from './core/rules.js';
 import { reducer, A, startGame, drawOne, drawOneNoAdd, shuffle, countControlled, countUnits } from './core/state.js';
 import { netState, NET_ON } from './core/netState.js';
@@ -31,6 +32,7 @@ import './ui/statusChip.js';
 import * as InputLock from './ui/inputLock.js';
 import { attachUIEvents } from './ui/domEvents.js';
 import * as BattleSplash from './ui/battleSplash.js';
+import * as DeckSelect from './ui/deckSelect.js';
 import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
@@ -51,6 +53,7 @@ try {
 
   window.CARDS = CARDS;
   window.STARTER_FIRESET = STARTER_FIRESET;
+  window.DECKS = DECKS;
 
   window.hasAdjacentGuard = Rules.hasAdjacentGuard;
   window.computeCellBuff = Rules.computeCellBuff;
@@ -177,6 +180,7 @@ try {
   window.__ui.inputLock = InputLock;
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
+  window.__ui.deckSelect = DeckSelect;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -47,7 +47,18 @@
       })();
       wrap.appendChild(btn);
     }
-    btn.addEventListener('click', onFindMatchClick);
+    btn.addEventListener('click', () => {
+      const ds = window.__ui?.deckSelect;
+      if (ds && typeof ds.open === 'function') {
+        ds.open(deck => {
+          try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+          window.__selectedDeckObj = deck;
+          onFindMatchClick();
+        });
+      } else {
+        onFindMatchClick();
+      }
+    });
   }
   mountOnlineButton();
   const mo = new MutationObserver(() => mountOnlineButton());

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -1,0 +1,96 @@
+// Меню выбора колоды
+import { DECKS } from '../core/decks.js';
+
+function pickDeckImage(deck) {
+  // выбираем самую дорогую по мане карту; при равенстве — случайная
+  const costs = deck.cards.map(c => c.cost || 0);
+  const max = Math.max(...costs);
+  const candidates = deck.cards.filter(c => (c.cost || 0) === max);
+  const card = candidates[Math.floor(Math.random() * candidates.length)];
+  return `card images/${card.id}.png`;
+}
+
+export function open(onConfirm, onCancel) {
+  if (typeof document === 'undefined') return;
+  let selected = 0;
+  const overlay = document.createElement('div');
+  overlay.id = 'deck-select-overlay';
+  overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60';
+
+  const panel = document.createElement('div');
+  // делаем панель шире примерно на 30%
+  panel.className = 'bg-slate-800 p-4 rounded-lg w-[26rem] max-h-[90vh] flex flex-col shadow-2xl';
+  overlay.appendChild(panel);
+
+  const title = document.createElement('div');
+  title.className = 'text-lg font-semibold mb-3';
+  title.textContent = 'Choose a deck';
+  panel.appendChild(title);
+
+  const list = document.createElement('div');
+  // ограничиваем высоту списка, чтобы появился скролл при избытке колод
+  list.className = 'flex-1 overflow-y-auto space-y-3 pr-2 max-h-64';
+  panel.appendChild(list);
+
+  DECKS.forEach((d, idx) => {
+    const item = document.createElement('div');
+    item.className = 'relative flex h-24 cursor-pointer rounded-md overflow-hidden border-2 border-slate-700 transition transform hover:bg-slate-700/30 hover:scale-[1.02]';
+    if (idx === selected) item.classList.add('border-yellow-400');
+
+    const imgWrap = document.createElement('div');
+    imgWrap.className = 'relative w-40 h-full flex-shrink-0 overflow-hidden';
+    const img = document.createElement('img');
+    img.src = pickDeckImage(d);
+    img.className = 'w-full h-full object-cover';
+    imgWrap.appendChild(img);
+    const fade = document.createElement('div');
+    fade.className = 'absolute inset-0 bg-gradient-to-r from-transparent to-slate-800';
+    imgWrap.appendChild(fade);
+    item.appendChild(imgWrap);
+
+    const text = document.createElement('div');
+    text.className = 'pl-4 pr-2 flex flex-col justify-center';
+    const nm = document.createElement('div');
+    nm.className = 'font-semibold';
+    nm.textContent = d.name;
+    const ds = document.createElement('div');
+    ds.className = 'text-sm text-slate-300';
+    ds.textContent = d.description;
+    text.appendChild(nm); text.appendChild(ds);
+    item.appendChild(text);
+
+    item.addEventListener('click', () => {
+      selected = idx;
+      [...list.children].forEach((el, i) => {
+        el.classList.toggle('border-yellow-400', i === selected);
+        el.classList.toggle('border-slate-700', i !== selected);
+      });
+    });
+    list.appendChild(item);
+  });
+
+  const btnWrap = document.createElement('div');
+  btnWrap.className = 'flex justify-end gap-2 mt-4';
+  panel.appendChild(btnWrap);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => { document.body.removeChild(overlay); onCancel && onCancel(); });
+  btnWrap.appendChild(cancelBtn);
+
+  const okBtn = document.createElement('button');
+  okBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
+  okBtn.textContent = 'Confirm';
+  okBtn.addEventListener('click', () => {
+    try { document.body.removeChild(overlay); } catch {}
+    onConfirm && onConfirm(DECKS[selected]);
+  });
+  btnWrap.appendChild(okBtn);
+
+  document.body.appendChild(overlay);
+}
+
+const api = { open };
+try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.deckSelect = api; } } catch {}
+export default api;

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -11,7 +11,18 @@ export function attachUIEvents() {
   });
   refreshInputLockUI();
 
-  document.getElementById('new-game-btn')?.addEventListener('click', () => location.reload());
+  document.getElementById('new-game-btn')?.addEventListener('click', () => {
+    const ds = w.__ui?.deckSelect;
+    if (ds && typeof ds.open === 'function') {
+      ds.open(deck => {
+        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+        w.__selectedDeckObj = deck;
+        location.reload();
+      });
+    } else {
+      location.reload();
+    }
+  });
 
   document.getElementById('log-btn')?.addEventListener('click', () => {
     const lp = document.getElementById('log-panel');

--- a/styles/main.css
+++ b/styles/main.css
@@ -62,6 +62,18 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 
 /* Панели */
 .overlay-panel { background: rgba(30, 41, 59, 0.95); backdrop-filter: blur(10px); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 16px; }
+/* Глянцевая кнопка с переливом при наведении */
+.glossy-btn { position: relative; overflow: hidden; }
+.glossy-btn::after {
+  content: '';
+  position: absolute;
+  top: 0; left: -150%;
+  width: 100%; height: 100%;
+  background: linear-gradient(120deg, rgba(255,255,255,0.0) 0%, rgba(255,255,255,0.4) 50%, rgba(255,255,255,0.0) 100%);
+  transform: skewX(-20deg);
+  transition: left .5s;
+}
+.glossy-btn:hover::after { left: 150%; }
 /* Prompt: кликабельна только панель, остальное кликается сквозь */
 #prompt-panel { pointer-events: none; }
 #prompt-panel .overlay-panel { pointer-events: auto; }


### PR DESCRIPTION
## Summary
- flesh out deck registry with real decks and an extra placeholder
- widen deck selection panel, add scroll, fix border, glossy hover buttons
- style gloss effect for overlay buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b41f98e48330916c2168859908c2