### PR TITLE
feat: improve double attack and field effects

### DIFF
--- a/cards_set1_fire_water.txt
+++ b/cards_set1_fire_water.txt
@@ -73,6 +73,7 @@ const CARDS = {
     id: 'FIRE_PARTMOLE_FLAME_GUARD', name: 'Partmole Flame Guard', type: 'UNIT',
     cost: 3, activation: 2, element: 'FIRE', atk: 1, hp: 3,
     pattern: 'FRONT', range: 2, attackType: 'MELEE', blindspots: ['S'],
+    pierce: true,
     plusAtkIfTargetOnElement: { element: 'WATER', amount: 2 },
     desc: 'Adds 2 to its Attack if at least one target creature is on a water field.'
   },
@@ -80,7 +81,7 @@ const CARDS = {
     id: 'FIRE_LESSER_GRANVENOA', name: 'Lesser Granvenoa', type: 'UNIT',
     cost: 4, activation: 2, element: 'FIRE', atk: 2, hp: 4,
     pattern: 'ALL', range: 1, attackType: 'MELEE', blindspots: [],
-    fortress: true, diesOffElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
+    fortress: true, diesOnElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
     desc: 'Fortress. Adjacent fields cannot be field‑quaked or exchanged. Destroy Lesser Granvenoa if it is on a Water field.'
   },
   FIRE_PARTMOLE_FIRE_ORACLE: {

--- a/index.html
+++ b/index.html
@@ -473,6 +473,9 @@
       // flashy заставка BATTLE (сокращённая)
       await showBattleSplash();
 
+      const attUnit = gameState.board?.[r]?.[c]?.unit;
+      const tplA = attUnit ? CARDS[attUnit.tplId] : null;
+      const isDouble = tplA && tplA.doubleAttack;
       let aMesh = unitMeshes.find(m => m.userData.row === r && m.userData.col === c);
       if (staged.quickRetaliation > 0) {
         const quickers = staged.quickRetaliators || [];
@@ -643,31 +646,39 @@
         if (firstTargetMesh) {
           const dir = new THREE.Vector3().subVectors(firstTargetMesh.position, aMesh.position).normalize();
           const push = { x: dir.x * 0.6, z: dir.z * 0.6 };
-          const tl = gsap.timeline({ onComplete: doStep1 });
-          tl.to(aMesh.position, { x: `+=${push.x}`, z: `+=${push.z}`, duration: 0.22, ease: 'power2.out' })
-            .to(aMesh.position, { x: `-=${push.x}`, z: `-=${push.z}`, duration: 0.3, ease: 'power2.inOut' });
-          // Онлайновая синхронизация выпадов (атакующий и цели)
-          try {
-            const shouldSend = (typeof window !== 'undefined' && window.socket && (typeof NET_ACTIVE !== 'undefined' ? NET_ACTIVE : false) && (typeof MY_SEAT !== 'undefined' ? MY_SEAT : null) === gameState.active);
-            console.log('[battleAnim] Checking if should send:', {
-              hasWindow: typeof window !== 'undefined',
-              hasSocket: !!(typeof window !== 'undefined' && window.socket),
-              NET_ACTIVE: typeof NET_ACTIVE !== 'undefined' ? NET_ACTIVE : 'undefined',
-              MY_SEAT: typeof MY_SEAT !== 'undefined' ? MY_SEAT : 'undefined',
-              gameStateActive: gameState.active,
-              seatMatches: (typeof MY_SEAT !== 'undefined' ? MY_SEAT : null) === gameState.active,
-              shouldSend
-            });
-            if (shouldSend) {
-              window.socket.emit('battleAnim', {
-                attacker: { r, c },
-                targets: hitsPrev.map(h => ({ r: h.r, c: h.c, dmg: h.dmg })),
-                bySeat: typeof window.MY_SEAT === 'number' ? window.MY_SEAT : null
-              });
-              console.log('[battleAnim] Sent battleAnim event', { attacker: { r, c }, targets: hitsPrev.length });
+          const doLunge = (onComplete, send = true) => {
+            const tl = gsap.timeline({ onComplete });
+            tl.to(aMesh.position, { x: `+=${push.x}`, z: `+=${push.z}`, duration: 0.22, ease: 'power2.out' })
+              .to(aMesh.position, { x: `-=${push.x}`, z: `-=${push.z}`, duration: 0.3, ease: 'power2.inOut' });
+            if (send) {
+              try {
+                const shouldSend = (typeof window !== 'undefined' && window.socket && (typeof NET_ACTIVE !== 'undefined' ? NET_ACTIVE : false) && (typeof MY_SEAT !== 'undefined' ? MY_SEAT : null) === gameState.active);
+                console.log('[battleAnim] Checking if should send:', {
+                  hasWindow: typeof window !== 'undefined',
+                  hasSocket: !!(typeof window !== 'undefined' && window.socket),
+                  NET_ACTIVE: typeof NET_ACTIVE !== 'undefined' ? NET_ACTIVE : 'undefined',
+                  MY_SEAT: typeof MY_SEAT !== 'undefined' ? MY_SEAT : 'undefined',
+                  gameStateActive: gameState.active,
+                  seatMatches: (typeof MY_SEAT !== 'undefined' ? MY_SEAT : null) === gameState.active,
+                  shouldSend
+                });
+                if (shouldSend) {
+                  window.socket.emit('battleAnim', {
+                    attacker: { r, c },
+                    targets: hitsPrev.map(h => ({ r: h.r, c: h.c, dmg: h.dmg })),
+                    bySeat: typeof window.MY_SEAT === 'number' ? window.MY_SEAT : null
+                  });
+                  console.log('[battleAnim] Sent battleAnim event', { attacker: { r, c }, targets: hitsPrev.length });
+                }
+              } catch (e) {
+                console.error('[battleAnim] Error sending battleAnim:', e);
+              }
             }
-          } catch (e) {
-            console.error('[battleAnim] Error sending battleAnim:', e);
+          };
+          if (isDouble) {
+            doLunge(() => doLunge(doStep1, false));
+          } else {
+            doLunge(doStep1);
           }
         } else {
           gsap.to(aMesh.position, { y: aMesh.position.y + 0.25, yoyo: true, repeat: 1, duration: 0.2, onComplete: doStep1 });

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -85,6 +85,7 @@ export const CARDS = {
     element: 'FIRE', atk: 1, hp: 3,
     attackType: 'STANDARD',
     attacks: [ { dir: 'N', ranges: [1,2] } ],
+    pierce: true,
     blindspots: ['S'],
     plusAtkIfTargetOnElement: { element: 'WATER', amount: 2 },
     desc: 'Adds 2 to its Attack if at least one target creature is on a water field.'
@@ -100,7 +101,7 @@ export const CARDS = {
       { dir: 'S', ranges: [1] },
       { dir: 'W', ranges: [1] }
     ],
-    blindspots: [], fortress: true, diesOffElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
+    blindspots: [], fortress: true, diesOnElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
     desc: 'Fortress. Adjacent fields cannot be field‑quaked or exchanged. Destroy Lesser Granvenoa if it is on a Water field.'
   },
 

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -455,6 +455,23 @@ export function magicAttack(state, fr, fc, tr, tc) {
       }
     }
   } catch {}
+  for (const d of deaths) {
+    const tplD = CARDS[d.tplId];
+    if (tplD?.onDeathHealAll) {
+      for (let rr = 0; rr < 3; rr++) {
+        for (let cc = 0; cc < 3; cc++) {
+          const ally = n1.board[rr][cc]?.unit;
+          if (!ally || ally.owner !== d.owner) continue;
+          const tplAlly = CARDS[ally.tplId];
+          const buff = computeCellBuff(n1.board[rr][cc].element, tplAlly.element);
+          const maxHP = (tplAlly.hp || 0) + buff.hp;
+          const before = ally.currentHP ?? tplAlly.hp;
+          ally.currentHP = Math.min(maxHP, before + tplD.onDeathHealAll);
+        }
+      }
+      logLines.push(`${tplD.name}: союзники получают +${tplD.onDeathHealAll} HP`);
+    }
+  }
   attacker.lastAttackTurn = n1.turn;
   const cellEl = n1.board?.[fr]?.[fc]?.element;
   attacker.apSpent = (attacker.apSpent || 0) + attackCost(tplA, cellEl);

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -258,7 +258,6 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
   const map = { N: [-1,0], E:[0,1], S:[1,0], W:[0,-1] };
   for (const a of attacks) {
     const isChoice = cardData.chooseDir || a.mode === 'ANY';
-    const minDist = Math.min(...(a.ranges || [1]));
     for (const dist of a.ranges || []) {
       const vec = map[a.dir];
       if (!vec) continue;
@@ -269,8 +268,8 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
       // заливаем все потенциальные клетки (включая выходящие за 3x3)
       ctx.fillStyle = 'rgba(56,189,248,0.35)';
       ctx.fillRect(cx, cy, cell, cell);
-      // красная рамка только если направление фиксировано
-      const mustHit = (!isChoice) && dist === minDist;
+      // красная рамка, если атака происходит по всем указанным дистанциям
+      const mustHit = (!isChoice) && a.mode !== 'ANY';
       ctx.strokeStyle = mustHit ? '#ef4444' : 'rgba(56,189,248,0.6)';
       ctx.lineWidth = 1.5;
       ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);

--- a/src/scene/fieldLockEffect.js
+++ b/src/scene/fieldLockEffect.js
@@ -24,10 +24,15 @@ function createLockMaterial(origMat, THREE) {
         `#include <dithering_fragment>\n{
           float pulse = sin(uTime*3.0)*0.5+0.5;
           vec2 centered = vUv*2.0-1.0;
-          float ring = smoothstep(0.4,0.38, length(centered));
-          vec3 glow = vec3(1.0,0.6,0.1)*ring*(0.6+0.4*pulse);
+          vec2 uv = centered;
+          float body = (1.0 - step(0.3, abs(uv.x))) * step(-0.5, uv.y) * (1.0 - step(0.1, uv.y));
+          float shOuter = smoothstep(0.45,0.43,length(uv - vec2(0.0,0.25)));
+          float shInner = smoothstep(0.25,0.23,length(uv - vec2(0.0,0.25)));
+          float shackle = (shOuter - shInner) * step(uv.y,0.25);
+          float lockShape = max(body, shackle);
+          vec3 glow = vec3(1.0,0.6,0.1)*lockShape*(0.4+0.2*pulse);
           gl_FragColor.rgb += glow;
-          gl_FragColor.a = max(gl_FragColor.a, ring*pulse*0.9);
+          gl_FragColor.a = max(gl_FragColor.a, lockShape*pulse*0.4);
         }`
       );
     state.uniforms.push(shader.uniforms.uTime);

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -528,6 +528,10 @@ export function placeUnitWithDirection(direction) {
     else window.addLog(`Элемент ослабляет ${cardData.name}: HP ${before}→${unit.currentHP}`);
   }
   let alive = unit.currentHP > 0;
+  if (alive && cardData.diesOnElement && cellElement === cardData.diesOnElement) {
+    window.addLog(`${cardData.name} погибает на поле стихии ${cardData.diesOnElement}!`);
+    alive = false;
+  }
   if (alive && cardData.diesOffElement && cellElement !== cardData.diesOffElement) {
     window.addLog(`${cardData.name} погибает вдали от стихии ${cardData.diesOffElement}!`);
     alive = false;

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -262,5 +262,28 @@ describe('новые механики', () => {
     const cells = computeFieldquakeLockedCells(state);
     expect(cells.length).toBe(8);
   });
+
+  it('Flame Guard пробивает и атакует две клетки вперёд', () => {
+    const state = makeState();
+    state.board[2][1].unit = { owner:0, tplId:'FIRE_PARTMOLE_FLAME_GUARD', facing:'N' };
+    state.board[1][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'S', currentHP:1 };
+    state.board[0][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'S', currentHP:1 };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    expect(fin.n1.board[1][1].unit).toBeNull();
+    expect(fin.n1.board[0][1].unit).toBeNull();
+  });
+
+  it('Fire Oracle лечит союзников при гибели от магии', () => {
+    CARDS.TEST_MAGIC = { id:'TEST_MAGIC', name:'Test Mage', type:'UNIT', cost:0, element:'FIRE', atk:2, hp:1, attackType:'MAGIC', attacks:[{ dir:'N', ranges:[1] }] };
+    const state = makeState();
+    state.board[2][1].unit = { owner:0, tplId:'TEST_MAGIC', facing:'N', currentHP:1 };
+    state.board[1][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FIRE_ORACLE', facing:'S', currentHP:1 };
+    state.board[0][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'S', currentHP:1 };
+    const res = magicAttack(state,2,1,1,1);
+    const healed = res.n1.board[0][1].unit;
+    expect(healed.currentHP).toBeGreaterThan(1);
+    delete CARDS.TEST_MAGIC;
+  });
 });
 


### PR DESCRIPTION
## Summary
- Animate double attack units twice before retaliation and keep counterattack after the second strike
- Add piercing double-front attack for Partmole Flame Guard and show both affected cells
- Rework field lock visual to subtler padlock and fix on-death heal for Fire Oracle and Granvenoa water weakness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c67f47d4188330a3b9cea64473c327