### PR TITLE
feat: улучшить визуализацию редактора колод

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -138,3 +138,49 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 #deck-select-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
   background-color: #64748b;
 }
+
+/* Кастомный скроллбар для редактора колод */
+#deck-builder-overlay .deck-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: #475569 rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-track {
+  background: rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-thumb {
+  background-color: #475569;
+  border-radius: 4px;
+  border: 2px solid rgba(30,41,59,0.7);
+}
+#deck-builder-overlay .deck-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: #64748b;
+}
+
+#deck-builder-overlay .catalog-grid {
+  grid-auto-rows: minmax(0, auto);
+  align-content: start;
+  padding-bottom: 1rem;
+}
+
+#deck-builder-overlay .catalog-card {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 6px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: 0 10px 30px rgba(2, 6, 23, 0.45);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+#deck-builder-overlay .catalog-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.55);
+}
+
+#deck-builder-overlay .catalog-card canvas {
+  border-radius: 10px;
+}


### PR DESCRIPTION
## Summary
- переработан канвас карты каталога: полноценный макет с бейджами стихий, компактной типографикой, обновлёнными сетками атак и улучшенной подгрузкой иллюстраций
- увеличено окно редактора, добавлена сетка 5x2 с расширенными отступами и обновлены полоски иллюстраций и скролл в списке колоды, каталожные карточки реагируют на догрузку текстур
- добавлен дополнительный декор и анимации для карточек каталога вместе с единым кастомным скроллбаром

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f1a4dfb88330a12b1038c3fb0dd0