### PR TITLE
Добавлено стартовое меню и кастомный скроллбар

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
       <div class="flex gap-2 opacity-90">
         <button id="log-btn" class="overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors">Log</button>
         <button id="help-btn" class="overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors">Help</button>
-        <button id="new-game-btn" class="overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors">Play offline</button>
+        <button id="menu-btn" class="overlay-panel px-3 py-1.5 text-xs bg-slate-600 hover:bg-slate-700 transition-colors">Menu</button>
       </div>
     </div>
     
@@ -441,6 +441,7 @@
         // Привязка обработчиков взаимодействия теперь в модуле interactions
         window.__interactions.setupInteractions();
         try { window.attachUIEvents && window.attachUIEvents(); } catch {}
+        try { window.__ui?.mainMenu?.open?.(true); } catch {}
       }
     try { window.init = init; window.initThreeJS = initThreeJS; window.initGame = initGame; window.animate = animate; } catch {}
 

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,7 @@ import * as InputLock from './ui/inputLock.js';
 import { attachUIEvents } from './ui/domEvents.js';
 import * as BattleSplash from './ui/battleSplash.js';
 import * as DeckSelect from './ui/deckSelect.js';
+import * as MainMenu from './ui/mainMenu.js';
 import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
@@ -181,6 +182,7 @@ try {
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
   window.__ui.deckSelect = DeckSelect;
+  window.__ui.mainMenu = MainMenu;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -29,7 +29,7 @@ export function open(onConfirm, onCancel) {
 
   const list = document.createElement('div');
   // ограничиваем высоту списка, чтобы появился скролл при избытке колод
-  list.className = 'flex-1 overflow-y-auto space-y-3 pr-2 max-h-64';
+  list.className = 'flex-1 overflow-y-auto space-y-3 pr-2 max-h-64 deck-scroll';
   panel.appendChild(list);
 
   DECKS.forEach((d, idx) => {

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -11,17 +11,9 @@ export function attachUIEvents() {
   });
   refreshInputLockUI();
 
-  document.getElementById('new-game-btn')?.addEventListener('click', () => {
-    const ds = w.__ui?.deckSelect;
-    if (ds && typeof ds.open === 'function') {
-      ds.open(deck => {
-        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
-        w.__selectedDeckObj = deck;
-        location.reload();
-      });
-    } else {
-      location.reload();
-    }
+  document.getElementById('menu-btn')?.addEventListener('click', () => {
+    // Открываем главное меню
+    try { w.__ui?.mainMenu?.open?.(); } catch {}
   });
 
   document.getElementById('log-btn')?.addEventListener('click', () => {

--- a/src/ui/mainMenu.js
+++ b/src/ui/mainMenu.js
@@ -1,0 +1,110 @@
+// Главное меню игры
+let firstOpen = true;
+
+export function open(initial = false) {
+  if (typeof document === 'undefined') return;
+  if (initial) firstOpen = true;
+  const overlay = document.createElement('div');
+  overlay.id = 'main-menu-overlay';
+  const bgClass = firstOpen ? 'bg-black bg-opacity-90' : 'bg-black bg-opacity-50';
+  overlay.className = `fixed inset-0 z-50 flex items-center justify-center ${bgClass}`;
+
+  const panel = document.createElement('div');
+  panel.className = 'overlay-panel p-6 w-60 flex flex-col items-center gap-3';
+  overlay.appendChild(panel);
+
+  if (firstOpen) {
+    const logo = document.createElement('img');
+    logo.src = 'textures/grid_of_judgment_logo.png';
+    logo.className = 'w-48 mb-4';
+    panel.appendChild(logo);
+  }
+
+  function addBtn(id, text, handler, disabled = false) {
+    const btn = document.createElement('button');
+    btn.id = id;
+    btn.textContent = text;
+    btn.className = 'w-full overlay-panel px-4 py-2 bg-slate-600 hover:bg-slate-700 transition-colors';
+    if (disabled) {
+      btn.classList.add('opacity-50', 'cursor-not-allowed');
+      btn.disabled = true;
+    } else {
+      btn.addEventListener('click', handler);
+    }
+    panel.appendChild(btn);
+  }
+
+  function close() {
+    try { document.body.removeChild(overlay); } catch {}
+  }
+
+  addBtn('mm-online', 'Play Online', () => {
+    close();
+    const ds = window.__ui?.deckSelect;
+    if (ds && typeof ds.open === 'function') {
+      ds.open(deck => {
+        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+        window.__selectedDeckObj = deck;
+        window.__net?.findMatch?.();
+      });
+    } else {
+      window.__net?.findMatch?.();
+    }
+    firstOpen = false;
+  });
+
+  addBtn('mm-offline', 'Play Offline', () => {
+    close();
+    const ds = window.__ui?.deckSelect;
+    if (ds && typeof ds.open === 'function') {
+      ds.open(deck => {
+        try { localStorage.setItem('selectedDeckId', deck.id); } catch {}
+        window.__selectedDeckObj = deck;
+        location.reload();
+      });
+    } else {
+      location.reload();
+    }
+    firstOpen = false;
+  });
+
+  addBtn('mm-deck', 'Deck Builder', () => {}, true);
+  addBtn('mm-settings', 'Settings', () => {}, true);
+
+  addBtn('mm-surrender', 'Surrender', () => {
+    close();
+    const confirmModal = document.createElement('div');
+    confirmModal.className = 'fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50';
+    confirmModal.innerHTML = `<div class="overlay-panel p-6 space-y-4 text-center">
+      <div>Вы уверены, что хотите сдаться?</div>
+      <div class="flex gap-2 justify-center">
+        <button id="mm-r-yes" class="overlay-panel px-4 py-2 bg-red-600 hover:bg-red-700">Да</button>
+        <button id="mm-r-no" class="overlay-panel px-4 py-2">Нет</button>
+      </div>
+    </div>`;
+    document.body.appendChild(confirmModal);
+    confirmModal.querySelector('#mm-r-no').addEventListener('click', () => confirmModal.remove());
+    confirmModal.querySelector('#mm-r-yes').addEventListener('click', () => {
+      try { window.socket?.emit('resign'); } catch {}
+      try { window.setWinner?.(1 - window.gameState.active, 'resign'); } catch {}
+      confirmModal.remove();
+    });
+  });
+
+  addBtn('mm-cancel', 'Cancel', () => {
+    close();
+    firstOpen = false;
+  });
+
+  document.body.appendChild(overlay);
+}
+
+const api = { open };
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.mainMenu = api;
+  }
+} catch {}
+
+export default api;

--- a/styles/main.css
+++ b/styles/main.css
@@ -118,3 +118,23 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
   background: #0f172a;
   transform-origin: bottom center;
 }
+
+/* Кастомный скроллбар для выбора колоды */
+#deck-select-overlay .deck-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #475569 rgba(30,41,59,0.7);
+}
+#deck-select-overlay .deck-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+#deck-select-overlay .deck-scroll::-webkit-scrollbar-track {
+  background: rgba(30,41,59,0.7);
+}
+#deck-select-overlay .deck-scroll::-webkit-scrollbar-thumb {
+  background-color: #475569;
+  border-radius: 4px;
+  border: 2px solid rgba(30,41,59,0.7);
+}
+#deck-select-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: #64748b;
+}


### PR DESCRIPTION
## Summary
- Объединены кнопки Play Online, Play Offline и Surrender в отдельное стартовое меню с логотипом.
- Настроен тёмный стиль скроллбара в меню выбора колоды.
- Добавлены заготовки пунктов Deck Builder и Settings в новом меню.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3f2ed568c83308e5b417c1db34328