### PR TITLE
feat: improve deck builder UI

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -138,3 +138,23 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 #deck-select-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
   background-color: #64748b;
 }
+
+/* Кастомный скроллбар для редактора колод */
+#deck-builder-overlay .deck-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #475569 rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-track {
+  background: rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-thumb {
+  background-color: #475569;
+  border-radius: 4px;
+  border: 2px solid rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: #64748b;
+}


### PR DESCRIPTION
## Summary
- fix filter popups positioning to overlay above deck list
- add card art strips and draggable deck list
- show full cards in catalog with 4x2 grid and custom scrollbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f1a4dfb88330a12b1038c3fb0dd0