### PR TITLE
Добавлены ассасины с атакой в спину

### DIFF
--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -244,6 +244,15 @@ export const CARDS = {
     swapWithTargetOnElement: 'WATER',
     desc: 'Gains Invisibility while at least one allied Swallow Ninja is on the board. If Wolf Ninja damages a creature on a Water field, it switches places with that creature (which cannot counterattack).'
   },
+  WATER_VENOAN_ASSASSIN: {
+    id: 'WATER_VENOAN_ASSASSIN', name: 'Venoan Assassin', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    backAttack: true,
+    desc: 'Always attacks the back of its target.'
+  },
   FOREST_SWALLOW_NINJA: {
     id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 1, hp: 3,
@@ -255,6 +264,16 @@ export const CARDS = {
     invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
     rotateTargetOnDamage: true,
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+  MECH_BIOLITH_NINJA: {
+    id: 'MECH_BIOLITH_NINJA', name: 'Biolith Ninja', type: 'UNIT', cost: 4, activation: 2,
+    element: 'MECH', atk: 4, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    backAttack: true,
+    gainPerfectDodgeOnElement: 'MECH',
+    desc: 'While Biolith Ninja is on a Biolith field, it gains Perfect Dodge. Biolith Ninja always attacks the back of its target.'
   },
 
   // Spells (subset)

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -123,13 +123,22 @@ export function computeHits(state, r, c, opts = {}) {
     }
     const backDir = { N: 'S', S: 'N', E: 'W', W: 'E' }[B.facing];
     const [bdr, bdc] = DIR_VECTORS[backDir] || [0, 0];
-    const isBack = (nr + bdr === r && nc + bdc === c);
-    const dirAbsFromB = (() => {
+    const forcedBack = !!tplA.backAttack;
+    let isBack = (!forcedBack && (nr + bdr === r && nc + bdc === c));
+    let dirAbsFromB = (() => {
       if (r === nr - 1 && c === nc) return 'N';
       if (r === nr + 1 && c === nc) return 'S';
       if (r === nr && c === nc - 1) return 'W';
       return 'E';
     })();
+    if (forcedBack) {
+      // Ниндзя с backAttack всегда считаются атакующими со спины,
+      // чтобы корректно добавлять бонус урона и помечать удар как backstab.
+      isBack = true;
+      if (backDir) {
+        dirAbsFromB = backDir;
+      }
+    }
     const ORDER = ['N', 'E', 'S', 'W'];
     const absIdx = ORDER.indexOf(dirAbsFromB);
     const faceIdx = ORDER.indexOf(B.facing);

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -118,6 +118,24 @@ describe('guards and hits', () => {
     const hits = computeHits(state, 1, 1);
     expect(hits.some(h => h.r === 0 && h.c === 1)).toBe(true);
   });
+
+  it('backAttack: ассасины всегда получают бонус за удар в спину', () => {
+    const state = { board: makeBoard() };
+    state.board[1][1].unit = { owner: 0, tplId: 'WATER_VENOAN_ASSASSIN', facing: 'E' };
+    state.board[1][2].unit = { owner: 1, tplId: 'FIRE_PARTMOLE_FLAME_LIZARD', facing: 'W' };
+    const hits = computeHits(state, 1, 1);
+    expect(hits).toHaveLength(1);
+    const hit = hits[0];
+    expect(hit.backstab).toBe(true);
+    expect(hit.dmg).toBe((CARDS.WATER_VENOAN_ASSASSIN.atk || 0) + 1);
+
+    state.board[1][1].unit = { owner: 0, tplId: 'MECH_BIOLITH_NINJA', facing: 'E' };
+    const hitsNinja = computeHits(state, 1, 1);
+    expect(hitsNinja).toHaveLength(1);
+    const backHit = hitsNinja[0];
+    expect(backHit.backstab).toBe(true);
+    expect(backHit.dmg).toBe((CARDS.MECH_BIOLITH_NINJA.atk || 0) + 1);
+  });
 });
 
 describe('особые способности', () => {


### PR DESCRIPTION
## Summary
- добавил в базу карт шаблоны для Venoan Assassin и Biolith Ninja с умением атаки в спину
- доработал расчёт ударов, чтобы умение backAttack всегда давало бонус как удар со спины
- покрыл механику тестами, подтверждающими работу способности для обеих карт

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb85a6df88833082e99d73e2b84433