### PR TITLE
feat: add deck editor frontend

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,7 @@ import { attachUIEvents } from './ui/domEvents.js';
 import * as BattleSplash from './ui/battleSplash.js';
 import * as DeckSelect from './ui/deckSelect.js';
 import * as MainMenu from './ui/mainMenu.js';
+import * as DeckBuilder from './ui/deckBuilder.js';
 import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
@@ -185,6 +186,7 @@ try {
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
   window.__ui.deckSelect = DeckSelect;
+  window.__ui.deckBuilder = DeckBuilder;
   window.__ui.mainMenu = MainMenu;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;

--- a/src/ui/deckBuilder.js
+++ b/src/ui/deckBuilder.js
@@ -1,0 +1,266 @@
+// Редактор колод: фронтенд без проверки ограничений
+import { CARDS } from '../core/cards.js';
+import { DECKS, saveUserDecks } from '../core/decks.js';
+
+const ELEMENTS = ['FIRE','WATER','EARTH','FOREST','BIOLITH'];
+const MAX_COPIES = 3;
+
+// Простая нечёткая проверка
+function fuzzyIncludes(text, term) {
+  return text.toLowerCase().includes(term.toLowerCase());
+}
+
+export function open(deck = null, onDone) {
+  if (typeof document === 'undefined') return;
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 bg-black bg-opacity-60 z-50 flex';
+
+  // Состояние редактируемой колоды
+  const working = deck ? { ...deck } : { id: 'CUSTOM_' + Date.now(), name: '', description: '', cards: [], builtIn: false };
+  const counts = {};
+  (deck ? deck.cards : []).forEach(c => { counts[c.id] = (counts[c.id]||0)+1; });
+
+  // Фильтры
+  const elFilter = new Set(ELEMENTS);
+  const typeFilter = new Set();
+  const summonFilter = new Set();
+  const actionFilter = new Set();
+  let search = '';
+
+  // ЛЕВАЯ ПАНЕЛЬ (колода)
+  const left = document.createElement('div');
+  left.className = 'w-64 bg-slate-800 p-3 flex flex-col';
+  overlay.appendChild(left);
+
+  const nameInput = document.createElement('input');
+  nameInput.className = 'mb-2 p-1 text-sm text-black';
+  nameInput.placeholder = 'Deck name';
+  nameInput.value = working.name || '';
+  left.appendChild(nameInput);
+
+  const deckList = document.createElement('div');
+  deckList.className = 'flex-1 overflow-y-auto space-y-2 pr-1';
+  left.appendChild(deckList);
+
+  function updateSummary() {
+    const total = Object.values(counts).reduce((a,b)=>a+b,0);
+    summary.textContent = `${total}/20 cards`;
+  }
+
+  function rebuildDeckList() {
+    deckList.innerHTML = '';
+    // группировка по стоимости
+    const groups = {};
+    Object.entries(counts).forEach(([id,cnt]) => {
+      const card = CARDS[id];
+      const cost = card.cost || 0;
+      (groups[cost] = groups[cost] || []).push({card, cnt});
+    });
+    Object.keys(groups).sort((a,b)=>a-b).forEach(cost => {
+      const group = document.createElement('div');
+      const gtitle = document.createElement('div');
+      gtitle.className = 'text-xs text-slate-300 mt-2';
+      gtitle.textContent = `Cost ${cost}`;
+      group.appendChild(gtitle);
+      groups[cost].forEach(({card,cnt}) => {
+        const row = document.createElement('div');
+        row.className = 'flex items-center h-10 cursor-pointer hover:bg-slate-700 rounded';
+        // узкая полоска изображения
+        const img = document.createElement('img');
+        img.src = `card images/${card.id}.png`;
+        img.className = 'w-10 h-full object-cover object-center';
+        row.appendChild(img);
+        // название
+        const nm = document.createElement('div');
+        nm.className = 'flex-1 pl-2 truncate';
+        nm.textContent = card.name;
+        row.appendChild(nm);
+        // стоимости
+        const costWrap = document.createElement('div');
+        costWrap.className = 'flex gap-1 pr-2 text-xs';
+        const sCost = document.createElement('span');
+        sCost.className = 'px-1 bg-slate-600 rounded';
+        sCost.textContent = card.cost ?? 0;
+        const aCost = document.createElement('span');
+        aCost.className = 'px-1 bg-slate-600 rounded';
+        aCost.textContent = card.activation ?? 0;
+        costWrap.appendChild(sCost); costWrap.appendChild(aCost);
+        row.appendChild(costWrap);
+        // счётчик
+        const cntDiv = document.createElement('div');
+        cntDiv.className = 'w-6 text-right pr-1';
+        cntDiv.textContent = cnt;
+        row.appendChild(cntDiv);
+        // tooltip
+        row.title = `${card.atk ?? '-'} / ${card.hp ?? '-'}\n${card.desc || ''}`;
+        // удаление по клику
+        row.addEventListener('click', () => {
+          if (counts[card.id]) {
+            counts[card.id]--;
+            if (counts[card.id] <= 0) delete counts[card.id];
+            rebuildDeckList(); updateSummary();
+          }
+        });
+        group.appendChild(row);
+      });
+      deckList.appendChild(group);
+    });
+    updateSummary();
+  }
+
+  const summary = document.createElement('div');
+  summary.className = 'mt-2 text-sm';
+  left.appendChild(summary);
+
+  const doneBtn = document.createElement('button');
+  doneBtn.className = 'mt-2 overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700';
+  doneBtn.textContent = 'Done';
+  doneBtn.addEventListener('click', () => {
+    working.name = nameInput.value || 'Untitled';
+    // разворачиваем counts в массив карт
+    working.cards = Object.entries(counts).flatMap(([id,c]) => Array(c).fill(CARDS[id]));
+    const idx = DECKS.findIndex(d => d.id === working.id);
+    if (idx >= 0) DECKS[idx] = working; else DECKS.push(working);
+    saveUserDecks();
+    try { document.body.removeChild(overlay); } catch {}
+    onDone && onDone(working);
+  });
+  left.appendChild(doneBtn);
+
+  // ЦЕНТРАЛЬНАЯ ПАНЕЛЬ (каталог)
+  const center = document.createElement('div');
+  center.className = 'flex-1 bg-slate-900 p-3 flex flex-col';
+  overlay.appendChild(center);
+
+  // верхняя панель фильтров
+  const topBar = document.createElement('div');
+  topBar.className = 'flex items-center gap-2 mb-3';
+  center.appendChild(topBar);
+
+  // выбор стихий
+  ELEMENTS.forEach(el => {
+    const chk = document.createElement('button');
+    chk.className = 'px-2 py-1 text-xs overlay-panel';
+    chk.textContent = el[0]; // первая буква как условная иконка
+    chk.dataset.el = el;
+    chk.classList.add('bg-slate-600');
+    chk.addEventListener('click', () => {
+      if (elFilter.has(el)) elFilter.delete(el); else elFilter.add(el);
+      chk.classList.toggle('opacity-50', !elFilter.has(el));
+      rebuildCatalog();
+    });
+    topBar.appendChild(chk);
+  });
+
+  // кнопка фильтров
+  const filterBtn = document.createElement('button');
+  filterBtn.className = 'px-2 py-1 text-xs overlay-panel bg-slate-600';
+  filterBtn.textContent = 'Filters';
+  topBar.appendChild(filterBtn);
+
+  // поиск
+  const searchInput = document.createElement('input');
+  searchInput.className = 'flex-1 p-1 text-black text-sm';
+  searchInput.placeholder = 'Search';
+  searchInput.addEventListener('input', () => { search = searchInput.value; rebuildCatalog(); });
+  topBar.appendChild(searchInput);
+
+  // оверлей фильтров
+  const filterOverlay = document.createElement('div');
+  filterOverlay.className = 'fixed inset-0 z-50 hidden items-center justify-center bg-black bg-opacity-60';
+  filterOverlay.innerHTML = `<div class="overlay-panel p-4 space-y-3">
+    <div class="text-sm font-semibold">By Type</div>
+    <label class="block text-sm"><input type="checkbox" id="flt-unit" class="mr-1">Units</label>
+    <label class="block text-sm mb-2"><input type="checkbox" id="flt-spell" class="mr-1">Spells</label>
+    <div class="text-sm font-semibold">By Summoning Cost</div>
+    <div id="flt-summon" class="flex flex-wrap gap-1 mb-2"></div>
+    <div class="text-sm font-semibold">By Action Cost</div>
+    <div id="flt-action" class="flex flex-wrap gap-1"></div>
+    <div class="text-right mt-3"><button id="flt-close" class="overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700">Close</button></div>
+  </div>`;
+  document.body.appendChild(filterOverlay);
+
+  filterBtn.addEventListener('click', ()=>{ filterOverlay.classList.remove('hidden'); });
+  filterOverlay.querySelector('#flt-close').addEventListener('click', ()=>{ filterOverlay.classList.add('hidden'); rebuildCatalog(); });
+  // заполнение блоков стоимостей
+  const summonWrap = filterOverlay.querySelector('#flt-summon');
+  const actionWrap = filterOverlay.querySelector('#flt-action');
+  const costOptions = [0,1,2,3,4,5,6,'7+'];
+  costOptions.forEach(c => {
+    const sBtn = document.createElement('button');
+    sBtn.className = 'overlay-panel px-2 py-1 text-xs bg-slate-600';
+    sBtn.textContent = c;
+    sBtn.addEventListener('click', () => { toggleCost(summonFilter,c,sBtn); });
+    summonWrap.appendChild(sBtn);
+    const aBtn = document.createElement('button');
+    aBtn.className = 'overlay-panel px-2 py-1 text-xs bg-slate-600';
+    aBtn.textContent = c;
+    aBtn.addEventListener('click', () => { toggleCost(actionFilter,c,aBtn); });
+    actionWrap.appendChild(aBtn);
+  });
+  function toggleCost(set,val,btn){
+    if(set.has(val)) set.delete(val); else set.add(val);
+    btn.classList.toggle('opacity-50', !set.has(val));
+  }
+  // чекбоксы типов
+  filterOverlay.querySelector('#flt-unit').addEventListener('change', e=>{ if(e.target.checked) typeFilter.add('UNIT'); else typeFilter.delete('UNIT'); });
+  filterOverlay.querySelector('#flt-spell').addEventListener('change', e=>{ if(e.target.checked) typeFilter.add('SPELL'); else typeFilter.delete('SPELL'); });
+
+  const catalog = document.createElement('div');
+  catalog.className = 'grid grid-cols-4 gap-2 flex-1 overflow-y-auto';
+  center.appendChild(catalog);
+
+  function cardPasses(card){
+    if (elFilter.size && !elFilter.has(card.element)) return false;
+    if (typeFilter.size && !typeFilter.has(card.type)) return false;
+    const sCost = card.cost || 0;
+    const aCost = card.activation || 0;
+    const sKey = sCost >=7 ? '7+' : sCost;
+    const aKey = aCost >=7 ? '7+' : aCost;
+    if (summonFilter.size && !summonFilter.has(sKey)) return false;
+    if (actionFilter.size && !actionFilter.has(aKey)) return false;
+    if (search && !fuzzyIncludes(card.name + ' ' + (card.desc||''), search)) return false;
+    return true;
+  }
+
+  function rebuildCatalog(){
+    catalog.innerHTML = '';
+    Object.values(CARDS).filter(cardPasses).forEach(card => {
+      const wrap = document.createElement('div');
+      wrap.className = 'relative cursor-pointer';
+      wrap.draggable = true;
+      const img = document.createElement('img');
+      img.src = `card images/${card.id}.png`;
+      img.className = 'w-full h-full object-cover';
+      wrap.appendChild(img);
+      wrap.addEventListener('click', () => addCard(card));
+      wrap.addEventListener('dragstart', e=>{ e.dataTransfer.setData('text/plain', card.id); });
+      catalog.appendChild(wrap);
+    });
+  }
+
+  function addCard(card){
+    const cur = counts[card.id]||0;
+    if (cur >= MAX_COPIES){ alert('Лимит копий достигнут'); return; }
+    counts[card.id] = cur+1;
+    rebuildDeckList();
+  }
+
+  // поддержка dnd в левую панель
+  deckList.addEventListener('dragover', e=>{ e.preventDefault(); });
+  deckList.addEventListener('drop', e=>{
+    e.preventDefault();
+    const id = e.dataTransfer.getData('text/plain');
+    const card = CARDS[id];
+    if(card) addCard(card);
+  });
+
+  rebuildDeckList();
+  rebuildCatalog();
+
+  document.body.appendChild(overlay);
+}
+
+const api = { open };
+try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.deckBuilder = api; } } catch {}
+export default api;

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -1,5 +1,5 @@
 // Меню выбора колоды
