### PR TITLE
refine deck builder visuals and preload cards

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -138,3 +138,48 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 #deck-select-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
   background-color: #64748b;
 }
+
+/* Кастомный скроллбар для редактора колод */
+#deck-builder-overlay .deck-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #475569 rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-track {
+  background: rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-thumb {
+  background-color: #475569;
+  border-radius: 4px;
+  border: 2px solid rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: #64748b;
+}
+
+#deck-builder-overlay .catalog-grid {
+  align-content: start;
+  justify-items: center;
+  padding-bottom: 1rem;
+}
+
+#deck-builder-overlay .catalog-card {
+  width: 100%;
+  padding: 6px;
+  border-radius: 18px;
+  background: rgba(15,23,42,0.65);
+  box-shadow: 0 8px 20px rgba(8,11,20,0.4);
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+#deck-builder-overlay .catalog-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 28px rgba(8,11,20,0.48);
+}
+
+#deck-builder-overlay .catalog-card canvas {
+  display: block;
+  border-radius: 14px;
+}


### PR DESCRIPTION
## Summary
- update deck builder layout with taller viewport, five-column catalog grid and matching scrollbars/art strips on the deck list
- hook card texture loading into catalog redraws and preload strip artwork with configurable offsets
- overhaul drawCardFace to mirror in-game proportions, smaller typography, elevated attack diagrams and stat badges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c7f1a4dfb88330a12b1038c3fb0dd0