### PR TITLE
Настроить общий сетевой конфиг для API колод

### DIFF
--- a/src/net/client.js
+++ b/src/net/client.js
@@ -1,11 +1,17 @@
+import { getServerBase } from './config.js';
+
   /* MODULE: network/multiplayer
      Purpose: handle server connection, matchmaking, state sync,
      countdowns, and input locking. */
 (() => {
   // ===== 0) Config =====
-  const SERVER_URL = (location.hostname === "localhost")
-    ? "http://localhost:3001"
-    : "https://eog-mp-server-production.up.railway.app"; // ← домен сервера
+  const SERVER_URL = getServerBase();
+  try {
+    if (typeof window !== 'undefined') {
+      const cfg = window.__netConfig = window.__netConfig || {};
+      cfg.socketUrl = SERVER_URL;
+    }
+  } catch {}
 
   // ===== 1) Styles =====
   const css = `

--- a/src/net/config.js
+++ b/src/net/config.js
@@ -1,0 +1,99 @@
+// Конфигурация сетевого взаимодействия: HTTP и WebSocket адреса сервера
+// Держим расчёт базовых URL изолированным, чтобы упростить перенос на другие движки
+const DEFAULT_REMOTE_BASE = 'https://eog-mp-server-production.up.railway.app';
+const LOCAL_DEFAULT_PORT = 3001;
+
+function sanitizeBase(url) {
+  if (!url || typeof url !== 'string') return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  const collapsed = trimmed.replace(/\s+/g, '');
+  if (!collapsed) return null;
+  if (collapsed === '/' || collapsed === '//') return collapsed;
+  return collapsed.replace(/\/+$/, '');
+}
+
+function isLocalHost(hostname) {
+  return hostname === 'localhost' || hostname === '127.0.0.1';
+}
+
+function readWindowOverride(name) {
+  if (typeof window === 'undefined') return null;
+  try {
+    const value = window[name];
+    if (!value) return null;
+    const normalized = sanitizeBase(String(value));
+    return normalized || null;
+  } catch {
+    return null;
+  }
+}
+
+export function getServerBase() {
+  const override = readWindowOverride('__MP_SERVER_URL');
+  if (override) {
+    if (override.startsWith('http://') || override.startsWith('https://')) {
+      return override;
+    }
+    // Поддерживаем краткую запись вроде //host:port
+    if (override.startsWith('//')) {
+      return `https:${override}`;
+    }
+    if (override.startsWith('/')) {
+      return override;
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    try {
+      const { protocol, hostname } = window.location || {};
+      if (hostname && isLocalHost(hostname)) {
+        const portOverride = Number(readWindowOverride('__MP_SERVER_PORT'));
+        const port = Number.isFinite(portOverride) && portOverride > 0
+          ? portOverride
+          : LOCAL_DEFAULT_PORT;
+        const scheme = protocol === 'https:' ? 'https' : 'http';
+        return `${scheme}://${hostname}:${port}`;
+      }
+    } catch {}
+  }
+
+  return DEFAULT_REMOTE_BASE;
+}
+
+export function getDecksApiBase() {
+  const override = readWindowOverride('__DECKS_API_BASE');
+  if (override) {
+    if (override.startsWith('http://') || override.startsWith('https://') || override.startsWith('/')) {
+      return override;
+    }
+  }
+  const base = getServerBase();
+  return `${base.replace(/\/+$/, '')}/decks`;
+}
+
+export function getResolvedConfig() {
+  return {
+    serverBase: getServerBase(),
+    decksApiBase: getDecksApiBase(),
+  };
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    const target = window.__netConfig || {};
+    Object.defineProperties(target, {
+      serverBase: {
+        get: getServerBase,
+        enumerable: true,
+        configurable: true,
+      },
+      decksApiBase: {
+        get: getDecksApiBase,
+        enumerable: true,
+        configurable: true,
+      },
+    });
+    window.__netConfig = target;
+  }
+} catch {}

--- a/src/net/decks.js
+++ b/src/net/decks.js
@@ -1,15 +1,14 @@
 // Сетевые операции с колодами — чистые функции без привязки к DOM
 import { hydrateDeck, serializeDeck, setDecks, upsertDeck } from '../core/decks.js';
-
-const DEFAULT_BASE = '/decks';
-const API_BASE = (typeof window !== 'undefined' && window.__DECKS_API_BASE) || DEFAULT_BASE;
+import { getDecksApiBase } from './config.js';
 
 let lastError = null;
 
 function buildUrl(path = '') {
-  if (!path) return API_BASE;
+  const apiBase = getDecksApiBase();
+  if (!path) return apiBase;
   if (path.startsWith('http')) return path;
-  const base = API_BASE.endsWith('/') ? API_BASE.slice(0, -1) : API_BASE;
+  const base = apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase;
   const suffix = path.startsWith('/') ? path : `/${path}`;
   return `${base}${suffix}`;
 }


### PR DESCRIPTION
## Summary
- вынес вычисление адресов сервера и API колод в общий модуль конфигурации
- подключил Deck API и клиент Socket.IO к общему определению адреса сервера, чтобы обращения шли на Railway

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c92e08fc388330886f80a362276e90