### PR TITLE
Доработка двойной атаки и визуальных эффектов

### DIFF
--- a/cards_set1_fire_water.txt
+++ b/cards_set1_fire_water.txt
@@ -73,6 +73,7 @@ const CARDS = {
     id: 'FIRE_PARTMOLE_FLAME_GUARD', name: 'Partmole Flame Guard', type: 'UNIT',
     cost: 3, activation: 2, element: 'FIRE', atk: 1, hp: 3,
     pattern: 'FRONT', range: 2, attackType: 'MELEE', blindspots: ['S'],
+    pierce: true,
     plusAtkIfTargetOnElement: { element: 'WATER', amount: 2 },
     desc: 'Adds 2 to its Attack if at least one target creature is on a water field.'
   },
@@ -80,7 +81,7 @@ const CARDS = {
     id: 'FIRE_LESSER_GRANVENOA', name: 'Lesser Granvenoa', type: 'UNIT',
     cost: 4, activation: 2, element: 'FIRE', atk: 2, hp: 4,
     pattern: 'ALL', range: 1, attackType: 'MELEE', blindspots: [],
-    fortress: true, diesOffElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
+    fortress: true, diesOnElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
     desc: 'Fortress. Adjacent fields cannot be field‑quaked or exchanged. Destroy Lesser Granvenoa if it is on a Water field.'
   },
   FIRE_PARTMOLE_FIRE_ORACLE: {

--- a/index.html
+++ b/index.html
@@ -520,6 +520,8 @@
         if (hpA <= 0) hitsPrev.length = 0;
       }
       const fromPos = (aMesh ? aMesh.position.clone() : tileMeshes[r][c].position.clone().add(new THREE.Vector3(0, 0.8, 0)));
