### PR TITLE
feat: add god incarnation cards and shared ability modules

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -1,6 +1,12 @@
 // Общие функции для обработки особых свойств карт
 import { CARDS } from './cards.js';
 import { applyFieldTransitionToUnit } from './fieldEffects.js';
+import {
+  isIncarnationCard,
+  evaluateIncarnationSummon as evaluateIncarnationSummonInternal,
+  applyIncarnationSummon as applyIncarnationSummonInternal,
+} from './abilityHandlers/incarnation.js';
+import { collectMagicTargets as collectMagicTargetsInternal } from './abilityHandlers/magicTargeting.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -482,6 +488,10 @@ export function computeMagicAreaCells(tpl, tr, tc) {
   return ensureUniqueCells(cells);
 }
 
+export function collectMagicTargetCells(state, tpl, attackerRef, primaryTarget) {
+  return collectMagicTargetsInternal(state, tpl, attackerRef, primaryTarget, computeMagicAreaCells);
+}
+
 export function computeDynamicMagicAttack(state, tpl) {
   if (!tpl) return null;
   if (tpl.dynamicMagicAtk === 'FIRE_FIELDS') {
@@ -510,3 +520,7 @@ export function getTargetElementBonus(tpl, state, hits) {
   if (!has) return null;
   return { amount, element: cfg.element };
 }
+
+export { isIncarnationCard };
+export const evaluateIncarnationSummon = evaluateIncarnationSummonInternal;
+export const applyIncarnationSummon = applyIncarnationSummonInternal;

--- a/src/core/abilityHandlers/incarnation.js
+++ b/src/core/abilityHandlers/incarnation.js
@@ -1,0 +1,78 @@
+// Модуль обработки механики "Инкарнация"
+import { CARDS } from '../cards.js';
+
+function getTemplate(tplOrId) {
+  if (!tplOrId) return null;
+  if (typeof tplOrId === 'string') {
+    return CARDS[tplOrId] || null;
+  }
+  if (tplOrId.id && CARDS[tplOrId.id]) {
+    return CARDS[tplOrId.id];
+  }
+  if (tplOrId.tplId && CARDS[tplOrId.tplId]) {
+    return CARDS[tplOrId.tplId];
+  }
+  return tplOrId || null;
+}
+
+function cloneSacrificeInfo(unit, tpl, position) {
+  if (!unit) return null;
+  return {
+    uid: unit.uid ?? null,
+    tplId: unit.tplId ?? null,
+    owner: unit.owner,
+    position: position ? { r: position.r, c: position.c } : null,
+    tplName: tpl?.name || null,
+    tplCost: tpl?.cost ?? null,
+  };
+}
+
+export function isIncarnationCard(tpl) {
+  return !!(tpl && tpl.incarnation);
+}
+
+export function evaluateIncarnationSummon(state, context = {}) {
+  const { r, c, tpl, owner } = context;
+  const template = getTemplate(tpl);
+  if (!template || !template.incarnation) {
+    return { ok: false, reason: 'NOT_INCARNATION' };
+  }
+  const board = state?.board;
+  if (!board || typeof r !== 'number' || typeof c !== 'number') {
+    return { ok: false, reason: 'INVALID_POSITION' };
+  }
+  const cell = board?.[r]?.[c];
+  const hostUnit = cell?.unit;
+  if (!hostUnit) {
+    return { ok: false, reason: 'NO_HOST' };
+  }
+  const controller = hostUnit.owner;
+  if (typeof owner === 'number' && controller !== owner) {
+    return { ok: false, reason: 'NOT_ALLY' };
+  }
+  const hostTpl = getTemplate(hostUnit.tplId);
+  const hostCost = hostTpl?.cost ?? 0;
+  const newCost = template.cost ?? 0;
+  const diff = Math.max(0, newCost - hostCost);
+  return {
+    ok: true,
+    cost: diff,
+    sacrifice: cloneSacrificeInfo(hostUnit, hostTpl, { r, c }),
+  };
+}
+
+export function applyIncarnationSummon(state, context = {}) {
+  const { r, c, tpl, owner } = context;
+  const check = evaluateIncarnationSummon(state, { r, c, tpl, owner });
+  if (!check.ok) return { ok: false, reason: check.reason };
+  const board = state?.board;
+  const cell = board?.[r]?.[c];
+  const removedUnit = cell?.unit || null;
+  const removedTpl = getTemplate(removedUnit?.tplId);
+  if (cell) cell.unit = null;
+  return {
+    ok: true,
+    cost: check.cost,
+    sacrifice: cloneSacrificeInfo(removedUnit, removedTpl, { r, c }),
+  };
+}

--- a/src/core/abilityHandlers/magicTargeting.js
+++ b/src/core/abilityHandlers/magicTargeting.js
@@ -1,0 +1,64 @@
+// Модуль обработки особых областей для магических атак
+import { inBounds } from '../constants.js';
+
+function ensureUnique(cells) {
+  const seen = new Set();
+  const res = [];
+  for (const cell of cells || []) {
+    if (!cell) continue;
+    const key = `${cell.r},${cell.c}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    res.push({ r: cell.r, c: cell.c });
+  }
+  return res;
+}
+
+function collectAllByPredicate(state, predicate) {
+  const result = [];
+  if (!state?.board) return result;
+  for (let r = 0; r < state.board.length; r++) {
+    for (let c = 0; c < state.board[r].length; c++) {
+      if (!inBounds(r, c)) continue;
+      const cell = state.board[r][c];
+      const unit = cell?.unit || null;
+      if (predicate(unit, cell?.element, r, c)) {
+        result.push({ r, c });
+      }
+    }
+  }
+  return result;
+}
+
+function resolveOwner(state, attackerRef = {}) {
+  if (typeof attackerRef.owner === 'number') return attackerRef.owner;
+  if (typeof attackerRef.r === 'number' && typeof attackerRef.c === 'number') {
+    const unit = state?.board?.[attackerRef.r]?.[attackerRef.c]?.unit;
+    if (unit) return unit.owner;
+  }
+  return null;
+}
+
+export function collectMagicTargets(state, tpl, attackerRef, primaryTarget, computeDefaultArea) {
+  if (!tpl) return [];
+  const owner = resolveOwner(state, attackerRef);
+
+  if (tpl.targetAllEnemies) {
+    return ensureUnique(collectAllByPredicate(state, (unit) => !!unit && (owner == null || unit.owner !== owner)));
+  }
+
+  if (tpl.targetAllNonElement) {
+    const forbidden = String(tpl.targetAllNonElement || '').toUpperCase();
+    return ensureUnique(collectAllByPredicate(
+      state,
+      (unit, element) => !!unit && (owner == null || unit.owner !== owner) && element !== forbidden,
+    ));
+  }
+
+  if (typeof primaryTarget?.r === 'number' && typeof primaryTarget?.c === 'number') {
+    const base = computeDefaultArea ? computeDefaultArea(tpl, primaryTarget.r, primaryTarget.c) : [];
+    return ensureUnique(base);
+  }
+
+  return [];
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -158,6 +158,61 @@ export const CARDS = {
     desc: 'Attacks the same target twice (counterattack after second attack). While on a Fire field he must use his Magic Attack, which affects the target and all adjacent enemies. The Attack value is equal to the number of Fire fields.'
   },
 
+  FIRE_SCIONDAR_FIRE_GOD: {
+    id: 'FIRE_SCIONDAR_FIRE_GOD', name: 'Sciondar Fire God', type: 'UNIT', cost: 9, activation: 5,
+    element: 'FIRE', atk: 3, hp: 9,
+    attackType: 'MAGIC',
+    attacks: [], blindspots: [],
+    incarnation: true,
+    targetAllNonElement: 'FIRE',
+    diesOnElement: 'MECH',
+    desc: 'Incarnation. Its Magic Attack targets all enemies on non-Fire fields. Destroy Sciondar Fire God if he is on a Biolith field.'
+  },
+
+  WATER_GODDESS_TRITONA: {
+    id: 'WATER_GODDESS_TRITONA', name: 'Goddess Tritona', type: 'UNIT', cost: 9, activation: 5,
+    element: 'WATER', atk: 3, hp: 9,
+    attackType: 'MAGIC',
+    attacks: [], blindspots: [],
+    incarnation: true,
+    targetAllNonElement: 'WATER',
+    diesOnElement: 'MECH',
+    desc: 'Incarnation. Goddess Tritona’s Magic Attack targets all enemies on non-Water fields. Destroy Goddess Tritona if she is on a Biolith field.'
+  },
+
+  EARTH_NOVOGUS_GRAVEKEEPER: {
+    id: 'EARTH_NOVOGUS_GRAVEKEEPER', name: 'Novogus Gravekeeper', type: 'UNIT', cost: 9, activation: 5,
+    element: 'EARTH', atk: 3, hp: 9,
+    attackType: 'MAGIC',
+    attacks: [], blindspots: [],
+    incarnation: true,
+    targetAllNonElement: 'EARTH',
+    diesOnElement: 'MECH',
+    desc: 'Incarnation. Novogus Gravekeeper’s Magic Attack targets all enemies on non-Earth fields. Destroy Novogus Gravekeeper if it is on a Biolith field.'
+  },
+
+  FOREST_EXALTED_ELVEN_DEITY: {
+    id: 'FOREST_EXALTED_ELVEN_DEITY', name: 'Exalted Elven Deity', type: 'UNIT', cost: 9, activation: 5,
+    element: 'FOREST', atk: 3, hp: 9,
+    attackType: 'MAGIC',
+    attacks: [], blindspots: [],
+    incarnation: true,
+    targetAllNonElement: 'FOREST',
+    diesOnElement: 'MECH',
+    desc: 'Incarnation. Exalted Elven Deity’s Magic Attack targets all enemies on non-Wood fields. Destroy Exalted Elven Deity if it is on a Biolith field.'
+  },
+
+  MECH_PHASEUS: {
+    id: 'MECH_PHASEUS', name: 'Phaseus, Biolith God', type: 'UNIT', cost: 9, activation: 5,
+    element: 'MECH', atk: 3, hp: 9,
+    attackType: 'MAGIC',
+    attacks: [], blindspots: [],
+    incarnation: true,
+    targetAllEnemies: true,
+    diesOffElement: 'MECH',
+    desc: 'Incarnation. Phaseus’s Magic Attack targets all enemies. Destroy Phaseus if he is on a non-Biolith field.'
+  },
+
   // Ninja cycle
   FIRE_FIREFLY_NINJA: {
     id: 'FIRE_FIREFLY_NINJA', name: 'Firefly Ninja', type: 'UNIT', cost: 3, activation: 2,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -6,7 +6,7 @@ import {
   hasDoubleAttack,
   canAttack,
   getTargetElementBonus,
-  computeMagicAreaCells,
+  collectMagicTargetCells,
   computeDynamicMagicAttack,
   releasePossessionsAfterDeaths,
   hasPerfectDodge,
@@ -484,15 +484,22 @@ export function magicAttack(state, fr, fc, tr, tc) {
     cells.push({ r: rr, c: cc });
   };
 
-  const baseArea = computeMagicAreaCells(tplA, tr, tc) || [];
-  for (const cell of baseArea) { addCell(cell.r, cell.c); }
+  const primaryTarget = (typeof tr === 'number' && typeof tc === 'number')
+    ? { r: tr, c: tc }
+    : null;
+  const baseCells = collectMagicTargetCells(n1, tplA, { r: fr, c: fc }, primaryTarget) || [];
+  for (const cell of baseCells) { addCell(cell.r, cell.c); }
 
   const splash = tplA.splash || 0;
-  if (splash > 0) {
-    const dirs = [ [-1,0], [1,0], [0,-1], [0,1] ];
-    for (const [dr, dc] of dirs) {
-      for (let dist = 1; dist <= splash; dist++) {
-        addCell(tr + dr * dist, tc + dc * dist);
+  if (splash > 0 && !tplA.targetAllEnemies && !tplA.targetAllNonElement) {
+    const refR = (primaryTarget && typeof primaryTarget.r === 'number') ? primaryTarget.r : tr;
+    const refC = (primaryTarget && typeof primaryTarget.c === 'number') ? primaryTarget.c : tc;
+    if (typeof refR === 'number' && typeof refC === 'number') {
+      const dirs = [ [-1,0], [1,0], [0,-1], [0,1] ];
+      for (const [dr, dc] of dirs) {
+        for (let dist = 1; dist <= splash; dist++) {
+          addCell(refR + dr * dist, refC + dc * dist);
+        }
       }
     }
   }

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -10,6 +10,7 @@ import {
   applyIncarnationSummon,
   isIncarnationCard,
 } from '../core/abilities.js';
+import { capMana } from '../core/constants.js';
 
 // Centralized interaction state
 export const interactionState = {
@@ -252,21 +253,21 @@ function onMouseUp(event) {
         const playerIndex = gameState.active;
         if (existingUnit) {
           if (!isIncarnationCard(cardData)) {
-            showNotification('Клетка занята: требуется свободное поле.', 'error');
+            showNotification('Cell is occupied: pick an empty field.', 'error');
             returnCardToHand(interactionState.draggedCard);
             endCardDrag();
             return;
           }
           const check = evaluateIncarnationSummon(gameState, { r: row, c: col, tpl: cardData, owner: playerIndex });
           if (!check?.ok) {
-            showNotification('Инкарнация невозможна на этой клетке.', 'error');
+            showNotification('Incarnation is not possible on this field.', 'error');
             returnCardToHand(interactionState.draggedCard);
             endCardDrag();
             return;
           }
           const player = gameState.players[playerIndex];
           if (check.cost > player.mana) {
-            showNotification(`Нужно ${check.cost} маны для инкарнации.`, 'error');
+            showNotification(`You need ${check.cost} mana for the incarnation.`, 'error');
             returnCardToHand(interactionState.draggedCard);
             endCardDrag();
             return;
@@ -280,7 +281,7 @@ function onMouseUp(event) {
           };
         } else {
           if (isIncarnationCard(cardData)) {
-            showNotification('Инкарнация требует союзную карту на поле.', 'error');
+            showNotification('Incarnation requires a friendly unit on the field.', 'error');
             returnCardToHand(interactionState.draggedCard);
             endCardDrag();
             return;
@@ -423,7 +424,7 @@ function performMagicAttack(from, targetMesh) {
   const gameState = window.gameState;
   const attacker = gameState.board?.[from.r]?.[from.c]?.unit;
   if (!attacker || attacker.lastAttackTurn === gameState.turn) {
-    showNotification('Некорректная атака', 'error');
+    showNotification('Invalid attack', 'error');
     return false;
   }
   const res = window.magicAttack(gameState, from.r, from.c, targetMesh.userData.row, targetMesh.userData.col);
@@ -485,7 +486,7 @@ function performChosenAttack(from, targetMesh) {
   const gameState = window.gameState;
   const attacker = gameState.board?.[from.r]?.[from.c]?.unit; if (!attacker) return;
   if (attacker.lastAttackTurn === gameState.turn) {
-    showNotification('Некорректная атака', 'error');
+    showNotification('Invalid attack', 'error');
     return;
   }
   const tr = targetMesh.userData.row; const tc = targetMesh.userData.col;
@@ -557,7 +558,7 @@ export function placeUnitWithDirection(direction) {
   const player = gameState.players[gameState.active];
   const summonCost = (incarnation?.active ? (incarnation.cost ?? cardData.cost ?? 0) : cardData.cost) ?? 0;
   if (summonCost > player.mana) {
-    showNotification('Недостаточно маны!', 'error');
+    showNotification('Not enough mana!', 'error');
     returnCardToHand(card);
     try { window.__ui.panels.hideOrientationPanel(); } catch {}
     interactionState.pendingPlacement = null;
@@ -567,7 +568,7 @@ export function placeUnitWithDirection(direction) {
   if (incarnation?.active) {
     const applied = applyIncarnationSummon(gameState, { r: row, c: col, tpl: cardData, owner: gameState.active });
     if (!applied?.ok) {
-      showNotification('Инкарнация прервана.', 'error');
+      showNotification('Incarnation cancelled.', 'error');
       returnCardToHand(card);
       try { window.__ui.panels.hideOrientationPanel(); } catch {}
       interactionState.pendingPlacement = null;
@@ -625,34 +626,38 @@ export function placeUnitWithDirection(direction) {
     window.addLog(`${cardData.name} не переносит стихию ${cardData.diesOnElement} и погибает!`);
     alive = false;
   }
-    if (!alive) {
-      // обработка эффектов при смерти (например, лечение союзников)
-      if (cardData.onDeathAddHPAll) {
-        const amount = cardData.onDeathAddHPAll;
-        for (let rr = 0; rr < 3; rr++) {
-          for (let cc = 0; cc < 3; cc++) {
-            if (rr === row && cc === col) continue; // пропускаем саму погибшую карту
-            const ally = gameState.board?.[rr]?.[cc]?.unit;
-            if (!ally || ally.owner !== unit.owner) continue;
-            const tplAlly = window.CARDS?.[ally.tplId];
-            const cellEl2 = gameState.board[rr][cc].element;
-            const buff2 = window.computeCellBuff(cellEl2, tplAlly.element);
-            ally.bonusHP = (ally.bonusHP || 0) + amount;
-            const maxHP = (tplAlly.hp || 0) + buff2.hp + (ally.bonusHP || 0);
-            const before = ally.currentHP ?? tplAlly.hp;
-            ally.currentHP = Math.min(maxHP, before + amount);
-          }
+  if (!alive) {
+    // обработка эффектов при смерти (например, лечение союзников)
+    if (cardData.onDeathAddHPAll) {
+      const amount = cardData.onDeathAddHPAll;
+      for (let rr = 0; rr < 3; rr++) {
+        for (let cc = 0; cc < 3; cc++) {
+          if (rr === row && cc === col) continue; // пропускаем саму погибшую карту
+          const ally = gameState.board?.[rr]?.[cc]?.unit;
+          if (!ally || ally.owner !== unit.owner) continue;
+          const tplAlly = window.CARDS?.[ally.tplId];
+          const cellEl2 = gameState.board[rr][cc].element;
+          const buff2 = window.computeCellBuff(cellEl2, tplAlly.element);
+          ally.bonusHP = (ally.bonusHP || 0) + amount;
+          const maxHP = (tplAlly.hp || 0) + buff2.hp + (ally.bonusHP || 0);
+          const before = ally.currentHP ?? tplAlly.hp;
+          ally.currentHP = Math.min(maxHP, before + amount);
         }
-        showOracleDeathBuff(unit.owner, amount);
-        window.addLog(`${cardData.name}: союзники получают +${amount} HP`);
       }
-      const owner = unit.owner;
-      try { gameState.players[owner].graveyard.push(window.CARDS[unit.tplId]); } catch {}
-      const ctx = getCtx();
+      showOracleDeathBuff(unit.owner, amount);
+      window.addLog(`${cardData.name}: союзники получают +${amount} HP`);
+    }
+    const owner = unit.owner;
+    const slotBeforeGain = gameState.players?.[owner]?.mana || 0;
+    try { gameState.players[owner].graveyard.push(window.CARDS[unit.tplId]); } catch {}
+    const ownerPlayer = gameState.players?.[owner];
+    if (ownerPlayer) {
+      ownerPlayer.mana = capMana((ownerPlayer.mana || 0) + 1);
+    }
+    const ctx = getCtx();
     const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
     const pos = ctx.tileMeshes[row][col].position.clone().add(new THREE.Vector3(0, 1.2, 0));
-    const slot = gameState.players?.[owner]?.mana || 0;
-    window.animateManaGainFromWorld(pos, owner, true, slot);
+    window.animateManaGainFromWorld(pos, owner, true, slotBeforeGain);
     gameState.board[row][col].unit = null;
   }
   if (gameState.board[row][col].unit) {
@@ -745,8 +750,8 @@ export function placeUnitWithDirection(direction) {
             interactionState.pendingAttack = { r: row, c: col };
             interactionState.autoEndTurnAfterAttack = true;
             highlightTiles(hitsAll);
-            window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
-            window.__ui?.notifications?.show('Выберите цель', 'info');
+            window.__ui?.log?.add?.(`${tpl.name}: choose a target for the attack.`);
+            window.__ui?.notifications?.show('Select a target', 'info');
           } else {
             let opts = {};
             if (needsChoice && hitsAll.length === 1) {

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -48,12 +48,12 @@ export function performUnitAttack(unitMesh) {
     // запрет на повторную атаку и на атаку укреплений
     const tpl = window.CARDS?.[unit.tplId];
     if (!canAttack(tpl)) {
-      window.__ui?.notifications?.show('Это укрепление не может атаковать', 'error');
+      window.__ui?.notifications?.show('This fortress cannot attack', 'error');
       return;
     }
     // запрет на повторную атаку в пределах одного хода
     if (unit.lastAttackTurn === gameState.turn) {
-      window.__ui?.notifications?.show('Это существо уже атаковало в этом ходу', 'error');
+      window.__ui?.notifications?.show('This unit has already attacked this turn', 'error');
       return;
     }
     const cost = typeof window.attackCost === 'function' ? window.attackCost(tpl) : 0;
@@ -119,8 +119,8 @@ export function performUnitAttack(unitMesh) {
         highlightTiles(hitsAll);
         try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
       }
-      window.__ui?.log?.add?.(`${tpl.name}: выберите цель для атаки.`);
-      window.__ui?.notifications?.show('Выберите цель', 'info');
+      window.__ui?.log?.add?.(`${tpl.name}: choose a target for the attack.`);
+      window.__ui?.notifications?.show('Select a target', 'info');
       return;
     }
     // если выбор не нужен или доступна единственная цель, атакуем сразу
@@ -223,7 +223,7 @@ export async function endTurn() {
       : 0;
     if (controlledCells >= 5) {
       gameState.winner = gameState.active;
-      w.showNotification?.(`${gameState.players[gameState.active].name} побеждает!`, 'success');
+      w.showNotification?.(`${gameState.players[gameState.active].name} wins!`, 'success');
       return;
     }
 

--- a/src/ui/deckBuilder.js
+++ b/src/ui/deckBuilder.js
@@ -515,7 +515,7 @@ export function open(deck = null, onDone) {
   function addCard(card) {
     const copies = working.cards.filter(c => c.id === card.id).length;
     if (copies >= 3) {
-      showNotification('Лимит копий достигнут', 'error');
+      showNotification('Copy limit reached', 'error');
       return;
     }
     working.cards.push(card);
@@ -574,14 +574,14 @@ export function open(deck = null, onDone) {
       };
       const saved = await saveDeckRemote(payload);
       if (saved) {
-        showNotification('Колода сохранена на сервере', 'success');
+        showNotification('Deck saved on the server', 'success');
       } else {
         throw new Error('Пустой ответ сервера при сохранении');
       }
     } catch (err) {
       console.warn('[deckBuilder] Ошибка сохранения на сервере', err);
       upsertDeck({ ...working, cards: [...working.cards] }, { persistLocal: true });
-      showNotification('Сервер недоступен — колода сохранена локально', 'error');
+      showNotification('Server unavailable — deck saved locally', 'error');
     } finally {
       cleanup();
       onDone && onDone();


### PR DESCRIPTION
## Summary
- add reusable ability handlers for incarnation cost/sacrifice logic and global magic target selection
- register new god units with incarnation mechanics and special magic targeting rules
- update summoning flow and magic combat to support incarnation replacements and board-wide targeting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caaff8facc8330b2c82803c869e175