### PR TITLE
feat: overhaul deck builder visuals

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -138,3 +138,23 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 #deck-select-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
   background-color: #64748b;
 }
+
+/* Кастомный скроллбар для редактора колод */
+#deck-builder-overlay .catalog-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #475569 rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .catalog-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+#deck-builder-overlay .catalog-scroll::-webkit-scrollbar-track {
+  background: rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .catalog-scroll::-webkit-scrollbar-thumb {
+  background-color: #475569;
+  border-radius: 4px;
+  border: 2px solid rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .catalog-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: #64748b;
+}


### PR DESCRIPTION
## Summary
- ensure filter overlays appear above deck panel
- show adjustable card art strips in deck list
- redesign catalog: full card visuals grid with custom scrollbar and drag & drop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f1a4dfb88330a12b1038c3fb0dd0