### PR TITLE
Adjust deck builder catalog layout and card visuals

### DIFF
--- a/src/ui/deckBuilder.js
+++ b/src/ui/deckBuilder.js
@@ -60,10 +60,22 @@ export function open(deck = null, onDone) {
   panel.className = 'bg-slate-800 mt-2 p-4 rounded-lg w-[92vw] h-[96vh] flex flex-col relative';
   overlay.appendChild(panel);
 
-  // === Верхняя панель фильтров ===
+  const main = document.createElement('div');
+  main.className = 'flex flex-1 overflow-hidden';
+  panel.appendChild(main);
+
+  const left = document.createElement('div');
+  left.className = 'w-64 flex-shrink-0 flex flex-col border-r border-slate-700 pr-2';
+  main.appendChild(left);
+
+  const right = document.createElement('div');
+  right.className = 'flex-1 flex flex-col pl-4';
+  main.appendChild(right);
+
+  // === Верхняя панель фильтров (привязана к правому блоку) ===
   const topBar = document.createElement('div');
-  topBar.className = 'flex items-center gap-4 mb-4';
-  panel.appendChild(topBar);
+  topBar.className = 'flex items-center justify-end gap-3 mb-3';
+  right.appendChild(topBar);
 
   // Переключатель стихий
   const elementBtn = document.createElement('button');
@@ -146,17 +158,8 @@ export function open(deck = null, onDone) {
   // Поиск
   const searchInput = document.createElement('input');
   searchInput.placeholder = 'Search';
-  searchInput.className = 'overlay-panel px-2 py-1 flex-1';
+  searchInput.className = 'overlay-panel px-2 py-1 w-56';
   topBar.appendChild(searchInput);
-
-  // === Левая панель текущей колоды ===
-  const main = document.createElement('div');
-  main.className = 'flex flex-1 overflow-hidden';
-  panel.appendChild(main);
-
-  const left = document.createElement('div');
-  left.className = 'w-64 flex-shrink-0 flex flex-col border-r border-slate-700 pr-2';
-  main.appendChild(left);
 
   const nameInput = document.createElement('input');
   nameInput.placeholder = 'Deck name';
@@ -186,9 +189,9 @@ export function open(deck = null, onDone) {
 
   // === Каталог карт ===
   const catalog = document.createElement('div');
-  // Сетка 5x2 с собственной полосой прокрутки
-  catalog.className = 'flex-1 overflow-y-auto grid grid-cols-5 grid-rows-2 gap-4 pl-4 deck-scroll catalog-grid';
-  main.appendChild(catalog);
+  // Сетка 5xN с собственной полосой прокрутки
+  catalog.className = 'flex-1 overflow-y-auto grid grid-cols-5 gap-4 deck-scroll catalog-grid';
+  right.appendChild(catalog);
 
   const scheduleCatalogRedraw = (() => {
     let pending = false;

--- a/styles/main.css
+++ b/styles/main.css
@@ -162,6 +162,7 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 #deck-builder-overlay .catalog-grid {
   align-content: start;
   justify-items: center;
+  grid-auto-rows: max-content;
   padding-bottom: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- move the deck builder filter bar into the right column, shrink the search field and let the catalog use a scrolling 5-column grid without overlapping cards
- rework card face rendering with larger names, diagrams directly above a slimmer stats footer, and new heart/sword stat icons
- ensure catalog rows size to content to avoid overlap while keeping scrolling available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8de1260488330ba05bd95650c25a6