### PR TITLE
feat: add basic deck builder UI

### DIFF
--- a/src/core/decks.js
+++ b/src/core/decks.js
@@ -126,9 +126,47 @@ function expand(ids) {
   return ids.map(id => CARDS[id]).filter(Boolean);
 }
 
-export const DECKS = RAW_DECKS.map(d => ({ ...d, cards: expand(d.cards) }));
+// Текущий список колод. Делается let, чтобы можно было модифицировать в рантайме.
+export let DECKS = RAW_DECKS.map(d => ({ ...d, cards: expand(d.cards) }));
 
-const api = { DECKS };
+// Сохраняем колоды в localStorage
+export function saveDecks() {
+  try {
+    const payload = DECKS.map(d => ({ ...d, cards: d.cards.map(c => c.id) }));
+    localStorage.setItem('customDecks', JSON.stringify(payload));
+  } catch {}
+}
+
+// Пытаемся загрузить сохранённые колоды
+try {
+  const saved = JSON.parse(localStorage.getItem('customDecks'));
+  if (Array.isArray(saved) && saved.length) {
+    DECKS = saved.map(d => ({ ...d, cards: expand(d.cards || []) }));
+  }
+} catch {}
+
+export function addDeck(deck) {
+  DECKS.push(deck);
+  saveDecks();
+}
+
+export function updateDeck(id, data) {
+  const idx = DECKS.findIndex(d => d.id === id);
+  if (idx >= 0) {
+    DECKS[idx] = { ...DECKS[idx], ...data };
+    saveDecks();
+  }
+}
+
+export function removeDeck(id) {
+  const idx = DECKS.findIndex(d => d.id === id);
+  if (idx >= 0) {
+    DECKS.splice(idx, 1);
+    saveDecks();
+  }
+}
+
+const api = { DECKS, addDeck, updateDeck, removeDeck, saveDecks };
 try {
   if (typeof window !== 'undefined') { window.DECKS = DECKS; }
 } catch {}

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,7 @@ import { attachUIEvents } from './ui/domEvents.js';
 import * as BattleSplash from './ui/battleSplash.js';
 import * as DeckSelect from './ui/deckSelect.js';
 import * as MainMenu from './ui/mainMenu.js';
+import * as DeckBuilder from './ui/deckBuilder.js';
 import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