-import { DECKS } from '../core/decks.js';
+import { DECKS, removeDeck } from '../core/decks.js';
 
 function pickDeckImage(deck) {
   // выбираем самую дорогую по мане карту; при равенстве — случайная
@@ -10,7 +10,7 @@ function pickDeckImage(deck) {
   return `card images/${card.id}.png`;
 }
 
-export function open(onConfirm, onCancel) {
+export function open(onConfirm, onCancel, opts = {}) {
   if (typeof document === 'undefined') return;
   let selected = 0;
   const overlay = document.createElement('div');
@@ -18,7 +18,6 @@ export function open(onConfirm, onCancel) {
   overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60';
 
   const panel = document.createElement('div');
-  // делаем панель шире примерно на 30%
   panel.className = 'bg-slate-800 p-4 rounded-lg w-[26rem] max-h-[90vh] flex flex-col shadow-2xl';
   overlay.appendChild(panel);
 
@@ -28,51 +27,65 @@ export function open(onConfirm, onCancel) {
   panel.appendChild(title);
 
   const list = document.createElement('div');
-  // ограничиваем высоту списка и добавляем отступы, чтобы карточки не вылезали за край
   list.className = 'flex-1 overflow-y-auto space-y-3 px-2 max-h-64 deck-scroll';
   panel.appendChild(list);
 
-  DECKS.forEach((d, idx) => {
-    const item = document.createElement('div');
-    // Небольшой горизонтальный отступ оставляет место для эффекта увеличения
-    item.className = 'relative flex h-24 cursor-pointer rounded-md overflow-hidden border-2 border-slate-700 transition transform hover:bg-slate-700/30 hover:scale-[1.02] mx-1';
-    if (idx === selected) item.classList.add('border-yellow-400');
+  const renderList = () => {
+    list.innerHTML = '';
+    DECKS.forEach((d, idx) => {
+      const item = document.createElement('div');
+      item.className = 'relative flex h-24 cursor-pointer rounded-md overflow-hidden border-2 border-slate-700 transition transform hover:bg-slate-700/30 hover:scale-[1.02] mx-1';
+      if (idx === selected) item.classList.add('border-yellow-400');
 
-    const imgWrap = document.createElement('div');
-    imgWrap.className = 'relative w-40 h-full flex-shrink-0 overflow-hidden';
-    const img = document.createElement('img');
-    img.src = pickDeckImage(d);
-    img.className = 'w-full h-full object-cover';
-    imgWrap.appendChild(img);
-    const fade = document.createElement('div');
-    fade.className = 'absolute inset-0 bg-gradient-to-r from-transparent to-slate-800';
-    imgWrap.appendChild(fade);
-    item.appendChild(imgWrap);
+      const imgWrap = document.createElement('div');
+      imgWrap.className = 'relative w-40 h-full flex-shrink-0 overflow-hidden';
+      const img = document.createElement('img');
+      img.src = pickDeckImage(d);
+      img.className = 'w-full h-full object-cover';
+      imgWrap.appendChild(img);
+      const fade = document.createElement('div');
+      fade.className = 'absolute inset-0 bg-gradient-to-r from-transparent to-slate-800';
+      imgWrap.appendChild(fade);
+      item.appendChild(imgWrap);
 
-    const text = document.createElement('div');
-    text.className = 'pl-4 pr-2 flex flex-col justify-center';
-    const nm = document.createElement('div');
-    nm.className = 'font-semibold';
-    nm.textContent = d.name;
-    const ds = document.createElement('div');
-    ds.className = 'text-sm text-slate-300';
-    ds.textContent = d.description;
-    text.appendChild(nm); text.appendChild(ds);
-    item.appendChild(text);
+      const text = document.createElement('div');
+      text.className = 'pl-4 pr-2 flex flex-col justify-center';
+      const nm = document.createElement('div');
+      nm.className = 'font-semibold';
+      nm.textContent = d.name;
+      const ds = document.createElement('div');
+      ds.className = 'text-sm text-slate-300';
+      ds.textContent = d.description;
+      text.appendChild(nm); text.appendChild(ds);
+      item.appendChild(text);
 
-    item.addEventListener('click', () => {
-      selected = idx;
-      [...list.children].forEach((el, i) => {
-        el.classList.toggle('border-yellow-400', i === selected);
-        el.classList.toggle('border-slate-700', i !== selected);
+      item.addEventListener('click', () => {
+        selected = idx;
+        [...list.children].forEach((el, i) => {
+          el.classList.toggle('border-yellow-400', i === selected);
+          el.classList.toggle('border-slate-700', i !== selected);
+        });
       });
+      list.appendChild(item);
     });
-    list.appendChild(item);
-  });
+  };
+
+  renderList();
 
   const btnWrap = document.createElement('div');
-  btnWrap.className = 'flex justify-end gap-2 mt-4';
+  btnWrap.className = 'flex justify-end gap-2 mt-4 flex-wrap';
   panel.appendChild(btnWrap);
+
+  if (opts.onCreate) {
+    const createBtn = document.createElement('button');
+    createBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors mr-auto';
+    createBtn.textContent = 'Create New Deck';
+    createBtn.addEventListener('click', () => {
+      try { document.body.removeChild(overlay); } catch {}
+      opts.onCreate();
+    });
+    btnWrap.appendChild(createBtn);
+  }
 
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
@@ -88,6 +101,35 @@ export function open(onConfirm, onCancel) {
     onConfirm && onConfirm(DECKS[selected]);
   });
   btnWrap.appendChild(okBtn);
+
+  if (opts.onEdit) {
+    const editBtn = document.createElement('button');
+    editBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
+    editBtn.textContent = 'Edit';
+    editBtn.addEventListener('click', () => {
+      try { document.body.removeChild(overlay); } catch {}
+      opts.onEdit(DECKS[selected]);
+    });
+    btnWrap.appendChild(editBtn);
+  }
+
+  if (opts.onDelete) {
+    const delBtn = document.createElement('button');
+    delBtn.className = 'overlay-panel px-3 py-1.5 bg-red-600 hover:bg-red-700 glossy-btn transition-colors';
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => {
+      const d = DECKS[selected];
+      if (d.builtIn) {
+        alert('Нельзя удалить встроенную колоду');
+        return;
+      }
+      removeDeck(d.id);
+      selected = 0;
+      renderList();
+      opts.onDelete && opts.onDelete(d);
+    });
+    btnWrap.appendChild(delBtn);
+  }
 
   document.body.appendChild(overlay);
 }

--- a/src/ui/mainMenu.js
+++ b/src/ui/mainMenu.js
@@ -87,7 +87,20 @@ export function open(initial = false) {
     }
   });
 
-  addBtn('mm-deck', 'Deck Builder', () => {}, true);
+  addBtn('mm-deck', 'Deck Builder', () => {
+    close();
+    const ds = window.__ui?.deckSelect;
+    const openMenu = () => open(true);
+    const openSelect = () => {
+      const opts = {
+        onEdit: d => window.__ui?.deckBuilder?.open(d, openSelect),
+        onCreate: () => window.__ui?.deckBuilder?.open(null, openSelect),
+        onDelete: () => openSelect(),
+      };
+      ds?.open(undefined, openMenu, opts);
+    };
+    openSelect();
+  });
   addBtn('mm-settings', 'Settings', () => {}, true);
 
   if (!firstOpen) {


### PR DESCRIPTION
## Summary
- persist user decks in localStorage and support deletion
- extend deck selection with edit/delete/new options
- implement deck builder UI with filtering, search and card management
- wire deck builder entry in main menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75f9faf008330b6da40bc464325a5