### PR TITLE
Improve field lock icon visibility and oracle heal feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,19 +610,23 @@
             for (const d of res.deaths) {
               try { gameState.players[d.owner].graveyard.push(CARDS[d.tplId]); } catch {}
               const deadMesh = unitMeshes.find(m => m.userData.row === d.r && m.userData.col === d.c);
-              if (deadMesh) {
-                const fromMesh = aMesh || deadMesh;
-                const dirUp = new THREE.Vector3().subVectors(deadMesh.position, fromMesh.position).normalize().multiplyScalar(0.4);
-                window.__fx.dissolveAndAsh(deadMesh, dirUp, 0.9);
-              }
-              // Орб маны появляется с задержкой 400мс после начала анимации смерти
-              setTimeout(() => {
-                const p = tileMeshes[d.r][d.c].position.clone().add(new THREE.Vector3(0, 1.6, 0));
-                // Показать визуальный орб у обоих игроков; фактическое начисление маны уже в res.n1
-                animateManaGainFromWorld(p, d.owner, true);
-              }, 400);
+            if (deadMesh) {
+              const fromMesh = aMesh || deadMesh;
+              const dirUp = new THREE.Vector3().subVectors(deadMesh.position, fromMesh.position).normalize().multiplyScalar(0.4);
+              window.__fx.dissolveAndAsh(deadMesh, dirUp, 0.9);
             }
-            if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
+            // Орб маны появляется с задержкой 400мс после начала анимации смерти
+            setTimeout(() => {
+              const p = tileMeshes[d.r][d.c].position.clone().add(new THREE.Vector3(0, 1.6, 0));
+              // Показать визуальный орб у обоих игроков; фактическое начисление маны уже в res.n1
+              animateManaGainFromWorld(p, d.owner, true);
+            }, 400);
+            const tplDead = CARDS[d.tplId];
+            if (tplDead?.onDeathAddHPAll) {
+              window.__interactions?.showOracleDeathBuff?.(d.owner, tplDead.onDeathAddHPAll);
+            }
+          }
+          if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
             setTimeout(() => {
               updateUnits(); updateUI();
               for (const l of res.logLines.reverse()) addLog(l);
@@ -728,6 +732,10 @@
             // Только визуальный орб; фактическое начисление — в res.n1
             animateManaGainFromWorld(p, d.owner, true);
           }, 400);
+          const tplDead = CARDS[d.tplId];
+          if (tplDead?.onDeathAddHPAll) {
+            window.__interactions?.showOracleDeathBuff?.(d.owner, tplDead.onDeathAddHPAll);
+          }
         }
         gameState = res.n1;
         try { window.applyGameState(gameState); } catch {}

--- a/src/scene/fieldLockEffect.js
+++ b/src/scene/fieldLockEffect.js
@@ -24,12 +24,23 @@ export function showFieldLockTiles(cells = []) {
   for (const { r, c } of cells) {
     const tile = tileMeshes?.[r]?.[c];
     if (!tile) continue;
-    const mat = new THREE.SpriteMaterial({ map: tex, color: 0xf97316, transparent: true, opacity: 0.25 });
+
+    // изначально почти прозрачный замок
+    const mat = new THREE.SpriteMaterial({ map: tex, color: 0xf97316, transparent: true, opacity: 0.2 });
     const spr = new THREE.Sprite(mat);
-    spr.position.copy(tile.position).add(new THREE.Vector3(0, 0.52, 0));
-    spr.scale.set(0.8, 0.8, 0.8);
+
+    // смещаем иконку ещё ближе к углу и чуть выше, чтобы её не закрывала карта
+    const tileSize = tile.geometry?.parameters?.width || 1;
+    const iconSize = 0.8;
+    const offset = tileSize / 2 - iconSize / 2;
+    const extra = iconSize * 0.15;
+    spr.position.copy(tile.position).add(new THREE.Vector3(offset + extra, 0.8, -(offset + extra)));
+    spr.scale.set(iconSize, iconSize, iconSize);
+    spr.renderOrder = 1300; // поверх карт на поле
     effectsGroup.add(spr);
-    try { window.gsap?.to(mat, { opacity: 0.05, duration: 0.8, yoyo: true, repeat: -1 }); } catch {}
+
+    // пульсация почти до полной непрозрачности
+    try { window.gsap?.to(mat, { opacity: 0.95, duration: 0.8, yoyo: true, repeat: -1 }); } catch {}
     state.sprites.push(spr);
   }
 }


### PR DESCRIPTION
## Summary
- strengthen field lock icon pulse and move above creatures for clarity
- show green `+1` above allies when Oracle dies in any scenario

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c69afa926c8330bf31814c6551ec99