@@ -185,6 +186,7 @@ try {
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
   window.__ui.deckSelect = DeckSelect;
+  window.__ui.deckBuilder = DeckBuilder;
   window.__ui.mainMenu = MainMenu;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;

--- a/src/ui/deckBuilder.js
+++ b/src/ui/deckBuilder.js
@@ -1,0 +1,155 @@
+// Редактор колод (упрощённая версия)
+import { CARDS } from '../core/cards.js';
+import { DECKS, addDeck, updateDeck, saveDecks } from '../core/decks.js';
+import { show as showNotification } from './notifications.js';
+
+// Создание нового ID
+function makeId() {
+  return 'DECK_' + Math.random().toString(36).slice(2, 9);
+}
+
+export function open(deck = null, onDone) {
+  if (typeof document === 'undefined') return;
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 z-50 flex items-start justify-center bg-black bg-opacity-60 overflow-auto';
+
+  const panel = document.createElement('div');
+  panel.className = 'bg-slate-800 mt-6 p-4 rounded-lg w-[90vw] h-[90vh] flex flex-col';
+  overlay.appendChild(panel);
+
+  const topBar = document.createElement('div');
+  topBar.className = 'flex items-center gap-4 mb-4';
+  panel.appendChild(topBar);
+
+  const searchInput = document.createElement('input');
+  searchInput.placeholder = 'Search';
+  searchInput.className = 'overlay-panel px-2 py-1 flex-1';
+  topBar.appendChild(searchInput);
+
+  const main = document.createElement('div');
+  main.className = 'flex flex-1 overflow-hidden';
+  panel.appendChild(main);
+
+  // Левая панель
+  const left = document.createElement('div');
+  left.className = 'w-64 flex-shrink-0 flex flex-col border-r border-slate-700 pr-2';
+  main.appendChild(left);
+
+  const nameInput = document.createElement('input');
+  nameInput.placeholder = 'Deck name';
+  nameInput.className = 'overlay-panel mb-2 px-2 py-1';
+  left.appendChild(nameInput);
+
+  const deckList = document.createElement('div');
+  deckList.className = 'flex-1 overflow-y-auto space-y-1 text-sm';
+  left.appendChild(deckList);
+
+  const summary = document.createElement('div');
+  summary.className = 'mt-2 text-center';
+  left.appendChild(summary);
+
+  const doneBtn = document.createElement('button');
+  doneBtn.className = 'overlay-panel mt-2 px-3 py-1.5 bg-slate-600 hover:bg-slate-700';
+  doneBtn.textContent = 'Done';
+  left.appendChild(doneBtn);
+
+  // Каталог
+  const catalog = document.createElement('div');
+  catalog.className = 'flex-1 overflow-y-auto grid grid-cols-4 gap-2 pl-4';
+  main.appendChild(catalog);
+
+  // Состояние редактируемой колоды
+  const working = deck ? {
+    id: deck.id,
+    name: deck.name,
+    description: deck.description || '',
+    cards: [...deck.cards],
+  } : { id: makeId(), name: '', description: '', cards: [] };
+
+  function renderDeck() {
+    deckList.innerHTML = '';
+    const grouped = {};
+    working.cards.forEach(c => {
+      grouped[c.id] = grouped[c.id] || { card: c, count: 0 };
+      grouped[c.id].count++;
+    });
+    Object.values(grouped).forEach(({ card, count }) => {
+      const row = document.createElement('div');
+      row.className = 'flex items-center justify-between overlay-panel px-1';
+      row.textContent = `${card.name}`;
+      const cnt = document.createElement('span');
+      cnt.textContent = count;
+      row.appendChild(cnt);
+      row.addEventListener('click', () => {
+        const i = working.cards.findIndex(x => x.id === card.id);
+        if (i >= 0) working.cards.splice(i, 1);
+        renderDeck();
+        updateSummary();
+      });
+      deckList.appendChild(row);
+    });
+  }
+
+  function updateSummary() {
+    summary.textContent = `${working.cards.length}/20`;
+  }
+
+  function addCard(card) {
+    const copies = working.cards.filter(c => c.id === card.id).length;
+    if (copies >= 3) {
+      showNotification('Лимит копий достигнут', 'error');
+      return;
+    }
+    working.cards.push(card);
+    renderDeck();
+    updateSummary();
+  }
+
+  function renderCatalog() {
+    catalog.innerHTML = '';
+    const query = searchInput.value.toLowerCase();
+    const cards = Object.values(CARDS).filter(c =>
+      c.name.toLowerCase().includes(query) ||
+      (c.desc || '').toLowerCase().includes(query)
+    );
+    cards.forEach(card => {
+      const item = document.createElement('div');
+      item.className = 'overlay-panel p-2 text-center cursor-pointer hover:bg-slate-700';
+      const img = document.createElement('img');
+      img.src = `card images/${card.id}.png`;
+      img.className = 'w-full h-32 object-cover mb-1';
+      item.appendChild(img);
+      const nm = document.createElement('div');
+      nm.className = 'text-xs';
+      nm.textContent = card.name;
+      item.appendChild(nm);
+      item.addEventListener('click', () => addCard(card));
+      catalog.appendChild(item);
+    });
+  }
+
+  searchInput.addEventListener('input', renderCatalog);
+
+  doneBtn.addEventListener('click', () => {
+    working.name = nameInput.value.trim() || 'Untitled';
+    if (deck) {
+      updateDeck(deck.id, working);
+    } else {
+      addDeck(working);
+    }
+    saveDecks();
+    document.body.removeChild(overlay);
+    onDone && onDone();
+  });
+
+  nameInput.value = working.name;
+  renderDeck();
+  updateSummary();
+  renderCatalog();
+
+  document.body.appendChild(overlay);
+}
+
+const api = { open };
+try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.deckBuilder = api; } } catch {}
+export default api;

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -1,5 +1,5 @@
 // Меню выбора колоды
