### PR TITLE
Improve field lock icon visibility and oracle heal feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,6 +621,21 @@
                 // Показать визуальный орб у обоих игроков; фактическое начисление маны уже в res.n1
                 animateManaGainFromWorld(p, d.owner, true);
               }, 400);
+
+              // если погибший юнит усиливает союзников при смерти — показываем зелёные +1
+              const tplD = CARDS[d.tplId];
+              if (tplD && tplD.onDeathAddHPAll) {
+                const amount = tplD.onDeathAddHPAll;
+                for (let rr = 0; rr < 3; rr++) {
+                  for (let cc = 0; cc < 3; cc++) {
+                    if (rr === d.r && cc === d.c) continue;
+                    const ally = gameState.board?.[rr]?.[cc]?.unit;
+                    if (!ally || ally.owner !== d.owner) continue;
+                    const tMesh = unitMeshes.find(m => m.userData.row === rr && m.userData.col === cc);
+                    if (tMesh) window.__fx.spawnDamageText(tMesh, `+${amount}`, '#22c55e');
+                  }
+                }
+              }
             }
             if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
             setTimeout(() => {
@@ -728,6 +743,21 @@
             // Только визуальный орб; фактическое начисление — в res.n1
             animateManaGainFromWorld(p, d.owner, true);
           }, 400);
+
+          // усиливаем союзников при смерти соответствующего юнита
+          const tplD = CARDS[d.tplId];
+          if (tplD && tplD.onDeathAddHPAll) {
+            const amount = tplD.onDeathAddHPAll;
+            for (let rr = 0; rr < 3; rr++) {
+              for (let cc = 0; cc < 3; cc++) {
+                if (rr === d.r && cc === d.c) continue;
+                const ally = gameState.board?.[rr]?.[cc]?.unit;
+                if (!ally || ally.owner !== d.owner) continue;
+                const tMesh = unitMeshes.find(m => m.userData.row === rr && m.userData.col === cc);
+                if (tMesh) window.__fx.spawnDamageText(tMesh, `+${amount}`, '#22c55e');
+              }
+            }
+          }
         }
         gameState = res.n1;
         try { window.applyGameState(gameState); } catch {}

--- a/src/scene/fieldLockEffect.js
+++ b/src/scene/fieldLockEffect.js
@@ -24,12 +24,38 @@ export function showFieldLockTiles(cells = []) {
   for (const { r, c } of cells) {
     const tile = tileMeshes?.[r]?.[c];
     if (!tile) continue;
-    const mat = new THREE.SpriteMaterial({ map: tex, color: 0xf97316, transparent: true, opacity: 0.25 });
+
+    // менее прозрачный замок с отключённым тестом глубины, чтобы он был поверх карты
+    const mat = new THREE.SpriteMaterial({
+      map: tex,
+      color: 0xf97316,
+      transparent: true,
+      opacity: 0.25,
+      depthTest: false,
+      depthWrite: false,
+    });
     const spr = new THREE.Sprite(mat);
-    spr.position.copy(tile.position).add(new THREE.Vector3(0, 0.52, 0));
-    spr.scale.set(0.8, 0.8, 0.8);
+
+    // поднимаем иконку выше и ещё чуть сдвигаем вправо/вперёд
+    const tileSize = tile.geometry?.parameters?.width || 1;
+    const iconSize = 0.8;
+    const offset = tileSize / 2 - iconSize / 2;
+    const extra = tileSize * 0.05;
+    spr.position.copy(tile.position).add(new THREE.Vector3(offset + extra, 1.4, -offset - extra));
+    spr.scale.set(iconSize, iconSize, iconSize);
+    spr.renderOrder = 1500;
     effectsGroup.add(spr);
-    try { window.gsap?.to(mat, { opacity: 0.05, duration: 0.8, yoyo: true, repeat: -1 }); } catch {}
+
+    // пульсация почти до полной непрозрачности
+    try {
+      window.gsap?.to(mat, {
+        opacity: 0.95,
+        duration: 0.8,
+        yoyo: true,
+        repeat: -1,
+        ease: 'sine.inOut',
+      });
+    } catch {}
     state.sprites.push(spr);
   }
 }


### PR DESCRIPTION
## Summary
- amplify field lock icon pulse and raise it above tiles
- show floating green `+1` above allies when Oracle dies in battle or by magic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c69afa926c8330bf31814c6551ec99