### PR TITLE
feat: add deck selection menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,18 @@
         // Взаимодействия с 3D-сценой вынесены в модуль src/scene/interactions.js
     
     async function initGame() {
-      gameState = startGame(STARTER_FIRESET, STARTER_FIRESET);
+      const decks = window.DECKS || [];
+      let chosen = window.__selectedDeckObj;
+      if (!chosen) {
+        try {
+          const id = localStorage.getItem('selectedDeckId');
+          chosen = decks.find(d => d.id === id) || decks[0];
+        } catch {
+          chosen = decks[0];
+        }
+      }
+      const d = chosen ? chosen.cards : STARTER_FIRESET;
+      gameState = startGame(d, d);
       try { window.applyGameState(gameState); } catch {}
       
       // Сразу строим сцену и мета-объекты, без задержки появления

--- a/src/core/decks.js
+++ b/src/core/decks.js
@@ -1,0 +1,78 @@
+// Определение доступных колод
+// Каждая колода включает id, имя, описание и список карт
+
+import { STARTER_FIRESET, CARDS } from './cards.js';
+
+export const DECKS = [
+  {
+    id: 'FIRE_STARTER',
+    name: 'Fire Awakening',
+    description: 'Starter mix of fiery spells and creatures.',
+    cards: STARTER_FIRESET,
+  },
+  {
+    id: 'BLAZE_RUSH',
+    name: 'Blaze Rush',
+    description: 'Aggressive deck with extra creatures.',
+    // немного изменённый набор карт
+    cards: [
+      CARDS.FIRE_FLAME_MAGUS,
+      CARDS.FIRE_FLAME_MAGUS,
+      CARDS.FIRE_HELLFIRE_SPITTER,
+      CARDS.FIRE_HELLFIRE_SPITTER,
+      CARDS.FIRE_FREEDONIAN,
+      CARDS.FIRE_FREEDONIAN,
+      CARDS.FIRE_FLAME_LIZARD,
+      CARDS.FIRE_FLAME_LIZARD,
+      CARDS.FIRE_GREAT_MINOS,
+      CARDS.FIRE_FLAME_ASCETIC,
+      CARDS.FIRE_TRICEPTAUR,
+      CARDS.FIRE_PURSUER,
+      CARDS.RAISE_STONE,
+      CARDS.SPELL_CLARE_WILS_BANNER,
+      CARDS.SPELL_SUMMONER_MESMERS_ERRAND,
+      CARDS.SPELL_FISSURES_OF_GOGHLIE,
+      CARDS.SPELL_BEGUILING_FOG,
+      CARDS.SPELL_PARMTETIC_HOLY_FEAST,
+      CARDS.SPELL_PARMTETIC_HOLY_FEAST,
+      CARDS.SPELL_GOGHLIE_ALTAR,
+    ].filter(Boolean),
+  },
+  {
+    id: 'PURE_BEASTS',
+    name: 'Pure Beasts',
+    description: 'Creature-only build with no spells.',
+    cards: STARTER_FIRESET.filter(c => c.type === 'UNIT'),
+  },
+  {
+    id: 'SPELLFIRE_STORM',
+    name: 'Spellfire Storm',
+    description: 'Experimental list packed with conjurations.',
+    cards: [
+      CARDS.RAISE_STONE,
+      CARDS.SPELL_FISSURES_OF_GOGHLIE,
+      CARDS.SPELL_BEGUILING_FOG,
+      CARDS.SPELL_CLARE_WILS_BANNER,
+      CARDS.SPELL_SUMMONER_MESMERS_ERRAND,
+      CARDS.SPELL_GOGHLIE_ALTAR,
+      CARDS.SPELL_PARMTETIC_HOLY_FEAST,
+      CARDS.SPELL_PARMTETIC_HOLY_FEAST,
+      CARDS.SPELL_FISSURES_OF_GOGHLIE,
+      CARDS.SPELL_BEGUILING_FOG,
+      CARDS.SPELL_SUMMONER_MESMERS_ERRAND,
+      CARDS.SPELL_CLARE_WILS_BANNER,
+      CARDS.SPELL_GOGHLIE_ALTAR,
+      CARDS.RAISE_STONE,
+      CARDS.SPELL_PARMTETIC_HOLY_FEAST,
+      CARDS.SPELL_FISSURES_OF_GOGHLIE,
+      CARDS.SPELL_BEGUILING_FOG,
+      CARDS.SPELL_SUMMONER_MESMERS_ERRAND,
+      CARDS.SPELL_CLARE_WILS_BANNER,
+      CARDS.SPELL_GOGHLIE_ALTAR,
+    ].filter(Boolean),
+  },
+];
+
+const api = { DECKS };
+try { if (typeof window !== 'undefined') { window.DECKS = DECKS; } } catch {}
+export default api;

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 ﻿// Bridge file to expose core modules to existing global code progressively
 import * as Constants from './core/constants.js';
 import { CARDS, STARTER_FIRESET } from './core/cards.js';
+import { DECKS } from './core/decks.js';
 import * as Rules from './core/rules.js';
 import { reducer, A, startGame, drawOne, drawOneNoAdd, shuffle, countControlled, countUnits } from './core/state.js';
 import { netState, NET_ON } from './core/netState.js';
@@ -31,6 +32,7 @@ import './ui/statusChip.js';
 import * as InputLock from './ui/inputLock.js';
 import { attachUIEvents } from './ui/domEvents.js';
 import * as BattleSplash from './ui/battleSplash.js';
+import * as DeckSelect from './ui/deckSelect.js';
 import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
@@ -51,6 +53,7 @@ try {
 
   window.CARDS = CARDS;
   window.STARTER_FIRESET = STARTER_FIRESET;
+  window.DECKS = DECKS;
 
   window.hasAdjacentGuard = Rules.hasAdjacentGuard;
   window.computeCellBuff = Rules.computeCellBuff;
@@ -177,6 +180,7 @@ try {
   window.__ui.inputLock = InputLock;
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
+  window.__ui.deckSelect = DeckSelect;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -47,7 +47,18 @@
       })();
       wrap.appendChild(btn);
     }
