### PR TITLE
Улучшение обмена позициями и визуализация невидимости

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,6 +603,7 @@
             }
           }
           // Финализация: анимация смерти и орбы перед применением состояния
+          const prevForFinish = JSON.parse(JSON.stringify(gameState));
           const res = staged.finish();
           gameState = res.n1;
           try { window.applyGameState(gameState); } catch {}
@@ -628,7 +629,9 @@
           }
           if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
             setTimeout(() => {
-              updateUnits(); updateUI();
+              updateUnits();
+              try { window.playDeltaAnimations?.(prevForFinish, gameState); } catch {}
+              updateUI();
               for (const l of res.logLines.reverse()) addLog(l);
               try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
@@ -639,7 +642,9 @@
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
-              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish', { force: true }); } catch {}
+              updateUnits();
+              try { window.playDeltaAnimations?.(prevForFinish, gameState); } catch {}
+              updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -700,6 +705,7 @@
       const tr = targetMesh.userData.row; const tc = targetMesh.userData.col;
       const attacker = gameState.board?.[from.r]?.[from.c]?.unit;
       if (!attacker || attacker.lastAttackTurn === gameState.turn) { showNotification('Incorrect target', 'error'); return; }
+      const prevMagicState = JSON.parse(JSON.stringify(gameState));
       const res = magicAttack(gameState, from.r, from.c, tr, tc);
       if (!res) { showNotification('Incorrect target', 'error'); return; }
       for (const l of res.logLines.reverse()) addLog(l);
@@ -741,7 +747,9 @@
         try { window.applyGameState(gameState); } catch {}
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         setTimeout(() => {
-          updateUnits(); updateUI();
+          updateUnits();
+          try { window.playDeltaAnimations?.(prevMagicState, gameState); } catch {}
+          updateUI();
           try { schedulePush('magic-battle-finish', { force: true }); } catch {}
           if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
             window.__interactions.interactionState.autoEndTurnAfterAttack = false;
@@ -751,7 +759,9 @@
       } else {
         // Если смертей нет — применяем состояние сразу
         gameState = res.n1; try { window.applyGameState(gameState); } catch {}
-        updateUnits(); updateUI();
+        updateUnits();
+        try { window.playDeltaAnimations?.(prevMagicState, gameState); } catch {}
+        updateUI();
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         try { schedulePush('magic-battle-finish', { force: true }); } catch {}
         if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -158,6 +158,50 @@ export const CARDS = {
     desc: 'Attacks the same target twice (counterattack after second attack). While on a Fire field he must use his Magic Attack, which affects the target and all adjacent enemies. The Attack value is equal to the number of Fire fields.'
   },
 
+  // Ninja cycle
+  FIRE_FIREFLY_NINJA: {
+    id: 'FIRE_FIREFLY_NINJA', name: 'Firefly Ninja', type: 'UNIT', cost: 3, activation: 2,
+    element: 'FIRE', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    gainPerfectDodgeOnElement: 'FIRE',
+    invisibilityAllies: ['EARTH_SPIDER_NINJA'],
+    desc: 'While on a Fire field it gains Perfect Dodge. Gains Invisibility while at least one allied Spider Ninja is on the board.'
+  },
+  EARTH_SPIDER_NINJA: {
+    id: 'EARTH_SPIDER_NINJA', name: 'Spider Ninja', type: 'UNIT', cost: 3, activation: 2,
+    element: 'EARTH', atk: 2, hp: 1,
+    attackType: 'MAGIC',
+    attacks: [ { dir: 'N', ranges: [1, 2, 3], mode: 'ANY' } ],
+    blindspots: ['S'],
+    invisibilityAllies: ['WATER_WOLF_NINJA'],
+    swapWithTargetOnElement: 'EARTH',
+    desc: 'Magic attack. Gains Invisibility while at least one allied Wolf Ninja is on the board. If it damages a creature on an Earth field, it switches places with that creature (which cannot counterattack).'
+  },
+  WATER_WOLF_NINJA: {
+    id: 'WATER_WOLF_NINJA', name: 'Wolf Ninja', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    blindspots: ['S'],
+    invisibilityAllies: ['FOREST_SWALLOW_NINJA'],
+    swapWithTargetOnElement: 'WATER',
+    desc: 'Gains Invisibility while at least one allied Swallow Ninja is on the board. If Wolf Ninja damages a creature on a Water field, it switches places with that creature (which cannot counterattack).'
+  },
+  FOREST_SWALLOW_NINJA: {
+    id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
+    element: 'FOREST', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    blindspots: ['S'],
+    friendlyFire: true,
+    pierce: true,
+    invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
+    rotateTargetOnDamage: true,
+    desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+
   // Spells (subset)
   RAISE_STONE: { id:'RAISE_STONE', name:'Raise Stone', type:'SPELL', cost:2, element:'EARTH', text:'+2 HP to a friendly unit.' },
   SPELL_FISSURES_OF_GOGHLIE: { id: 'SPELL_FISSURES_OF_GOGHLIE', name: 'Fissures of Goghlie', type: 'SPELL', element: 'NEUTRAL', spellType: 'CONJURATION', cost: 2, text: 'Fieldquake any one field.' },

--- a/src/scene/invisibilityFx.js
+++ b/src/scene/invisibilityFx.js
@@ -1,0 +1,104 @@
+// Эффект невидимости для 3D-карт: лёгкая прозрачность и мерцающая дымка
+import { getCtx } from './context.js';
+
+const ACTIVE_OVERLAYS = new WeakMap();
+
+function ensureTHREE() {
+  const ctx = getCtx();
+  const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
+  if (!THREE) throw new Error('THREE not available');
+  return THREE;
+}
+
+function collectMaterials(mesh) {
+  if (!mesh) return [];
+  const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  return mats.filter(Boolean);
+}
+
+export function applyInvisibilityEffect(mesh) {
+  try {
+    if (!mesh) return;
+    const THREE = ensureTHREE();
+    if (ACTIVE_OVERLAYS.has(mesh)) {
+      // Уже применён — ничего не делаем, но обновим время
+      const stored = ACTIVE_OVERLAYS.get(mesh);
+      if (stored?.uniforms) {
+        stored.uniforms.uTime.value = performance.now() / 1000;
+      }
+      return;
+    }
+
+    const originals = [];
+    for (const mat of collectMaterials(mesh)) {
+      originals.push({ mat, transparent: mat.transparent, opacity: mat.opacity, depthWrite: mat.depthWrite });
+      mat.transparent = true;
+      const targetOpacity = typeof mat.opacity === 'number' ? Math.min(mat.opacity, 0.55) : 0.55;
+      mat.opacity = targetOpacity;
+      mat.depthWrite = false;
+    }
+
+    const geomParams = mesh.geometry?.parameters || {};
+    const width = geomParams.width || 4.8;
+    const height = geomParams.height || 0.12;
+    const depth = geomParams.depth || 5.6;
+
+    const overlayGeom = new THREE.PlaneGeometry(width * 1.05, depth * 1.05);
+    const uniforms = {
+      uTime: { value: performance.now() / 1000 },
+      uBaseAlpha: { value: 0.32 },
+      uTint: { value: new THREE.Color(0x9bd7ff) },
+    };
+    const overlayMat = new THREE.ShaderMaterial({
+      transparent: true,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      uniforms,
+      vertexShader: `varying vec2 vUv;\nvoid main(){\n  vUv = uv;\n  gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);\n}`,
+      fragmentShader: `uniform float uTime;\nuniform float uBaseAlpha;\nuniform vec3 uTint;\nvarying vec2 vUv;\nvoid main(){\n  float wave = sin((vUv.x + uTime * 0.6) * 8.0) * 0.18;\n  wave += sin((vUv.y - uTime * 0.45) * 9.0) * 0.15;\n  float alpha = clamp(uBaseAlpha + wave, 0.08, 0.45);\n  gl_FragColor = vec4(uTint, alpha);\n}`,
+    });
+    const overlay = new THREE.Mesh(overlayGeom, overlayMat);
+    overlay.rotation.x = -Math.PI / 2;
+    overlay.position.set(0, (height / 2) + 0.018, 0);
+    overlay.renderOrder = (mesh.renderOrder || 1200) + 5;
+    overlay.userData = { kind: 'invisibilityOverlay' };
+    overlay.onBeforeRender = () => {
+      if (overlay.material?.uniforms?.uTime) {
+        overlay.material.uniforms.uTime.value = performance.now() / 1000;
+      }
+    };
+    mesh.add(overlay);
+
+    ACTIVE_OVERLAYS.set(mesh, { originals, overlay, uniforms });
+  } catch {}
+}
+
+export function removeInvisibilityEffect(mesh) {
+  try {
+    if (!mesh) return;
+    const stored = ACTIVE_OVERLAYS.get(mesh);
+    if (!stored) return;
+    for (const entry of stored.originals || []) {
+      if (!entry || !entry.mat) continue;
+      entry.mat.transparent = entry.transparent;
+      if (typeof entry.opacity === 'number') entry.mat.opacity = entry.opacity;
+      entry.mat.depthWrite = entry.depthWrite;
+    }
+    if (stored.overlay) {
+      try { mesh.remove(stored.overlay); } catch {}
+      try { stored.overlay.geometry?.dispose(); } catch {}
+      try { stored.overlay.material?.dispose(); } catch {}
+    }
+    ACTIVE_OVERLAYS.delete(mesh);
+  } catch {}
+}
+
+export function clearInvisibilityEffect(mesh) {
+  removeInvisibilityEffect(mesh);
+}
+
+export default {
+  applyInvisibilityEffect,
+  removeInvisibilityEffect,
+  clearInvisibilityEffect,
+};


### PR DESCRIPTION
## Summary
- пересчёт бонусов и штрафов от поля при обмене позициями и распространение событий перемещения для логики
- добавлена анимация перемещений фигур как в дельта-анимациях, так и в локальных последовательностях боя
- реализован шейдер невидимости для 3D-карт и тест, проверяющий перерасчёт здоровья после обмена

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca6438b2e48330b15fa610aa304fc7