### PR TITLE
Добавить стартовое меню и кастомный скролл

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
       <div class="flex gap-2 opacity-90">
         <button id="log-btn" class="overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors">Log</button>
         <button id="help-btn" class="overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors">Help</button>
-        <button id="new-game-btn" class="overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors">Play offline</button>
+        <button id="menu-btn" class="overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors">Menu</button>
       </div>
     </div>
     

--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,7 @@ import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
 import * as CancelButton from './ui/cancelButton.js';
+import * as MainMenu from './ui/mainMenu.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -180,6 +181,7 @@ try {
   window.__ui.inputLock = InputLock;
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
+  window.__ui.mainMenu = MainMenu;
   window.__ui.deckSelect = DeckSelect;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;
@@ -198,5 +200,12 @@ try {
 } catch {}
 
 import * as UISync from './ui/sync.js';
+
+// автоматически открываем стартовое меню при загрузке страницы
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    try { MainMenu.open(true); } catch {}
+  });
+}
 try { UISync.attachSocketUIRefresh(); if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.sync = UISync; } } catch {}
 

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -29,40 +29,24 @@
   `;
   const st = document.createElement('style'); st.textContent = css; document.head.appendChild(st);
 
-  // ===== 2) Кнопка «Онлайн-игра» — как стандартные overlay-кнопки рядом с остальными =====
-  function mountOnlineButton() {
-    if (document.getElementById('find-match-btn')) return;
-    const btn = document.createElement('button');
-    btn.id = 'find-match-btn';
-    btn.className = 'overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors';
-    btn.textContent = 'Play Online';
-    // Place inside the right-side control panel, next to other buttons
-    const host = document.querySelector('#corner-right .flex') || document.getElementById('corner-right');
-    if (host) {
-      host.appendChild(btn);
-    } else {
-      // Fallback: if panel not yet mounted, use floater
-      const wrap = document.getElementById('mp-floater') || (() => {
-        const d = document.createElement('div'); d.id='mp-floater'; d.className='mp-floater'; document.body.appendChild(d); return d;
-      })();
-      wrap.appendChild(btn);
-    }
-    btn.addEventListener('click', () => {
-      const ds = window.__ui?.deckSelect;
-      if (ds && typeof ds.open === 'function') {
-        ds.open(deck => {
-          try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
-          window.__selectedDeckObj = deck;
-          onFindMatchClick();
-        });
-      } else {
+  // ===== 2) API для кнопки "Play Online" в главном меню =====
+  function startOnlineMatch(){
+    const ds = window.__ui?.deckSelect;
+    if (ds && typeof ds.open === 'function') {
+      ds.open(deck => {
+        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+        window.__selectedDeckObj = deck;
         onFindMatchClick();
-      }
-    });
+      });
+    } else {
+      onFindMatchClick();
+    }
   }
-  mountOnlineButton();
-  const mo = new MutationObserver(() => mountOnlineButton());
-  mo.observe(document.body, { childList:true, subtree:true });
+  try {
+    window.__ui = window.__ui || {};
+    window.__ui.mainMenuActions = window.__ui.mainMenuActions || {};
+    window.__ui.mainMenuActions.playOnline = startOnlineMatch;
+  } catch {}
 
   // ===== 3) Queue modal + countdown =====
   let queueModal=null, startModal=null;
@@ -937,36 +921,29 @@
     });
   }
 
-  // Кнопка «Сдаться» рядом с остальными
-  function mountResignButton(){
-    if (document.getElementById('resign-btn')) return;
-    const host = document.querySelector('#corner-right .flex') || document.getElementById('corner-right');
-    if (!host) return;
-    const btn = document.createElement('button');
-    btn.id = 'resign-btn';
-    btn.className = 'overlay-panel px-3 py-1.5 text-xs bg-red-600 hover:bg-red-700 transition-colors';
-    btn.textContent = 'Surrender';
-    host.appendChild(btn);
-    btn.addEventListener('click', ()=>{
-      const confirmModal = document.createElement('div');
-      confirmModal.className = 'mp-modal';
-      confirmModal.innerHTML = `<div class="mp-card">
-        <div>Вы уверены, что хотите сдаться?</div>
-        <div style="display:flex;gap:8px;justify-content:center;margin-top:10px">
-          <button id="r-yes" class="mp-btn">Да</button>
-          <button id="r-no" class="mp-btn">Нет</button>
-        </div>
-      </div>`;
-      document.body.appendChild(confirmModal);
-      confirmModal.querySelector('#r-no').addEventListener('click', ()=> confirmModal.remove());
-      confirmModal.querySelector('#r-yes').addEventListener('click', ()=>{
-        try { (window.socket || socket).emit('resign'); } catch {}
-        try { confirmModal.remove(); } catch {}
-      });
+  // ===== API для кнопки "Surrender" в главном меню =====
+  function promptResign(){
+    const confirmModal = document.createElement('div');
+    confirmModal.className = 'mp-modal';
+    confirmModal.innerHTML = `<div class="mp-card">
+      <div>Вы уверены, что хотите сдаться?</div>
+      <div style="display:flex;gap:8px;justify-content:center;margin-top:10px">
+        <button id="r-yes" class="mp-btn">Да</button>
+        <button id="r-no" class="mp-btn">Нет</button>
+      </div>
+    </div>`;
+    document.body.appendChild(confirmModal);
+    confirmModal.querySelector('#r-no').addEventListener('click', ()=> confirmModal.remove());
+    confirmModal.querySelector('#r-yes').addEventListener('click', ()=>{
+      try { (window.socket || socket).emit('resign'); } catch {}
+      try { confirmModal.remove(); } catch {}
     });
   }
-  mountResignButton();
-  setInterval(mountResignButton, 1000);
+  try {
+    window.__ui = window.__ui || {};
+    window.__ui.mainMenuActions = window.__ui.mainMenuActions || {};
+    window.__ui.mainMenuActions.surrender = promptResign;
+  } catch {}
 
   socket.on('matchEnded', ({ winnerSeat, reason })=>{
     // Полный сброс клиентского онлайнового состояния и комнаты перед показом модалки

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -29,7 +29,8 @@ export function open(onConfirm, onCancel) {
 
   const list = document.createElement('div');
   // ограничиваем высоту списка, чтобы появился скролл при избытке колод
-  list.className = 'flex-1 overflow-y-auto space-y-3 pr-2 max-h-64';
+  // добавляем кастомный скролл, чтобы он вписывался в общий стиль
+  list.className = 'flex-1 overflow-y-auto space-y-3 pr-2 max-h-64 custom-scroll';
   panel.appendChild(list);
 
   DECKS.forEach((d, idx) => {

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -11,17 +11,9 @@ export function attachUIEvents() {
   });
   refreshInputLockUI();
 
-  document.getElementById('new-game-btn')?.addEventListener('click', () => {
-    const ds = w.__ui?.deckSelect;
-    if (ds && typeof ds.open === 'function') {
-      ds.open(deck => {
-        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
-        w.__selectedDeckObj = deck;
-        location.reload();
-      });
-    } else {
-      location.reload();
-    }
+  document.getElementById('menu-btn')?.addEventListener('click', () => {
+    // открываем главное меню
+    w.__ui?.mainMenu?.open?.();
   });
 
   document.getElementById('log-btn')?.addEventListener('click', () => {

--- a/src/ui/mainMenu.js
+++ b/src/ui/mainMenu.js
@@ -1,0 +1,70 @@
+// Главное меню игры
+export function open(initial = false) {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById('main-menu-overlay')) return;
+  const overlay = document.createElement('div');
+  overlay.id = 'main-menu-overlay';
+  // при первом запуске затемняем фон, далее оставляем прозрачным
+  overlay.className = `fixed inset-0 z-50 flex flex-col items-center justify-center ${initial ? 'bg-black bg-opacity-60' : 'bg-transparent'}`;
+
+  if (initial) {
+    const logo = document.createElement('img');
+    logo.src = 'textures/grid_of_judgment_logo.png';
+    logo.alt = 'The Grid of Judgement';
+    logo.className = 'w-72 mb-6 select-none';
+    overlay.appendChild(logo);
+  }
+
+  const panel = document.createElement('div');
+  panel.className = 'overlay-panel p-6 flex flex-col gap-3 min-w-[12rem]';
+  overlay.appendChild(panel);
+
+  // вспомогательный генератор кнопок
+  function addBtn(id, label, onClick, disabled = false) {
+    const b = document.createElement('button');
+    b.id = id;
+    b.textContent = label;
+    b.className = 'overlay-panel px-4 py-2 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
+    if (disabled) {
+      b.disabled = true;
+      b.classList.add('opacity-50', 'cursor-not-allowed');
+    }
+    if (onClick) {
+      b.addEventListener('click', onClick);
+    }
+    panel.appendChild(b);
+  }
+
+  addBtn('mm-play-online', 'Play Online', () => {
+    close();
+    window.__ui?.mainMenuActions?.playOnline?.();
+  });
+  addBtn('mm-play-offline', 'Play Offline', () => {
+    close();
+    const ds = window.__ui?.deckSelect;
+    if (ds && typeof ds.open === 'function') {
+      ds.open(deck => {
+        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+        window.__selectedDeckObj = deck;
+        location.reload();
+      });
+    } else {
+      location.reload();
+    }
+  });
+  addBtn('mm-surrender', 'Surrender', () => {
+    close();
+    window.__ui?.mainMenuActions?.surrender?.();
+  });
+  addBtn('mm-deckbuilder', 'Deck Builder', null, true);
+  addBtn('mm-settings', 'Settings', null, true);
+  addBtn('mm-cancel', 'Cancel', () => close());
+
+  document.body.appendChild(overlay);
+}
+
+export function close() {
+  try { document.getElementById('main-menu-overlay')?.remove(); } catch {}
+}
+
+export default { open, close };

--- a/styles/main.css
+++ b/styles/main.css
@@ -74,6 +74,25 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
   transition: left .5s;
 }
 .glossy-btn:hover::after { left: 150%; }
+/* Кастомный скролл для списков */
+.custom-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148,163,184,0.6) rgba(30,41,59,0.9);
+}
+.custom-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+.custom-scroll::-webkit-scrollbar-track {
+  background: rgba(30,41,59,0.9);
+  border-radius: 8px;
+}
+.custom-scroll::-webkit-scrollbar-thumb {
+  background: rgba(148,163,184,0.6);
+  border-radius: 8px;
+}
+.custom-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(203,213,225,0.8);
+}
 /* Prompt: кликабельна только панель, остальное кликается сквозь */
 #prompt-panel { pointer-events: none; }
 #prompt-panel .overlay-panel { pointer-events: auto; }


### PR DESCRIPTION
## Summary
- Вынесены кнопки Play Online, Play Offline и Surrender в отдельное стартовое меню с логотипом
- Добавлен кастомный скролл в окне выбора колоды
- Кнопка Menu заменяет старые сервисные кнопки

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3f2ed568c83308e5b417c1db34328