-    btn.addEventListener('click', onFindMatchClick);
+    btn.addEventListener('click', () => {
+      const ds = window.__ui?.deckSelect;
+      if (ds && typeof ds.open === 'function') {
+        ds.open(deck => {
+          try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+          window.__selectedDeckObj = deck;
+          onFindMatchClick();
+        });
+      } else {
+        onFindMatchClick();
+      }
+    });
   }
   mountOnlineButton();
   const mo = new MutationObserver(() => mountOnlineButton());

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -1,0 +1,98 @@
+// Меню выбора колоды
+import { DECKS } from '../core/decks.js';
+
+function pickDeckImage(deck) {
+  // выбираем самую дорогую по мане карту; при равенстве — случайная
+  const costs = deck.cards.map(c => c.cost || 0);
+  const max = Math.max(...costs);
+  const candidates = deck.cards.filter(c => (c.cost || 0) === max);
+  const card = candidates[Math.floor(Math.random() * candidates.length)];
+  return `card images/${card.id}.png`;
+}
+
+export function open(onConfirm, onCancel) {
+  if (typeof document === 'undefined') return;
+  let selected = 0;
+  const overlay = document.createElement('div');
+  overlay.id = 'deck-select-overlay';
+  overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60';
+
+  const panel = document.createElement('div');
+  // панель стала шире и получила лёгкую тень для выразительности
+  panel.className = 'bg-slate-800 p-4 rounded-lg w-[26rem] max-h-[90vh] flex flex-col shadow-xl';
+  overlay.appendChild(panel);
+
+  const title = document.createElement('div');
+  title.className = 'text-lg font-semibold mb-3';
+  title.textContent = 'Choose a deck';
+  panel.appendChild(title);
+
+  const list = document.createElement('div');
+  // ограничиваем высоту списка, чтобы появлялась прокрутка
+  list.className = 'flex-1 overflow-y-auto space-y-3 pr-1 max-h-72';
+  panel.appendChild(list);
+
+  DECKS.forEach((d, idx) => {
+    const item = document.createElement('div');
+    // внутреннее кольцо выделения, эффект наведения и плавное масштабирование
+    item.className = 'relative flex h-24 cursor-pointer rounded-md border border-slate-700 overflow-hidden transition-all hover:scale-[1.02] hover:shadow-lg';
+    if (idx === selected) item.classList.add('ring-2', 'ring-inset', 'ring-yellow-500');
+
+    const imgWrap = document.createElement('div');
+    imgWrap.className = 'relative w-40 h-full flex-shrink-0 overflow-hidden';
+    const img = document.createElement('img');
+    img.src = pickDeckImage(d);
+    img.className = 'w-full h-full object-cover';
+    imgWrap.appendChild(img);
+    const fade = document.createElement('div');
+    fade.className = 'absolute inset-0 bg-gradient-to-r from-transparent to-slate-800';
+    imgWrap.appendChild(fade);
+    item.appendChild(imgWrap);
+
+    const text = document.createElement('div');
+    text.className = 'pl-4 pr-2 flex flex-col justify-center';
+    const nm = document.createElement('div');
+    nm.className = 'font-semibold';
+    nm.textContent = d.name;
+    const ds = document.createElement('div');
+    ds.className = 'text-sm text-slate-300';
+    ds.textContent = d.description;
+    text.appendChild(nm); text.appendChild(ds);
+    item.appendChild(text);
+
+    item.addEventListener('click', () => {
+      selected = idx;
+      [...list.children].forEach((el, i) => {
+        el.classList.toggle('ring-2', i === selected);
+        el.classList.toggle('ring-inset', i === selected);
+        el.classList.toggle('ring-yellow-500', i === selected);
+      });
+    });
+    list.appendChild(item);
+  });
+
+  const btnWrap = document.createElement('div');
+  btnWrap.className = 'flex justify-end gap-2 mt-4';
+  panel.appendChild(btnWrap);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-500 transition-colors btn-gloss';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => { document.body.removeChild(overlay); onCancel && onCancel(); });
+  btnWrap.appendChild(cancelBtn);
+
+  const okBtn = document.createElement('button');
+  okBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-500 transition-colors btn-gloss';
+  okBtn.textContent = 'Confirm';
+  okBtn.addEventListener('click', () => {
+    try { document.body.removeChild(overlay); } catch {}
+    onConfirm && onConfirm(DECKS[selected]);
+  });
+  btnWrap.appendChild(okBtn);
+
+  document.body.appendChild(overlay);
+}
+
+const api = { open };
+try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.deckSelect = api; } } catch {}
+export default api;

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -11,7 +11,18 @@ export function attachUIEvents() {
   });
   refreshInputLockUI();
 
