### PR TITLE
Добавлены карты Веноанский убийца и Биолит-ниндзя

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -163,6 +163,10 @@ export function collectDamageInteractions(state, context = {}) {
 
   for (const h of hits) {
     if (!h) continue;
+    const key = `${h.r},${h.c}`;
+    if (tpl.backAttack) {
+      result.preventRetaliation.add(key);
+    }
     const dealt = h.dealt ?? h.dmg ?? 0;
     if (dealt <= 0) continue;
     const cell = state.board?.[h.r]?.[h.c];
@@ -170,7 +174,6 @@ export function collectDamageInteractions(state, context = {}) {
     if (!target) continue;
     const tplTarget = getUnitTemplate(target);
     const alive = (target.currentHP ?? tplTarget?.hp ?? 0) > 0;
-    const key = `${h.r},${h.c}`;
 
     if (!swapHandled && swapElements.size && alive && cell?.element && swapElements.has(cell.element)) {
       result.events.push({

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -244,6 +244,15 @@ export const CARDS = {
     swapWithTargetOnElement: 'WATER',
     desc: 'Gains Invisibility while at least one allied Swallow Ninja is on the board. If Wolf Ninja damages a creature on a Water field, it switches places with that creature (which cannot counterattack).'
   },
+  WATER_VENOAN_ASSASSIN: {
+    id: 'WATER_VENOAN_ASSASSIN', name: 'Venoan Assassin', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    backAttack: true,
+    desc: 'Always attacks the back of its target.'
+  },
   FOREST_SWALLOW_NINJA: {
     id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 1, hp: 3,
@@ -255,6 +264,17 @@ export const CARDS = {
     invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
     rotateTargetOnDamage: true,
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+
+  MECH_BIOLITH_NINJA: {
+    id: 'MECH_BIOLITH_NINJA', name: 'Biolith Ninja', type: 'UNIT', cost: 4, activation: 2,
+    element: 'MECH', atk: 4, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    backAttack: true,
+    gainPerfectDodgeOnElement: 'MECH',
+    desc: 'While on a Biolith field it gains Perfect Dodge. Always attacks the back of its target.'
   },
 
   // Spells (subset)

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -87,6 +87,7 @@ export function computeHits(state, r, c, opts = {}) {
   const aFlying = (tplA.keywords || []).includes('FLYING');
   const allowPierce = tplA.pierce;
   const allowFriendly = !!tplA.friendlyFire; // может ли существо задевать союзников
+  const forceBackAttack = !!tplA.backAttack;
   for (const cell of cells) {
     const [dr, dc] = DIR_VECTORS[cell.dirAbs];
     const nr = r + dr * cell.range;
@@ -123,7 +124,7 @@ export function computeHits(state, r, c, opts = {}) {
     }
     const backDir = { N: 'S', S: 'N', E: 'W', W: 'E' }[B.facing];
     const [bdr, bdc] = DIR_VECTORS[backDir] || [0, 0];
-    const isBack = (nr + bdr === r && nc + bdc === c);
+    let isBack = (nr + bdr === r && nc + bdc === c);
     const dirAbsFromB = (() => {
       if (r === nr - 1 && c === nc) return 'N';
       if (r === nr + 1 && c === nc) return 'S';
@@ -134,7 +135,11 @@ export function computeHits(state, r, c, opts = {}) {
     const absIdx = ORDER.indexOf(dirAbsFromB);
     const faceIdx = ORDER.indexOf(B.facing);
     const relIdx = (absIdx - faceIdx + 4) % 4;
-    const dirRel = ORDER[relIdx];
+    let dirRel = ORDER[relIdx];
+    if (forceBackAttack) {
+      isBack = true;
+      dirRel = 'S';
+    }
     const blind = CARDS[B.tplId].blindspots || ['S'];
     const inBlind = blind.includes(dirRel);
     const extraTotal = isBack ? 1 : (inBlind ? 1 : 0);

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -259,6 +259,28 @@ describe('особые способности', () => {
     const dmgEntry = fin.targets.find(t => t.r === 1 && t.c === 1);
     expect(dmgEntry?.dmg).toBe(1);
   });
+
+  it('способность backAttack наносит удар в спину и блокирует ответный урон', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[0][1].element = 'MECH';
+    state.board[1][1].unit = { owner:0, tplId:'WATER_VENOAN_ASSASSIN', facing:'N', currentHP:CARDS.WATER_VENOAN_ASSASSIN.hp };
+    state.board[0][1].unit = { owner:1, tplId:'FIRE_TRICEPTAUR_BEHEMOTH', facing:'S', currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp };
+    const hits = computeHits(state,1,1);
+    expect(hits.length).toBeGreaterThan(0);
+    const strike = hits[0];
+    expect(strike.backstab).toBe(true);
+    expect(strike.dmg).toBe(CARDS.WATER_VENOAN_ASSASSIN.atk + 1);
+
+    const res = stagedAttack(state,1,1);
+    const fin = res.finish();
+    const attacker = fin.n1.board[1][1].unit;
+    expect(attacker).toBeTruthy();
+    expect(attacker.currentHP ?? CARDS.WATER_VENOAN_ASSASSIN.hp).toBe(CARDS.WATER_VENOAN_ASSASSIN.hp);
+    const defender = fin.n1.board[0][1].unit;
+    expect(defender).toBeTruthy();
+    expect(defender.currentHP).toBe(CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp - strike.dmg);
+    expect(fin.retaliators.length).toBe(0);
+  });
 });
 
 describe('magicAttack', () => {


### PR DESCRIPTION
## Summary
- добавлены шаблоны карт Venoan Assassin и Biolith Ninja с флагом backAttack и соответствующим описанием
- обновлена логика расчёта ударов и взаимодействий урона, чтобы backAttack считался атакой со спины и блокировал контратаку
- добавлены юнит-тесты, проверяющие новую механику атаки со спины

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb85a6df88833082e99d73e2b84433