### PR TITLE
Обновление обмена позициями и визуальных эффектов

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -1,5 +1,6 @@
 // Общие функции для обработки особых свойств карт
 import { CARDS } from './cards.js';
+import { applyFieldTransitionToUnit } from './fieldEffects.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -12,6 +13,253 @@ function getUnitTemplate(unit) {
 
 function getUnitUid(unit) {
   return (unit && unit.uid != null) ? unit.uid : null;
+}
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
+function normalizeTplIdList(value) {
+  const result = new Set();
+  for (const raw of toArray(value)) {
+    if (!raw || typeof raw !== 'string') continue;
+    const direct = CARDS[raw];
+    if (direct?.id) { result.add(direct.id); continue; }
+    const byId = Object.values(CARDS).find(card => card?.id === raw);
+    if (byId?.id) { result.add(byId.id); continue; }
+    const byName = Object.values(CARDS).find(card => card?.name === raw);
+    if (byName?.id) { result.add(byName.id); continue; }
+    result.add(raw);
+  }
+  return Array.from(result);
+}
+
+function normalizeElements(value) {
+  const set = new Set();
+  for (const raw of toArray(value)) {
+    if (typeof raw === 'string' && raw) {
+      set.add(raw.toUpperCase());
+    }
+  }
+  return set;
+}
+
+function collectInvisibilitySources(tpl) {
+  const sources = new Set();
+  for (const id of normalizeTplIdList(tpl?.invisibilityAllies)) sources.add(id);
+  for (const id of normalizeTplIdList(tpl?.invisibilityWithAlly)) sources.add(id);
+  for (const id of normalizeTplIdList(tpl?.invisibilityWithAllyName)) sources.add(id);
+  if (tpl?.invisibilityWithSpider) sources.add('EARTH_SPIDER_NINJA');
+  if (tpl?.invisibilityWithWolf) sources.add('WATER_WOLF_NINJA');
+  return Array.from(sources);
+}
+
+export function hasPerfectDodge(state, r, c, opts = {}) {
+  const cell = state?.board?.[r]?.[c];
+  const unit = opts.unit || cell?.unit;
+  if (!unit) return false;
+  const tpl = opts.tpl || getUnitTemplate(unit);
+  if (!tpl) return false;
+  if (tpl.perfectDodge) return true;
+  const cellElement = cell?.element;
+  if (!cellElement) return false;
+  const elements = normalizeElements(
+    tpl.gainPerfectDodgeOnElement || tpl.perfectDodgeOnElement
+  );
+  if (tpl.perfectDodgeOnFire) elements.add('FIRE');
+  return elements.has(cellElement);
+}
+
+export function hasInvisibility(state, r, c, opts = {}) {
+  const cell = state?.board?.[r]?.[c];
+  const unit = opts.unit || cell?.unit;
+  if (!unit) return false;
+  const tpl = opts.tpl || getUnitTemplate(unit);
+  if (!tpl) return false;
+  if (tpl.invisibility) return true;
+  const byElement = normalizeElements(tpl.invisibilityOnElement);
+  if (byElement.size && cell?.element && byElement.has(cell.element)) {
+    return true;
+  }
+  const sources = collectInvisibilitySources(tpl);
+  if (!sources.length) return false;
+  for (let rr = 0; rr < 3; rr++) {
+    for (let cc = 0; cc < 3; cc++) {
+      if (rr === r && cc === c) continue;
+      const ally = state?.board?.[rr]?.[cc]?.unit;
+      if (!ally || ally.owner !== unit.owner) continue;
+      if (sources.includes(ally.tplId)) return true;
+      const tplAlly = getUnitTemplate(ally);
+      if (tplAlly?.id && sources.includes(tplAlly.id)) return true;
+      if (tplAlly?.name && sources.includes(tplAlly.name)) return true;
+    }
+  }
+  return false;
+}
+
+const OPPOSITE_DIR = { N: 'S', S: 'N', E: 'W', W: 'E' };
+
+function directionBetween(from, to) {
+  if (!from || !to) return null;
+  const dr = (to.r ?? 0) - (from.r ?? 0);
+  const dc = (to.c ?? 0) - (from.c ?? 0);
+  if (dr === -1 && dc === 0) return 'N';
+  if (dr === 1 && dc === 0) return 'S';
+  if (dr === 0 && dc === 1) return 'E';
+  if (dr === 0 && dc === -1) return 'W';
+  return null;
+}
+
+function computeFacingAway(targetRef, attackerRef) {
+  const dirToAttacker = directionBetween(targetRef, attackerRef);
+  if (!dirToAttacker) return null;
+  return OPPOSITE_DIR[dirToAttacker] || null;
+}
+
+function findUnitRef(state, ref = {}) {
+  if (!state?.board) return { unit: null, r: null, c: null };
+  const { uid, r, c } = ref || {};
+  if (uid != null) {
+    for (let rr = 0; rr < 3; rr++) {
+      for (let cc = 0; cc < 3; cc++) {
+        const unit = state.board?.[rr]?.[cc]?.unit;
+        if (unit && getUnitUid(unit) === uid) {
+          return { unit, r: rr, c: cc };
+        }
+      }
+    }
+  }
+  if (typeof r === 'number' && typeof c === 'number') {
+    const unit = state.board?.[r]?.[c]?.unit || null;
+    return { unit, r, c };
+  }
+  return { unit: null, r: null, c: null };
+}
+
+export function collectDamageInteractions(state, context = {}) {
+  const result = { preventRetaliation: new Set(), events: [] };
+  if (!state?.board) return result;
+  const { attackerPos, attackerUnit, tpl, hits } = context;
+  if (!tpl || !attackerUnit || !Array.isArray(hits) || !hits.length) return result;
+
+  const attackerRef = {
+    uid: getUnitUid(attackerUnit),
+    r: attackerPos?.r,
+    c: attackerPos?.c,
+    tplId: tpl.id,
+  };
+
+  let swapHandled = false;
+  const swapElements = normalizeElements(
+    tpl.swapWithTargetOnElement || (tpl.switchOnDamage ? tpl.element : null)
+  );
+
+  for (const h of hits) {
+    if (!h) continue;
+    const dealt = h.dealt ?? h.dmg ?? 0;
+    if (dealt <= 0) continue;
+    const cell = state.board?.[h.r]?.[h.c];
+    const target = cell?.unit;
+    if (!target) continue;
+    const tplTarget = getUnitTemplate(target);
+    const alive = (target.currentHP ?? tplTarget?.hp ?? 0) > 0;
+    const key = `${h.r},${h.c}`;
+
+    if (!swapHandled && swapElements.size && alive && cell?.element && swapElements.has(cell.element)) {
+      result.events.push({
+        type: 'SWAP_POSITIONS',
+        attacker: attackerRef,
+        target: { uid: getUnitUid(target), r: h.r, c: h.c, tplId: tplTarget?.id },
+      });
+      swapHandled = true;
+      result.preventRetaliation.add(key);
+    }
+
+    if (tpl.rotateTargetOnDamage && alive) {
+      result.events.push({
+        type: 'ROTATE_TARGET',
+        target: { uid: getUnitUid(target), r: h.r, c: h.c, tplId: tplTarget?.id },
+        faceAwayFrom: attackerRef,
+      });
+      result.preventRetaliation.add(key);
+    }
+
+    if (tpl.preventRetaliationOnDamage) {
+      result.preventRetaliation.add(key);
+    }
+  }
+
+  return result;
+}
+
+export function applyDamageInteractionResults(state, effects = {}) {
+  const logs = [];
+  let attackerPosUpdate = null;
+  const events = Array.isArray(effects?.events) ? effects.events : [];
+
+  for (const ev of events) {
+    if (ev?.type === 'SWAP_POSITIONS') {
+      const attacker = findUnitRef(state, ev.attacker);
+      const target = findUnitRef(state, ev.target);
+      if (!attacker.unit || !target.unit) continue;
+      const aliveAttacker = (attacker.unit.currentHP ?? CARDS[attacker.unit.tplId]?.hp ?? 0) > 0;
+      const aliveTarget = (target.unit.currentHP ?? CARDS[target.unit.tplId]?.hp ?? 0) > 0;
+      if (!aliveAttacker || !aliveTarget) continue;
+      const attackerUnit = attacker.unit;
+      const targetUnit = target.unit;
+      const tplAttacker = CARDS[attackerUnit.tplId];
+      const tplTarget = CARDS[targetUnit.tplId];
+      const attackerPrevElement = state.board?.[attacker.r]?.[attacker.c]?.element || null;
+      const targetPrevElement = state.board?.[target.r]?.[target.c]?.element || null;
+      state.board[attacker.r][attacker.c].unit = targetUnit;
+      state.board[target.r][target.c].unit = attackerUnit;
+      attackerPosUpdate = { r: target.r, c: target.c };
+      const attackerName = tplAttacker?.name || 'Атакующий';
+      const targetName = tplTarget?.name || 'Цель';
+      logs.push(`${attackerName} меняется местами с ${targetName}.`);
+      const shiftAttacker = applyFieldTransitionToUnit(
+        attackerUnit,
+        tplAttacker,
+        attackerPrevElement,
+        targetPrevElement,
+      );
+      const shiftTarget = applyFieldTransitionToUnit(
+        targetUnit,
+        tplTarget,
+        targetPrevElement,
+        attackerPrevElement,
+      );
+      const describeShift = (shift, name) => {
+        if (!shift) return null;
+        const fieldLabel = shift.nextElement ? `поле ${shift.nextElement}` : 'нейтральном поле';
+        const prev = shift.beforeHp;
+        const next = shift.afterHp;
+        if (shift.deltaHp > 0) {
+          return `${name} усиливается на ${fieldLabel}: HP ${prev}→${next}.`;
+        }
+        return `${name} теряет силу на ${fieldLabel}: HP ${prev}→${next}.`;
+      };
+      const attackerLog = describeShift(shiftAttacker, attackerName);
+      if (attackerLog) logs.push(attackerLog);
+      const targetLog = describeShift(shiftTarget, targetName);
+      if (targetLog) logs.push(targetLog);
+    } else if (ev?.type === 'ROTATE_TARGET') {
+      const target = findUnitRef(state, ev.target);
+      if (!target.unit) continue;
+      const aliveTarget = (target.unit.currentHP ?? CARDS[target.unit.tplId]?.hp ?? 0) > 0;
+      if (!aliveTarget) continue;
+      const attacker = findUnitRef(state, ev.faceAwayFrom);
+      const facing = computeFacingAway(target, attacker);
+      if (facing) {
+        target.unit.facing = facing;
+        const name = CARDS[target.unit.tplId]?.name || 'Цель';
+        logs.push(`${name} поворачивается спиной к атакующему.`);
+      }
+    }
+  }
+
+  return { attackerPosUpdate, logLines: logs };
 }
 
 function normalizeElementConfig(value, defaults = {}) {

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -158,6 +158,50 @@ export const CARDS = {
     desc: 'Attacks the same target twice (counterattack after second attack). While on a Fire field he must use his Magic Attack, which affects the target and all adjacent enemies. The Attack value is equal to the number of Fire fields.'
   },
 
+  // Ninja cycle
+  FIRE_FIREFLY_NINJA: {
+    id: 'FIRE_FIREFLY_NINJA', name: 'Firefly Ninja', type: 'UNIT', cost: 3, activation: 2,
+    element: 'FIRE', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    gainPerfectDodgeOnElement: 'FIRE',
+    invisibilityAllies: ['EARTH_SPIDER_NINJA'],
+    desc: 'While on a Fire field it gains Perfect Dodge. Gains Invisibility while at least one allied Spider Ninja is on the board.'
+  },
+  EARTH_SPIDER_NINJA: {
+    id: 'EARTH_SPIDER_NINJA', name: 'Spider Ninja', type: 'UNIT', cost: 3, activation: 2,
+    element: 'EARTH', atk: 2, hp: 1,
+    attackType: 'MAGIC',
+    attacks: [ { dir: 'N', ranges: [1, 2, 3], mode: 'ANY' } ],
+    blindspots: ['S'],
+    invisibilityAllies: ['WATER_WOLF_NINJA'],
+    swapWithTargetOnElement: 'EARTH',
+    desc: 'Magic attack. Gains Invisibility while at least one allied Wolf Ninja is on the board. If it damages a creature on an Earth field, it switches places with that creature (which cannot counterattack).'
+  },
+  WATER_WOLF_NINJA: {
+    id: 'WATER_WOLF_NINJA', name: 'Wolf Ninja', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    blindspots: ['S'],
+    invisibilityAllies: ['FOREST_SWALLOW_NINJA'],
+    swapWithTargetOnElement: 'WATER',
+    desc: 'Gains Invisibility while at least one allied Swallow Ninja is on the board. If Wolf Ninja damages a creature on a Water field, it switches places with that creature (which cannot counterattack).'
+  },
+  FOREST_SWALLOW_NINJA: {
+    id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
+    element: 'FOREST', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    blindspots: ['S'],
+    friendlyFire: true,
+    pierce: true,
+    invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
+    rotateTargetOnDamage: true,
+    desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+
   // Spells (subset)
   RAISE_STONE: { id:'RAISE_STONE', name:'Raise Stone', type:'SPELL', cost:2, element:'EARTH', text:'+2 HP to a friendly unit.' },
   SPELL_FISSURES_OF_GOGHLIE: { id: 'SPELL_FISSURES_OF_GOGHLIE', name: 'Fissures of Goghlie', type: 'SPELL', element: 'NEUTRAL', spellType: 'CONJURATION', cost: 2, text: 'Fieldquake any one field.' },

--- a/src/core/fieldEffects.js
+++ b/src/core/fieldEffects.js
@@ -1,0 +1,43 @@
+// Эффекты от смены поля: вычисление баффов и пересчёт здоровья
+// Модуль не зависит от DOM или визуализации и может использоваться из чистой логики
+// и из тестов. Логика вынесена отдельно для облегчения повторного использования
+// при будущей миграции движка.
+
+// Таблица противоположных стихий. Дублируем локально, чтобы избежать циклических
+// зависимостей между core-модулями.
+const OPPOSITES = {
+  FIRE: 'WATER',
+  WATER: 'FIRE',
+  EARTH: 'FOREST',
+  FOREST: 'EARTH',
+};
+
+export function computeCellBuff(cellElement, unitElement) {
+  if (!cellElement || !unitElement) return { atk: 0, hp: 0 };
+  if (cellElement === unitElement) return { atk: 0, hp: 2 };
+  if (cellElement === 'MECH') return { atk: 0, hp: 0 };
+  const opposite = OPPOSITES[unitElement];
+  if (opposite && cellElement === opposite) return { atk: 0, hp: -2 };
+  return { atk: 0, hp: 0 };
+}
+
+export function applyFieldTransitionToUnit(unit, tpl, prevElement, nextElement) {
+  if (!unit || !tpl) return null;
+  const fromEl = prevElement || null;
+  const toEl = nextElement || null;
+  if (fromEl === toEl) return null;
+  const prevBuff = computeCellBuff(fromEl, tpl.element);
+  const nextBuff = computeCellBuff(toEl, tpl.element);
+  const deltaHp = (nextBuff.hp || 0) - (prevBuff.hp || 0);
+  if (!deltaHp) return null;
+  const before = typeof unit.currentHP === 'number' ? unit.currentHP : (tpl.hp || 0);
+  const after = Math.max(0, before + deltaHp);
+  unit.currentHP = after;
+  return {
+    deltaHp,
+    beforeHp: before,
+    afterHp: after,
+    prevElement: fromEl,
+    nextElement: toEl,
+  };
+}

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -1,5 +1,5 @@
 // Pure game rules helpers (no DOM/THREE/GSAP/socket)
-import { DIR_VECTORS, inBounds, attackCost, OPPOSITE_ELEMENT, capMana } from './constants.js';
+import { DIR_VECTORS, inBounds, attackCost, capMana } from './constants.js';
 import { CARDS } from './cards.js';
 import {
   hasFirstStrike,
@@ -9,8 +9,13 @@ import {
   computeMagicAreaCells,
   computeDynamicMagicAttack,
   releasePossessionsAfterDeaths,
+  hasPerfectDodge,
+  hasInvisibility,
+  collectDamageInteractions,
+  applyDamageInteractionResults,
 } from './abilities.js';
 import { countUnits } from './board.js';
+import { computeCellBuff } from './fieldEffects.js';
 
 export function hasAdjacentGuard(state, r, c) {
   const target = state.board?.[r]?.[c]?.unit;
@@ -61,15 +66,6 @@ function attackCellsForTpl(tpl, facing, opts = {}) {
 }
 
 // Compute effective stats (handles temp buffs if present on cell)
-export function computeCellBuff(cellElement, unitElement) {
-  if (!cellElement || !unitElement) return { atk: 0, hp: 0 };
-  if (cellElement === unitElement) return { atk: 0, hp: 2 };
-  if (cellElement === 'MECH') return { atk: 0, hp: 0 };
-  const opp = OPPOSITE_ELEMENT[unitElement];
-  if (cellElement === opp) return { atk: 0, hp: -2 };
-  return { atk: 0, hp: 0 };
-}
-
 export function effectiveStats(cell, unit) {
   const tpl = unit ? CARDS[unit.tplId] : null;
   const buff = computeCellBuff(cell?.element, tpl?.element);
@@ -162,6 +158,7 @@ export function stagedAttack(state, r, c, opts = {}) {
   const baseStats = effectiveStats(base.board[r][c], attacker);
   let atk = baseStats.atk;
   let logLines = [];
+  const damageEffects = { preventRetaliation: new Set(), events: [] };
 
   const hitsRaw = computeHits(base, r, c, opts);
   if (!hitsRaw.length) return { empty: true };
@@ -239,9 +236,12 @@ export function stagedAttack(state, r, c, opts = {}) {
     if (!B) return { ...h, dealt: 0 };
     const isMagic = tplA.attackType === 'MAGIC';
     const tplB = CARDS[B.tplId];
-    const dodge = !isMagic && (tplB.perfectDodge || (tplB.dodge50 && Math.random() < 0.5));
-    const dealt = dodge ? 0 : h.dmg;
-    return { ...h, dealt, dodge };
+    const invisible = hasInvisibility(base, h.r, h.c, { unit: B, tpl: tplB });
+    const dodge = !isMagic && !invisible && (
+      hasPerfectDodge(base, h.r, h.c, { unit: B, tpl: tplB }) || (tplB.dodge50 && Math.random() < 0.5)
+    );
+    const dealt = (invisible || dodge) ? 0 : h.dmg;
+    return { ...h, dealt, dodge, invisible };
   });
 
   const n1 = JSON.parse(JSON.stringify(base));
@@ -277,6 +277,7 @@ export function stagedAttack(state, r, c, opts = {}) {
         const parts = [`${nameA} → ${nameB}: ${h.dealt || 0} dmg (HP ${before}→${afterHP})`];
         if (h.backstab) parts.push('(+1 backstab)');
         if (h.dodge) parts.push('(dodge)');
+        if (h.invisible) parts.push('(невидимость)');
         logLines.push(parts.join(' '));
       }
       if (hasDoubleAttack(tplA)) {
@@ -292,6 +293,23 @@ export function stagedAttack(state, r, c, opts = {}) {
           logLines.push(`${nameA} (2nd) → ${nameB}: ${h.dealt || 0} dmg (HP ${before2}→${after2})`);
         }
       }
+      const interactions = collectDamageInteractions(n1, {
+        attackerPos: { r, c },
+        attackerUnit: n1.board?.[r]?.[c]?.unit,
+        tpl: tplA,
+        hits: step1Damages.map(h => ({ r: h.r, c: h.c, dealt: h.dealt || 0 })),
+      });
+      if (interactions) {
+        const prevents = interactions.preventRetaliation;
+        if (prevents instanceof Set || Array.isArray(prevents)) {
+          for (const key of prevents) {
+            damageEffects.preventRetaliation.add(key);
+          }
+        }
+        if (Array.isArray(interactions.events) && interactions.events.length) {
+          damageEffects.events.push(...interactions.events);
+        }
+      }
     }
     step1Done = true;
   }
@@ -303,6 +321,8 @@ export function stagedAttack(state, r, c, opts = {}) {
     let totalRetaliation = 0;
     const retaliators = [];
     for (const h of step1Damages) {
+      const preventKey = `${h.r},${h.c}`;
+      if (damageEffects.preventRetaliation.has(preventKey)) continue;
       const B = n1.board?.[h.r]?.[h.c]?.unit;
       if (!B) continue;
       const tplB = CARDS[B.tplId];
@@ -326,6 +346,15 @@ export function stagedAttack(state, r, c, opts = {}) {
     ensureStep1();
     const nFinal = JSON.parse(JSON.stringify(n1));
     const ret = step2();
+
+    const applied = applyDamageInteractionResults(nFinal, damageEffects);
+    if (applied?.attackerPosUpdate) {
+      r = applied.attackerPosUpdate.r;
+      c = applied.attackerPosUpdate.c;
+    }
+    if (Array.isArray(applied?.logLines) && applied.logLines.length) {
+      logLines.push(...applied.logLines);
+    }
 
     const A = nFinal.board?.[r]?.[c]?.unit;
     if (A && (ret.total || 0) > 0) {
@@ -420,6 +449,16 @@ export function magicAttack(state, fr, fc, tr, tc) {
 
   const logLines = [];
   const targets = [];
+  const damageEffects = { preventRetaliation: new Set(), events: [] };
+  const hitsSummary = new Map();
+  const addSummary = (r, c, dealt, extra = {}) => {
+    const key = `${r},${c}`;
+    const entry = hitsSummary.get(key) || { r, c, dealt: 0, invisible: false };
+    entry.dealt += dealt;
+    entry.invisible = entry.invisible || !!extra.invisible;
+    hitsSummary.set(key, entry);
+  };
+
   const atkStats = effectiveStats(n1.board[fr][fc], attacker);
   let atk = atkStats.atk || 0;
   const dynMagic = computeDynamicMagicAttack(n1, tplA);
@@ -472,22 +511,60 @@ export function magicAttack(state, fr, fc, tr, tc) {
     const u = n1.board?.[cell.r]?.[cell.c]?.unit;
     if (!u) continue;
     if (!allowFriendly && u.owner === attacker.owner) continue;
-    const before = u.currentHP ?? u.hp;
-    u.currentHP = Math.max(0, before - dmg);
-    targets.push({ r: cell.r, c: cell.c, dmg });
-    logLines.push(`${CARDS[attacker.tplId].name} (Magic) → ${CARDS[u.tplId].name}: ${dmg} dmg (HP ${before}→${u.currentHP})`);
+    const tplB = CARDS[u.tplId];
+    const invisible = hasInvisibility(n1, cell.r, cell.c, { unit: u, tpl: tplB });
+    const before = u.currentHP ?? tplB.hp;
+    let dealt = 0;
+    if (!invisible) {
+      dealt = Math.max(0, dmg);
+      u.currentHP = Math.max(0, before - dealt);
+    }
+    addSummary(cell.r, cell.c, dealt, { invisible });
+    targets.push({ r: cell.r, c: cell.c, dmg: dealt });
+    const after = invisible ? before : (u.currentHP ?? tplB.hp);
+    const parts = [`${CARDS[attacker.tplId].name} (Magic) → ${CARDS[u.tplId].name}: ${dealt} dmg (HP ${before}→${after})`];
+    if (invisible) parts.push('(невидимость)');
+    logLines.push(parts.join(' '));
   }
 
   if (hasDoubleAttack(tplA)) {
     for (const cell of cells) {
       const u2 = n1.board?.[cell.r]?.[cell.c]?.unit;
       if (!u2) continue;
+      if (!allowFriendly && u2.owner === attacker.owner) continue;
       const tplB2 = CARDS[u2.tplId];
       if ((u2.currentHP ?? tplB2.hp) <= 0) continue;
+      const invisible = hasInvisibility(n1, cell.r, cell.c, { unit: u2, tpl: tplB2 });
       const before2 = u2.currentHP ?? tplB2.hp;
-      u2.currentHP = Math.max(0, before2 - dmg);
-      targets.push({ r: cell.r, c: cell.c, dmg });
-      logLines.push(`${CARDS[attacker.tplId].name} (Magic 2nd) → ${CARDS[u2.tplId].name}: ${dmg} dmg (HP ${before2}→${u2.currentHP})`);
+      let dealt2 = 0;
+      if (!invisible) {
+        dealt2 = Math.max(0, dmg);
+        u2.currentHP = Math.max(0, before2 - dealt2);
+      }
+      addSummary(cell.r, cell.c, dealt2, { invisible });
+      targets.push({ r: cell.r, c: cell.c, dmg: dealt2 });
+      const after2 = invisible ? before2 : (u2.currentHP ?? tplB2.hp);
+      const parts = [`${CARDS[attacker.tplId].name} (Magic 2nd) → ${CARDS[u2.tplId].name}: ${dealt2} dmg (HP ${before2}→${after2})`];
+      if (invisible) parts.push('(невидимость)');
+      logLines.push(parts.join(' '));
+    }
+  }
+
+  const interactions = collectDamageInteractions(n1, {
+    attackerPos: { r: fr, c: fc },
+    attackerUnit: attacker,
+    tpl: tplA,
+    hits: Array.from(hitsSummary.values()),
+  });
+  if (interactions) {
+    const prevents = interactions.preventRetaliation;
+    if (prevents instanceof Set || Array.isArray(prevents)) {
+      for (const key of prevents) {
+        damageEffects.preventRetaliation.add(key);
+      }
+    }
+    if (Array.isArray(interactions.events) && interactions.events.length) {
+      damageEffects.events.push(...interactions.events);
     }
   }
 
@@ -515,8 +592,18 @@ export function magicAttack(state, fr, fc, tr, tc) {
       logLines.push(`${name}: контроль возвращается к игроку ${rel.owner + 1}.`);
     }
   }
+  const applied = applyDamageInteractionResults(n1, damageEffects);
+  if (applied?.attackerPosUpdate) {
+    fr = applied.attackerPosUpdate.r;
+    fc = applied.attackerPosUpdate.c;
+  }
+  if (Array.isArray(applied?.logLines) && applied.logLines.length) {
+    logLines.push(...applied.logLines);
+  }
   attacker.lastAttackTurn = n1.turn;
   const cellEl = n1.board?.[fr]?.[fc]?.element;
   attacker.apSpent = (attacker.apSpent || 0) + attackCost(tplA, cellEl);
   return { n1, logLines, targets, deaths, releases: releaseEvents.releases };
 }
+
+export { computeCellBuff };

--- a/src/scene/context.js
+++ b/src/scene/context.js
@@ -19,6 +19,7 @@ const ctx = {
   tileFrames: [],
   // Scene caches for units and hand cards
   unitMeshes: [],
+  unitMeshesByUid: new Map(),
   handCardMeshes: [],
   // Textures cache
   TILE_TEXTURES: {},

--- a/src/scene/unitFx.js
+++ b/src/scene/unitFx.js
@@ -1,0 +1,187 @@
+// Эффекты, связанные с визуализацией конкретных юнитов (невидимость и т.п.)
+// Логика анимаций вынесена отдельно от основного рендера, чтобы облегчить
+// повторное использование при переносе на другие движки.
+
+import { getCtx } from './context.js';
+
+const activeInvisibilityFx = new Set();
+let rafId = null;
+
+function ensureLoop() {
+  if (typeof window === 'undefined') return;
+  if (rafId !== null) return;
+  let last = performance.now();
+  const step = (now) => {
+    const delta = Math.max(0, (now - last) / 1000);
+    last = now;
+    for (const fx of activeInvisibilityFx) {
+      try {
+        if (fx.uniforms?.uTime) {
+          fx.uniforms.uTime.value += delta;
+          if (fx.uniforms.uTime.value > 1000) {
+            fx.uniforms.uTime.value = fx.uniforms.uTime.value % 1000;
+          }
+        }
+      } catch {}
+    }
+    if (activeInvisibilityFx.size > 0) {
+      rafId = window.requestAnimationFrame(step);
+    } else {
+      rafId = null;
+    }
+  };
+  rafId = window.requestAnimationFrame(step);
+}
+
+function stopLoopIfNeeded() {
+  if (typeof window === 'undefined') return;
+  if (activeInvisibilityFx.size === 0 && rafId !== null) {
+    window.cancelAnimationFrame(rafId);
+    rafId = null;
+  }
+}
+
+function createShaderOverlay(THREE, mesh) {
+  const width = mesh?.geometry?.parameters?.width || 4.8;
+  const depth = mesh?.geometry?.parameters?.depth || 5.6;
+  const height = mesh?.geometry?.parameters?.height || 0.12;
+  const uniforms = {
+    uTime: { value: 0 },
+    uOpacity: { value: 0.45 },
+    uColor: { value: new THREE.Color(0.65, 0.8, 1.0) },
+  };
+  const vertexShader = `
+    varying vec2 vUv;
+    void main() {
+      vUv = uv;
+      gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    }
+  `;
+  const fragmentShader = `
+    varying vec2 vUv;
+    uniform float uTime;
+    uniform float uOpacity;
+    uniform vec3 uColor;
+    float hash(vec2 p) {
+      return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+    }
+    void main() {
+      float wave = sin((vUv.x + vUv.y + uTime * 0.6) * 6.2831);
+      float wave2 = sin((vUv.x * 4.0 - uTime * 0.8) + sin(vUv.y * 3.0 + uTime * 0.9));
+      float flicker = hash(vUv * 12.0 + uTime);
+      float intensity = 0.45 + 0.55 * wave * wave2 + 0.1 * flicker;
+      float alpha = clamp(uOpacity * intensity, 0.0, 0.75);
+      gl_FragColor = vec4(uColor, alpha);
+    }
+  `;
+  const material = new THREE.ShaderMaterial({
+    uniforms,
+    vertexShader,
+    fragmentShader,
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  });
+  const geometry = new THREE.PlaneGeometry(width * 1.04, depth * 1.04);
+  const plane = new THREE.Mesh(geometry, material);
+  plane.rotation.x = -Math.PI / 2;
+  plane.position.set(0, height / 2 + 0.08, 0);
+  plane.renderOrder = (mesh.renderOrder || 1200) + 5;
+  return { plane, geometry, material, uniforms };
+}
+
+function makeMaterialsTransparent(mesh) {
+  const entries = [];
+  const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  for (const mat of mats) {
+    if (!mat) continue;
+    const prev = {
+      mat,
+      transparent: mat.transparent,
+      opacity: typeof mat.opacity === 'number' ? mat.opacity : 1,
+    };
+    entries.push(prev);
+    if (typeof mat.opacity === 'number') {
+      mat.opacity = Math.min(prev.opacity, 0.68);
+    }
+    mat.transparent = true;
+    mat.needsUpdate = true;
+  }
+  const faceOverlay = mesh.children?.find(ch => ch.userData?.kind === 'faceOverlay');
+  let overlayPrev = null;
+  if (faceOverlay?.material) {
+    const mat = faceOverlay.material;
+    overlayPrev = {
+      mat,
+      transparent: mat.transparent,
+      opacity: typeof mat.opacity === 'number' ? mat.opacity : 1,
+    };
+    mat.transparent = true;
+    if (typeof mat.opacity === 'number') {
+      mat.opacity = Math.min(mat.opacity, 0.55);
+    } else {
+      mat.opacity = 0.55;
+    }
+    mat.needsUpdate = true;
+  }
+  return { materials: entries, overlay: overlayPrev };
+}
+
+function restoreMaterials(data) {
+  if (!data) return;
+  for (const entry of data.materials || []) {
+    try {
+      entry.mat.transparent = entry.transparent;
+      if (typeof entry.mat.opacity === 'number') {
+        entry.mat.opacity = entry.opacity;
+      }
+      entry.mat.needsUpdate = true;
+    } catch {}
+  }
+  if (data.overlay?.mat) {
+    try {
+      data.overlay.mat.transparent = data.overlay.transparent;
+      if (typeof data.overlay.mat.opacity === 'number') {
+        data.overlay.mat.opacity = data.overlay.opacity;
+      }
+      data.overlay.mat.needsUpdate = true;
+    } catch {}
+  }
+}
+
+export function setInvisibilityFx(mesh, enabled) {
+  if (!mesh) return;
+  const ctx = getCtx();
+  const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
+  if (!THREE) return;
+  const current = mesh.userData?.__invisibilityFx;
+  if (enabled) {
+    if (current) return;
+    const overlay = createShaderOverlay(THREE, mesh);
+    if (!overlay?.plane) return;
+    mesh.add(overlay.plane);
+    const stored = makeMaterialsTransparent(mesh);
+    const fx = {
+      mesh,
+      overlay,
+      stored,
+      uniforms: overlay.uniforms,
+    };
+    mesh.userData.__invisibilityFx = fx;
+    activeInvisibilityFx.add(fx);
+    ensureLoop();
+  } else {
+    if (!current) return;
+    try {
+      if (current.overlay?.plane && current.overlay.plane.parent === mesh) {
+        mesh.remove(current.overlay.plane);
+      }
+    } catch {}
+    try { current.overlay?.geometry?.dispose?.(); } catch {}
+    try { current.overlay?.material?.dispose?.(); } catch {}
+    restoreMaterials(current.stored);
+    activeInvisibilityFx.delete(current);
+    delete mesh.userData.__invisibilityFx;
+    stopLoopIfNeeded();
+  }
+}

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -182,6 +182,83 @@ describe('особые способности', () => {
     expect(attacker.currentHP ?? tplA.hp).toBe(2);
     delete CARDS.TEST_DEFENDER;
   });
+
+  it('Firefly Ninja получает Perfect Dodge и невидимость с союзным Пауком', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[1][0].unit = { owner:0, tplId:'FIRE_FIREFLY_NINJA', facing:'E' };
+    state.board[1][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'W' };
+    const res = stagedAttack(state,1,1);
+    const fin = res.finish();
+    const ninja = fin.n1.board[1][0].unit;
+    const tplNinja = CARDS[ninja.tplId];
+    expect(ninja.currentHP ?? tplNinja.hp).toBe(tplNinja.hp);
+
+    const state2 = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state2.board[1][0].unit = { owner:0, tplId:'FIRE_FIREFLY_NINJA', facing:'E' };
+    state2.board[2][2].unit = { owner:0, tplId:'EARTH_SPIDER_NINJA', facing:'N' };
+    state2.board[1][2].unit = { owner:1, tplId:'FIRE_FLAME_MAGUS', facing:'W' };
+    const magicRes = magicAttack(state2,1,2,1,0);
+    const ninja2 = magicRes.n1.board[1][0].unit;
+    const tplNinja2 = CARDS[ninja2.tplId];
+    expect(ninja2.currentHP ?? tplNinja2.hp).toBe(tplNinja2.hp);
+    const dmgEntry = magicRes.targets.find(t => t.r === 1 && t.c === 0);
+    expect(dmgEntry?.dmg).toBe(0);
+  });
+
+  it('Spider Ninja меняется местами с врагом на земляном поле и отключает контратаку', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].element = 'EARTH';
+    state.board[1][1].element = 'EARTH';
+    state.board[2][1].unit = { owner:0, tplId:'EARTH_SPIDER_NINJA', facing:'N' };
+    state.board[1][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'S', currentHP:3 };
+    const res = magicAttack(state,2,1,1,1);
+    const board = res.n1.board;
+    expect(board[1][1].unit?.tplId).toBe('EARTH_SPIDER_NINJA');
+    expect(board[2][1].unit?.tplId).toBe('FIRE_PARTMOLE_FLAME_LIZARD');
+    expect(res.targets.find(t => t.r === 1 && t.c === 1)?.dmg).toBeGreaterThan(0);
+  });
+
+  it('обновляет здоровье существ после обмена позициями на разных полях', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].element = 'FIRE';
+    state.board[1][1].element = 'EARTH';
+    state.board[2][1].unit = { owner:0, tplId:'EARTH_SPIDER_NINJA', facing:'N', currentHP:1 };
+    state.board[1][1].unit = { owner:1, tplId:'FIRE_TRICEPTAUR_BEHEMOTH', facing:'S', currentHP:4 };
+    const res = magicAttack(state,2,1,1,1);
+    const board = res.n1.board;
+    const spider = board[1][1].unit;
+    const behemoth = board[2][1].unit;
+    expect(spider?.currentHP).toBe(3);
+    expect(behemoth?.currentHP).toBe(4);
+  });
+
+  it('Wolf Ninja меняется местами с целью на воде и не получает ответного удара', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].element = 'WATER';
+    state.board[1][1].element = 'WATER';
+    state.board[2][1].unit = { owner:0, tplId:'WATER_WOLF_NINJA', facing:'N' };
+    state.board[1][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'S', currentHP:3 };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    expect(fin.n1.board[1][1].unit?.tplId).toBe('WATER_WOLF_NINJA');
+    expect(fin.n1.board[2][1].unit?.tplId).toBe('FIRE_PARTMOLE_FLAME_LIZARD');
+    expect(fin.retaliators.length).toBe(0);
+  });
+
+  it('Swallow Ninja разворачивает цель и лишает её контратаки', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].element = 'FOREST';
+    state.board[2][1].unit = { owner:0, tplId:'FOREST_SWALLOW_NINJA', facing:'N' };
+    state.board[1][1].unit = { owner:1, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'S', currentHP:3 };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    const enemy = fin.n1.board[1][1].unit;
+    expect(enemy.tplId).toBe('FIRE_PARTMOLE_FLAME_LIZARD');
+    expect(enemy.facing).toBe('N');
+    expect(fin.retaliators.length).toBe(0);
+    const dmgEntry = fin.targets.find(t => t.r === 1 && t.c === 1);
+    expect(dmgEntry?.dmg).toBe(1);
+  });
 });
 
 describe('magicAttack', () => {


### PR DESCRIPTION
## Summary
- вынес расчёт баффов от поля в отдельный модуль и применил его при обмене позициями, чтобы корректно пересчитывать здоровье существ
- переработал отрисовку юнитов: переиспользование мешей, плавная анимация перемещений и новый шейдер невидимости
- добавил тест на проверку пересчёта здоровья после обмена позициями

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca6438b2e48330b15fa610aa304fc7