+      const tplAttacker = gameState.board?.[r]?.[c]?.unit ? CARDS[gameState.board[r][c].unit.tplId] : null;
+      const attackerDouble = tplAttacker && tplAttacker.doubleAttack;
 
       const doStep1 = () => {
         // Убраны жёлтые лучи/стрелки под картами
@@ -531,9 +533,15 @@
         // Тряска и всплывающий урон — уже по актуальным мешам после обновления
         for (const h of hitsPrev) {
           const tMesh = unitMeshes.find(m => m.userData.row === h.r && m.userData.col === h.c);
-          if (tMesh) { 
-            window.__fx.shakeMesh(tMesh, 6, 0.12); 
+          if (tMesh) {
+            window.__fx.shakeMesh(tMesh, 6, 0.12);
             window.__fx.spawnDamageText(tMesh, `-${h.dmg}`, '#ff5555');
+            if (attackerDouble) {
+              setTimeout(() => {
+                window.__fx.shakeMesh(tMesh, 6, 0.12);
+                window.__fx.spawnDamageText(tMesh, `-${h.dmg}`, '#ff5555');
+              }, 300);
+            }
           }
         }
         setTimeout(async () => {
@@ -643,9 +651,15 @@
         if (firstTargetMesh) {
           const dir = new THREE.Vector3().subVectors(firstTargetMesh.position, aMesh.position).normalize();
           const push = { x: dir.x * 0.6, z: dir.z * 0.6 };
+          const tplA = CARDS[gameState.board[r][c]?.unit?.tplId];
+          const isDouble = tplA && tplA.doubleAttack;
           const tl = gsap.timeline({ onComplete: doStep1 });
           tl.to(aMesh.position, { x: `+=${push.x}`, z: `+=${push.z}`, duration: 0.22, ease: 'power2.out' })
             .to(aMesh.position, { x: `-=${push.x}`, z: `-=${push.z}`, duration: 0.3, ease: 'power2.inOut' });
+          if (isDouble) {
+            tl.to(aMesh.position, { x: `+=${push.x}`, z: `+=${push.z}`, duration: 0.22, ease: 'power2.out' })
+              .to(aMesh.position, { x: `-=${push.x}`, z: `-=${push.z}`, duration: 0.3, ease: 'power2.inOut' });
+          }
           // Онлайновая синхронизация выпадов (атакующий и цели)
           try {
             const shouldSend = (typeof window !== 'undefined' && window.socket && (typeof NET_ACTIVE !== 'undefined' ? NET_ACTIVE : false) && (typeof MY_SEAT !== 'undefined' ? MY_SEAT : null) === gameState.active);

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -84,7 +84,9 @@ export const CARDS = {
     id: 'FIRE_PARTMOLE_FLAME_GUARD', name: 'Partmole Flame Guard', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 1, hp: 3,
     attackType: 'STANDARD',
+    // пробивает первую цель и бьёт следующую за ней
     attacks: [ { dir: 'N', ranges: [1,2] } ],
+    pierce: true,
     blindspots: ['S'],
     plusAtkIfTargetOnElement: { element: 'WATER', amount: 2 },
     desc: 'Adds 2 to its Attack if at least one target creature is on a water field.'
@@ -100,7 +102,7 @@ export const CARDS = {
       { dir: 'S', ranges: [1] },
       { dir: 'W', ranges: [1] }
     ],
-    blindspots: [], fortress: true, diesOffElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
+    blindspots: [], fortress: true, diesOnElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
     desc: 'Fortress. Adjacent fields cannot be field‑quaked or exchanged. Destroy Lesser Granvenoa if it is on a Water field.'
   },
 

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -269,8 +269,9 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
       // заливаем все потенциальные клетки (включая выходящие за 3x3)
       ctx.fillStyle = 'rgba(56,189,248,0.35)';
       ctx.fillRect(cx, cy, cell, cell);
-      // красная рамка только если направление фиксировано
-      const mustHit = (!isChoice) && dist === minDist;
+      // если атака охватывает несколько дистанций одновременно, подсвечиваем все
+      const multi = (!a.mode || a.mode !== 'ANY') && (a.ranges && a.ranges.length > 1);
+      const mustHit = (!isChoice) && (multi || dist === minDist);
       ctx.strokeStyle = mustHit ? '#ef4444' : 'rgba(56,189,248,0.6)';
       ctx.lineWidth = 1.5;
       ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);

--- a/src/scene/fieldLockEffect.js
+++ b/src/scene/fieldLockEffect.js
@@ -23,11 +23,16 @@ function createLockMaterial(origMat, THREE) {
         '#include <dithering_fragment>',
         `#include <dithering_fragment>\n{
           float pulse = sin(uTime*3.0)*0.5+0.5;
-          vec2 centered = vUv*2.0-1.0;
-          float ring = smoothstep(0.4,0.38, length(centered));
-          vec3 glow = vec3(1.0,0.6,0.1)*ring*(0.6+0.4*pulse);
+          vec2 uv = vUv*2.0-1.0;
+          // простая фигура замка: дуга + прямоугольное тело
+          float body = step(abs(uv.x),0.3)*step(-0.2,uv.y)*step(uv.y,0.4);
+          float outer = step(length(uv+vec2(0.0,0.3)),0.5);
+          float inner = step(length(uv+vec2(0.0,0.3)),0.3);
+          float shackle = (outer-inner)*step(uv.y,0.0);
+          float lock = max(body, shackle);
+          vec3 glow = vec3(1.0,0.6,0.1)*lock*(0.3+0.2*pulse);
           gl_FragColor.rgb += glow;
-          gl_FragColor.a = max(gl_FragColor.a, ring*pulse*0.9);
+          gl_FragColor.a = max(gl_FragColor.a, lock*pulse*0.4);
         }`
       );
     state.uniforms.push(shader.uniforms.uTime);

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -532,7 +532,27 @@ export function placeUnitWithDirection(direction) {
     window.addLog(`${cardData.name} погибает вдали от стихии ${cardData.diesOffElement}!`);
     alive = false;
   }
+  if (alive && cardData.diesOnElement && cellElement === cardData.diesOnElement) {
+    window.addLog(`${cardData.name} не переносит стихию ${cardData.diesOnElement} и погибает!`);
+    alive = false;
+  }
   if (!alive) {
+    // обработка эффектов при смерти (например, лечение союзников)
+    if (cardData.onDeathHealAll) {
+      for (let rr = 0; rr < 3; rr++) {
+        for (let cc = 0; cc < 3; cc++) {
+          const ally = gameState.board?.[rr]?.[cc]?.unit;
+          if (!ally || ally.owner !== unit.owner) continue;
+          const tplAlly = window.CARDS?.[ally.tplId];
+          const cellEl2 = gameState.board[rr][cc].element;
+          const buff2 = window.computeCellBuff(cellEl2, tplAlly.element);
+          const maxHP = (tplAlly.hp || 0) + buff2.hp;
+          const before = ally.currentHP ?? tplAlly.hp;
+          ally.currentHP = Math.min(maxHP, before + cardData.onDeathHealAll);
+        }
+      }
+      window.addLog(`${cardData.name}: союзники получают +${cardData.onDeathHealAll} HP`);
+    }
     const owner = unit.owner;
     try { gameState.players[owner].graveyard.push(window.CARDS[unit.tplId]); } catch {}
     const ctx = getCtx();

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -233,6 +233,28 @@ describe('новые механики', () => {
     expect(fin.n1.board[0][1].unit).toBeNull();
   });
 
+  it('double attack вызывает только одну контратаку', () => {
+    const state = makeState();
+    state.board[1][1].unit = { owner:0, tplId:'FIRE_DIDI_THE_ENLIGHTENED', facing:'N', currentHP:4 };
+    state.board[0][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'S', currentHP:10 };
+    const res = stagedAttack(state,1,1);
+    const fin = res.finish();
+    const attacker = fin.n1.board[1][1].unit;
+    expect(attacker.currentHP).toBe(2);
+  });
+
+  it('Flame Guard атакует две клетки вперёд', () => {
+    const state = makeState();
+    state.board[2][1].unit = { owner:0, tplId:'FIRE_PARTMOLE_FLAME_GUARD', facing:'N' };
+    state.board[1][1].unit = { owner:1, tplId:'FIRE_FLAME_MAGUS', facing:'S', currentHP:1 };
+    state.board[0][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FIRE_ORACLE', facing:'S', currentHP:3 };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    expect(fin.n1.board[1][1].unit).toBeNull();
+    const second = fin.n1.board[0][1].unit;
+    expect(second.currentHP).toBeLessThan(3);
+  });
+
   it('fortress не может атаковать, но может контратаковать', () => {
     const state = makeState();
     state.board[1][1].unit = { owner:0, tplId:'FIRE_LESSER_GRANVENOA', facing:'N' };


### PR DESCRIPTION
## Изменения
- Анимация двойной атаки теперь воспроизводится дважды, контратака запускается после второго удара
- Эффект защищённого поля стал более прозрачным и отображается силуэтом замка
- Flame Guard пробивает первую цель и бьёт по двум клеткам вперёд
- Lesser Granvenoa погибает только на водной клетке
- Исправлено лечение союзников от Partmole Fire Oracle при его смерти
- Актуализированы схемы атак на картах и добавлены тесты

## Тесты
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c67f47d4188330a3b9cea64473c327