### PR TITLE
feat: улучшенные боевые и визуальные эффекты

### DIFF
--- a/cards_set1_fire_water.txt
+++ b/cards_set1_fire_water.txt
@@ -58,7 +58,7 @@ const CARDS = {
   FIRE_GREAT_MINOS: {
     id: 'FIRE_GREAT_MINOS', name: 'Great Minos of Sciondar', type: 'UNIT',
     cost: 3, activation: 2, element: 'FIRE', atk: 2, hp: 1,
-    pattern: 'FRONT', range: 2, attackType: 'MELEE', blindspots: ['S'],
+    pattern: 'FRONT', range: 2, attackType: 'MELEE', blindspots: ['S'], pierce: true,
     dodge50: true, activationReduction: 1, diesOffElement: 'FIRE',
     desc: 'Perfect Dodge. The activation cost to attack is 1 less. Destroy Great Minos if he is on a non‑Fire field.'
   },
@@ -80,7 +80,7 @@ const CARDS = {
     id: 'FIRE_LESSER_GRANVENOA', name: 'Lesser Granvenoa', type: 'UNIT',
     cost: 4, activation: 2, element: 'FIRE', atk: 2, hp: 4,
     pattern: 'ALL', range: 1, attackType: 'MELEE', blindspots: [],
-    fortress: true, diesOffElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
+    fortress: true, diesOnElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
     desc: 'Fortress. Adjacent fields cannot be field‑quaked or exchanged. Destroy Lesser Granvenoa if it is on a Water field.'
   },
   FIRE_PARTMOLE_FIRE_ORACLE: {

--- a/index.html
+++ b/index.html
@@ -643,9 +643,16 @@
         if (firstTargetMesh) {
           const dir = new THREE.Vector3().subVectors(firstTargetMesh.position, aMesh.position).normalize();
           const push = { x: dir.x * 0.6, z: dir.z * 0.6 };
+          const attackerUnit = gameState.board?.[r]?.[c]?.unit;
+          const tplA = attackerUnit ? CARDS[attackerUnit.tplId] : null;
+          const doubleAtk = tplA?.doubleAttack;
           const tl = gsap.timeline({ onComplete: doStep1 });
           tl.to(aMesh.position, { x: `+=${push.x}`, z: `+=${push.z}`, duration: 0.22, ease: 'power2.out' })
             .to(aMesh.position, { x: `-=${push.x}`, z: `-=${push.z}`, duration: 0.3, ease: 'power2.inOut' });
+          if (doubleAtk) {
+            tl.to(aMesh.position, { x: `+=${push.x}`, z: `+=${push.z}`, duration: 0.22, ease: 'power2.out' })
+              .to(aMesh.position, { x: `-=${push.x}`, z: `-=${push.z}`, duration: 0.3, ease: 'power2.inOut' });
+          }
           // Онлайновая синхронизация выпадов (атакующий и цели)
           try {
             const shouldSend = (typeof window !== 'undefined' && window.socket && (typeof NET_ACTIVE !== 'undefined' ? NET_ACTIVE : false) && (typeof MY_SEAT !== 'undefined' ? MY_SEAT : null) === gameState.active);

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -85,6 +85,7 @@ export const CARDS = {
     element: 'FIRE', atk: 1, hp: 3,
     attackType: 'STANDARD',
     attacks: [ { dir: 'N', ranges: [1,2] } ],
+    pierce: true,
     blindspots: ['S'],
     plusAtkIfTargetOnElement: { element: 'WATER', amount: 2 },
     desc: 'Adds 2 to its Attack if at least one target creature is on a water field.'
@@ -100,7 +101,7 @@ export const CARDS = {
       { dir: 'S', ranges: [1] },
       { dir: 'W', ranges: [1] }
     ],
-    blindspots: [], fortress: true, diesOffElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
+    blindspots: [], fortress: true, diesOnElement: 'WATER', fieldquakeLock: { type: 'ADJACENT' },
     desc: 'Fortress. Adjacent fields cannot be field‑quaked or exchanged. Destroy Lesser Granvenoa if it is on a Water field.'
   },
 

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -455,6 +455,23 @@ export function magicAttack(state, fr, fc, tr, tc) {
       }
     }
   } catch {}
+  for (const d of deaths) {
+    const tplD = CARDS[d.tplId];
+    if (tplD?.onDeathHealAll) {
+      for (let rr = 0; rr < 3; rr++) {
+        for (let cc = 0; cc < 3; cc++) {
+          const ally = n1.board[rr][cc]?.unit;
+          if (!ally || ally.owner !== d.owner) continue;
+          const tplAlly = CARDS[ally.tplId];
+          const buff = computeCellBuff(n1.board[rr][cc].element, tplAlly.element);
+          const maxHP = (tplAlly.hp || 0) + buff.hp;
+          const before = ally.currentHP ?? tplAlly.hp;
+          ally.currentHP = Math.min(maxHP, before + tplD.onDeathHealAll);
+        }
+      }
+      logLines.push(`${tplD.name}: союзники получают +${tplD.onDeathHealAll} HP`);
+    }
+  }
   attacker.lastAttackTurn = n1.turn;
   const cellEl = n1.board?.[fr]?.[fc]?.element;
   attacker.apSpent = (attacker.apSpent || 0) + attackCost(tplA, cellEl);

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -512,6 +512,9 @@
       const targetPos = tileMeshes[first.r][first.c].position;
       const dir = new THREE.Vector3().subVectors(targetPos, aMesh.position).normalize();
       const push = { x: dir.x * 0.6, z: dir.z * 0.6 };
+      const unit = gameState?.board?.[attacker.r]?.[attacker.c]?.unit;
+      const tpl = unit ? (typeof window !== 'undefined' ? window.CARDS?.[unit.tplId] : null) : null;
+      const doubleAtk = tpl?.doubleAttack;
       // Wrap target mesh into a transient group to ensure movement is visible
       const parent = aMesh.parent; if (!parent) return false;
       const fromPos = aMesh.position.clone();
@@ -525,10 +528,16 @@
       }});
       tl.to(wrapper.position, { x: toPos.x, z: toPos.z, duration: 0.22, ease: 'power2.out' })
         .to(wrapper.position, { x: fromPos.x, z: fromPos.z, duration: 0.30, ease: 'power2.inOut' });