-import { DECKS } from '../core/decks.js';
+import { DECKS, removeDeck, saveDecks } from '../core/decks.js';
 
 function pickDeckImage(deck) {
   // выбираем самую дорогую по мане карту; при равенстве — случайная
@@ -10,8 +10,9 @@ function pickDeckImage(deck) {
   return `card images/${card.id}.png`;
 }
 
-export function open(onConfirm, onCancel) {
+export function open(opts = {}) {
   if (typeof document === 'undefined') return;
+  const { onConfirm, onCancel, onEdit, onCreate } = opts;
   let selected = 0;
   const overlay = document.createElement('div');
   overlay.id = 'deck-select-overlay';
@@ -71,23 +72,63 @@ export function open(onConfirm, onCancel) {
   });
 
   const btnWrap = document.createElement('div');
-  btnWrap.className = 'flex justify-end gap-2 mt-4';
+  btnWrap.className = 'flex justify-between gap-2 mt-4';
   panel.appendChild(btnWrap);
+
+  const leftBtns = document.createElement('div');
+  leftBtns.className = 'flex gap-2';
+  btnWrap.appendChild(leftBtns);
+  const rightBtns = document.createElement('div');
+  rightBtns.className = 'flex gap-2';
+  btnWrap.appendChild(rightBtns);
+
+  if (onEdit) {
+    const editBtn = document.createElement('button');
+    editBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
+    editBtn.textContent = 'Edit';
+    editBtn.addEventListener('click', () => {
+      try { document.body.removeChild(overlay); } catch {}
+      onEdit && onEdit(DECKS[selected]);
+    });
+    leftBtns.appendChild(editBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'overlay-panel px-3 py-1.5 bg-red-600 hover:bg-red-700 glossy-btn transition-colors';
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => {
+      removeDeck(DECKS[selected].id);
+      saveDecks();
+      document.body.removeChild(overlay);
+      open(opts); // перерисовываем список
+    });
+    leftBtns.appendChild(delBtn);
+
+    const createBtn = document.createElement('button');
+    createBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
+    createBtn.textContent = 'Create New Deck';
+    createBtn.addEventListener('click', () => {
+      try { document.body.removeChild(overlay); } catch {}
+      onCreate && onCreate();
+    });
+    leftBtns.appendChild(createBtn);
+  }
 
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
   cancelBtn.textContent = 'Cancel';
   cancelBtn.addEventListener('click', () => { document.body.removeChild(overlay); onCancel && onCancel(); });
-  btnWrap.appendChild(cancelBtn);
+  rightBtns.appendChild(cancelBtn);
 
-  const okBtn = document.createElement('button');
-  okBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
-  okBtn.textContent = 'Confirm';
-  okBtn.addEventListener('click', () => {
-    try { document.body.removeChild(overlay); } catch {}
-    onConfirm && onConfirm(DECKS[selected]);
-  });
-  btnWrap.appendChild(okBtn);
+  if (onConfirm) {
+    const okBtn = document.createElement('button');
+    okBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
+    okBtn.textContent = 'Confirm';
+    okBtn.addEventListener('click', () => {
+      try { document.body.removeChild(overlay); } catch {}
+      onConfirm && onConfirm(DECKS[selected]);
+    });
+    rightBtns.appendChild(okBtn);
+  }
 
   document.body.appendChild(overlay);
 }

--- a/src/ui/mainMenu.js
+++ b/src/ui/mainMenu.js
@@ -52,7 +52,7 @@ export function open(initial = false) {
     // если передумали — возвращаемся в стартовое меню
     const back = () => open(true);
     if (ds && typeof ds.open === 'function') {
-      ds.open(startOnline, back);
+      ds.open({ onConfirm: startOnline, onCancel: back });
     } else {
       firstOpen = false;
       window.__net?.findMatch?.(window.__selectedDeckObj?.id);
@@ -80,14 +80,22 @@ export function open(initial = false) {
     };
     const back = () => open(true);
     if (ds && typeof ds.open === 'function') {
-      ds.open(startOffline, back);
+      ds.open({ onConfirm: startOffline, onCancel: back });
     } else {
       firstOpen = false;
       startOffline(window.__selectedDeckObj || (window.DECKS && window.DECKS[0]));
     }
   });
 
-  addBtn('mm-deck', 'Deck Builder', () => {}, true);
+  addBtn('mm-deck', 'Deck Builder', () => {
+    close();
+    const ds = window.__ui?.deckSelect;
+    const openEditor = (deck) => {
+      const db = window.__ui?.deckBuilder;
+      db?.open(deck, () => ds.open({ onCancel: () => open(true), onEdit: openEditor, onCreate: () => openEditor(null) }));
+    };
+    ds.open({ onCancel: () => open(true), onEdit: openEditor, onCreate: () => openEditor(null) });
+  });
   addBtn('mm-settings', 'Settings', () => {}, true);
 
   if (!firstOpen) {


### PR DESCRIPTION
## Summary
- add local storage deck store with CRUD helpers
- extend deck selection with edit/delete/new deck options
- integrate minimal deck builder UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c75f9faf008330b6da40bc464325a5