-  document.getElementById('new-game-btn')?.addEventListener('click', () => location.reload());
+  document.getElementById('new-game-btn')?.addEventListener('click', () => {
+    const ds = w.__ui?.deckSelect;
+    if (ds && typeof ds.open === 'function') {
+      ds.open(deck => {
+        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+        w.__selectedDeckObj = deck;
+        location.reload();
+      });
+    } else {
+      location.reload();
+    }
+  });
 
   document.getElementById('log-btn')?.addEventListener('click', () => {
     const lp = document.getElementById('log-panel');

--- a/styles/main.css
+++ b/styles/main.css
@@ -106,3 +106,23 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
   background: #0f172a;
   transform-origin: bottom center;
 }
+
+/* Глянцевый эффект для кнопок в меню */
+.btn-gloss {
+  position: relative;
+  overflow: hidden;
+}
+.btn-gloss::after {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -40%;
+  width: 40%;
+  height: 200%;
+  background: rgba(255,255,255,0.2);
+  transform: rotate(25deg);
+  transition: left 0.6s;
+}
+.btn-gloss:hover::after {
+  left: 140%;
+}


### PR DESCRIPTION
## Summary
- enlarge and polish deck selection panel with scroll and glossy buttons
- expand deck registry with four named decks including a creature-only option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b41f98e48330916c2168859908c2