-      __REMOTE_BATTLE_ANIM_UNTIL = Date.now() + 720; try { window.__REMOTE_BATTLE_ANIM_UNTIL = __REMOTE_BATTLE_ANIM_UNTIL; } catch {}
+      if (doubleAtk) {
+        tl.to(wrapper.position, { x: toPos.x, z: toPos.z, duration: 0.22, ease: 'power2.out' })
+          .to(wrapper.position, { x: fromPos.x, z: fromPos.z, duration: 0.30, ease: 'power2.inOut' });
+      }
+      const totalDur = doubleAtk ? 1440 : 720;
+      __REMOTE_BATTLE_ANIM_UNTIL = Date.now() + totalDur; try { window.__REMOTE_BATTLE_ANIM_UNTIL = __REMOTE_BATTLE_ANIM_UNTIL; } catch {}
       
       // Тряска цели и синхронный урон для неинициатора
-      setTimeout(() => {
+        const shakeDelay = doubleAtk ? 840 : 420;
+        setTimeout(() => {
         try {
           for (const target of targets) {
             const tMesh = unitMeshes.find(m => m.userData.row === target.r && m.userData.col === target.c);
@@ -543,7 +552,7 @@
             }
           }
         } catch {}
-      }, 420);
+        }, shakeDelay);
       
       return true;
     } catch { return false; }

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -258,6 +258,7 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
   const map = { N: [-1,0], E:[0,1], S:[1,0], W:[0,-1] };
   for (const a of attacks) {
     const isChoice = cardData.chooseDir || a.mode === 'ANY';
+    const multi = (a.ranges || []).length > 1 && a.mode !== 'ANY';
     const minDist = Math.min(...(a.ranges || [1]));
     for (const dist of a.ranges || []) {
       const vec = map[a.dir];
@@ -270,7 +271,7 @@ function drawAttacksGrid(ctx, cardData, x, y, cell, gap) {
       ctx.fillStyle = 'rgba(56,189,248,0.35)';
       ctx.fillRect(cx, cy, cell, cell);
       // красная рамка только если направление фиксировано
-      const mustHit = (!isChoice) && dist === minDist;
+      const mustHit = (!isChoice) && (multi ? true : dist === minDist);
       ctx.strokeStyle = mustHit ? '#ef4444' : 'rgba(56,189,248,0.6)';
       ctx.lineWidth = 1.5;
       ctx.strokeRect(cx + 0.5, cy + 0.5, cell - 1, cell - 1);

--- a/src/scene/fieldLockEffect.js
+++ b/src/scene/fieldLockEffect.js
@@ -1,88 +1,52 @@
-// Визуальный эффект для клеток, защищённых от fieldquake/exchange
-// Основан на эффекте подсветки, но имеет иной цвет и форму
+// Визуальный эффект для защищённых клеток (fieldquake/exchange lock)
+// Показывает полупрозрачный силуэт замка, который мягко пульсирует
+// Логика отделена от вычислений: сюда не передаются игровые состояния,
+// только координаты уже вычисленных защищённых клеток
+
 import { getCtx } from './context.js';
 
 const state = {
-  tiles: [],
-  uniforms: [],
-  rafId: 0,
+  sprites: [],
+  texture: null,
 };
 
-function createLockMaterial(origMat, THREE) {
-  const mat = origMat.clone();
-  mat.transparent = true;
-  mat.onBeforeCompile = (shader) => {
-    shader.uniforms.uTime = { value: 0 };
-    shader.vertexShader = shader.vertexShader
-      .replace('#include <common>', '#include <common>\nvarying vec2 vUv;')
-      .replace('#include <uv_vertex>', '#include <uv_vertex>\n vUv = uv;');
-    const head = `\n varying vec2 vUv;\n uniform float uTime;\n`;
-    shader.fragmentShader = shader.fragmentShader
-      .replace('#include <common>', '#include <common>' + head)
-      .replace(
-        '#include <dithering_fragment>',
-        `#include <dithering_fragment>\n{
-          float pulse = sin(uTime*3.0)*0.5+0.5;
-          vec2 centered = vUv*2.0-1.0;
-          float ring = smoothstep(0.4,0.38, length(centered));
-          vec3 glow = vec3(1.0,0.6,0.1)*ring*(0.6+0.4*pulse);
-          gl_FragColor.rgb += glow;
-          gl_FragColor.a = max(gl_FragColor.a, ring*pulse*0.9);
-        }`
-      );
-    state.uniforms.push(shader.uniforms.uTime);
-  };
-  return mat;
-}
-
-function startAnim() {
-  const start = (typeof performance !== 'undefined' ? performance.now() : Date.now());
-  function tick() {
-    const t = ((typeof performance !== 'undefined' ? performance.now() : Date.now()) - start) / 1000;
-    state.uniforms.forEach(u => { if (u) u.value = t; });
-    state.rafId = (typeof requestAnimationFrame !== 'undefined')
-      ? requestAnimationFrame(tick)
-      : setTimeout(tick, 16);
-  }
-  tick();
+function getTexture(THREE) {
+  if (state.texture) return state.texture;
+  state.texture = new THREE.TextureLoader().load('textures/lock.svg');
+  return state.texture;
 }
 
 export function showFieldLockTiles(cells = []) {
   const ctx = getCtx();
   const { tileMeshes, THREE } = ctx;
+  const gsap = (typeof window !== 'undefined') ? window.gsap : undefined;
   if (!tileMeshes || !THREE) return;
   clearFieldLockTiles();
+  const tex = getTexture(THREE);
   for (const { r, c } of cells) {
     const tile = tileMeshes?.[r]?.[c];
     if (!tile) continue;
-    tile.traverse(obj => {
-      if (obj.isMesh) {
-        obj.userData._lockOrigMat = obj.material;
-        obj.material = createLockMaterial(obj.material, THREE);
-      }
-    });
-    state.tiles.push(tile);
+    const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, opacity: 0.35, depthWrite: false });
+    const spr = new THREE.Sprite(mat);
+    spr.position.set(0, 1.01, 0); // немного над тайлом
+    spr.scale.set(0.8, 0.8, 0.8);
+    tile.add(spr);
+    if (gsap) {
+      gsap.to(mat, { opacity: 0.15, duration: 1, yoyo: true, repeat: -1, ease: 'sine.inOut' });
+    }
+    state.sprites.push({ tile, spr, mat });
   }
-  if (state.tiles.length) startAnim();
 }
 
 export function clearFieldLockTiles() {
-  if (state.rafId) {
-    if (typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(state.rafId);
-    else clearTimeout(state.rafId);
-    state.rafId = 0;
+  const gsap = (typeof window !== 'undefined') ? window.gsap : undefined;
+  for (const { tile, spr, mat } of state.sprites) {
+    try { if (gsap) gsap.killTweensOf(mat); } catch {}
+    try { tile.remove(spr); } catch {}
+    try { mat.map?.dispose(); mat.dispose(); } catch {}
   }
-  state.uniforms = [];
-  state.tiles.forEach(tile => {
-    tile.traverse(obj => {
-      if (obj.isMesh && obj.userData._lockOrigMat) {
-        try { obj.material.dispose(); } catch {}
-        obj.material = obj.userData._lockOrigMat;
-        delete obj.userData._lockOrigMat;
-      }
-    });
-  });
-  state.tiles = [];
+  state.sprites = [];
 }
 
 export default { showFieldLockTiles, clearFieldLockTiles };
+

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -528,6 +528,10 @@ export function placeUnitWithDirection(direction) {
     else window.addLog(`Элемент ослабляет ${cardData.name}: HP ${before}→${unit.currentHP}`);
   }
   let alive = unit.currentHP > 0;
+  if (alive && cardData.diesOnElement && cellElement === cardData.diesOnElement) {
+    window.addLog(`${cardData.name} погибает на поле стихии ${cardData.diesOnElement}!`);
+    alive = false;
+  }
   if (alive && cardData.diesOffElement && cellElement !== cardData.diesOffElement) {
     window.addLog(`${cardData.name} погибает вдали от стихии ${cardData.diesOffElement}!`);
     alive = false;


### PR DESCRIPTION
## Summary
- Удвоена анимация удара для карт с двойной атакой и синхронизирована контратака
- Обновлён эффект защиты поля — теперь это пульсирующий силуэт замка
- Flame Guard пробивает две клетки вперёд; Lesser Granvenoa уязвим лишь на воде и исправлен бонус Fire Oracle при магической смерти

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c67f47d4188330a3b9cea64473c327