### PR TITLE
feat: polish deck builder visuals and loading

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -138,3 +138,69 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 #deck-select-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
   background-color: #64748b;
 }
+
+/* Кастомный скроллбар для редактора колод */
+#deck-builder-overlay .deck-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #475569 rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-track {
+  background: rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-thumb {
+  background-color: #475569;
+  border-radius: 4px;
+  border: 2px solid rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: #64748b;
+}
+
+/* Дополнительные стили редактора колод */
+#deck-builder-overlay .deck-builder-panel {
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.55);
+}
+
+#deck-builder-overlay .catalog-grid {
+  align-content: start;
+  padding-bottom: 18px;
+}
+
+#deck-builder-overlay .catalog-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.45);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+#deck-builder-overlay .catalog-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.55);
+}
+
+#deck-builder-overlay .catalog-card canvas {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 14px;
+}
+
+#deck-builder-overlay .deck-entry {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.3);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+#deck-builder-overlay .deck-entry:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.4);
+}


### PR DESCRIPTION
## Summary
- add configurable art strips and matching scroll styles for the deck list and expand the editor viewport with a 5x2 catalog grid
- overhaul card face rendering with scaled layout, stat pills, and automatic redraw when textures or illustrations load
- expose card-face update subscription so the deck builder refreshes previews as assets arrive and apply refined catalog styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f1a4dfb88330a12b1038c3fb0dd0