### PR TITLE
feat: enhance field lock visuals and oracle death heal

### DIFF
--- a/src/scene/fieldLockEffect.js
+++ b/src/scene/fieldLockEffect.js
@@ -24,12 +24,16 @@ export function showFieldLockTiles(cells = []) {
   for (const { r, c } of cells) {
     const tile = tileMeshes?.[r]?.[c];
     if (!tile) continue;
-    const mat = new THREE.SpriteMaterial({ map: tex, color: 0xf97316, transparent: true, opacity: 0.25 });
+    // делаем замок менее прозрачным и смещаем в верхний правый угол клетки
+    const mat = new THREE.SpriteMaterial({ map: tex, color: 0xf97316, transparent: true, opacity: 0.6 });
     const spr = new THREE.Sprite(mat);
-    spr.position.copy(tile.position).add(new THREE.Vector3(0, 0.52, 0));
-    spr.scale.set(0.8, 0.8, 0.8);
+    // небольшое смещение по горизонтали, чтобы иконка была видна под существом
+    spr.position.copy(tile.position).add(new THREE.Vector3(0.35, 0.32, -0.35));
+    // меньший размер, чтобы уместиться в углу
+    spr.scale.set(0.4, 0.4, 0.4);
     effectsGroup.add(spr);
-    try { window.gsap?.to(mat, { opacity: 0.05, duration: 0.8, yoyo: true, repeat: -1 }); } catch {}
+    // мигаем между 0.3 и 0.6, чтобы привлечь внимание, но не перекрывать существо
+    try { window.gsap?.to(mat, { opacity: 0.3, duration: 0.8, yoyo: true, repeat: -1 }); } catch {}
     state.sprites.push(spr);
   }
 }

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -539,6 +539,7 @@ export function placeUnitWithDirection(direction) {
   if (!alive) {
     // обработка эффектов при смерти (например, лечение союзников)
     if (cardData.onDeathAddHPAll) {
+      const { unitMeshes } = getCtx();
       for (let rr = 0; rr < 3; rr++) {
         for (let cc = 0; cc < 3; cc++) {
           const ally = gameState.board?.[rr]?.[cc]?.unit;
@@ -551,6 +552,11 @@ export function placeUnitWithDirection(direction) {
           const maxHP = (tplAlly.hp || 0) + buff2.hp + (ally.bonusHP || 0);
           const before = ally.currentHP ?? tplAlly.hp;
           ally.currentHP = Math.min(maxHP, before + amount);
+          // показываем всплывающий текст лечения над союзником
+          try {
+            const tMesh = unitMeshes.find(m => m.userData.row === rr && m.userData.col === cc);
+            if (tMesh) window.__fx?.spawnDamageText(tMesh, `+${amount}`, '#22c55e');
+          } catch {}
         }
       }
       window.addLog(`${cardData.name}: союзники получают +${cardData.onDeathAddHPAll} HP`);


### PR DESCRIPTION
## Summary
- переместил и сделал менее прозрачной иконку fieldquake lock
- добавил всплывающий зеленый `+1` при смерти Оракула для всех союзников

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c69afa926c8330bf31814c6551ec99