### PR TITLE
Add cubic sacrifice actions and UI support

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
       <div class="overlay-panel p-6 space-y-3">
         <div id="unit-info" class="text-center mb-4"></div>
         <button id="attack-btn" class="w-full overlay-panel px-4 py-2 bg-red-600 hover:bg-red-700">Attack</button>
+        <div id="unit-extra-actions" class="space-y-2"></div>
         <div class="grid grid-cols-2 gap-2">
           <button id="rotate-cw-btn" class="overlay-panel px-4 py-2 hover:bg-slate-700">Rotate ↻</button>
           <button id="rotate-ccw-btn" class="overlay-panel px-4 py-2 hover:bg-slate-700">Rotate ↺</button>

--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -11,6 +11,10 @@ import {
   collectSacrificeActions,
   executeSacrificeAction,
 } from './abilityHandlers/sacrifice.js';
+import {
+  ensureDodgeState,
+  attemptDodge as attemptDodgeInternal,
+} from './abilityHandlers/dodge.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -389,6 +393,8 @@ export function applySummonAbilities(state, r, c) {
   const tpl = getUnitTemplate(unit);
   if (!tpl) return events;
 
+  ensureDodgeState(unit, tpl);
+
   const possessionCfg = normalizeElementConfig(
     tpl.gainPossessionEnemiesOnElement,
     { requireDifferentField: true }
@@ -531,6 +537,8 @@ export function getTargetElementBonus(tpl, state, hits) {
 export { isIncarnationCard };
 export const evaluateIncarnationSummon = evaluateIncarnationSummonInternal;
 export const applyIncarnationSummon = applyIncarnationSummonInternal;
+export const ensureUnitDodgeState = ensureDodgeState;
+export const attemptUnitDodge = attemptDodgeInternal;
 
 export function collectUnitActions(state, r, c) {
   const actions = [];

--- a/src/core/abilityHandlers/dodge.js
+++ b/src/core/abilityHandlers/dodge.js
@@ -1,0 +1,153 @@
+// Модуль обработки ключевого слова "dodge" и его вариаций
+import { CARDS } from '../cards.js';
+
+function clampChance(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0.5;
+  if (num <= 0) return 0;
+  if (num >= 1) return 1;
+  return num;
+}
+
+function normalizeAttempts(value) {
+  if (value == null) return null;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (num <= 0) return 0;
+  return Math.floor(num);
+}
+
+function resolveDodgeSource(tpl) {
+  if (!tpl) return null;
+  if (tpl.dodge != null) return tpl.dodge;
+  if (tpl.dodge50) return { chance: 0.5, keyword: 'DODGE' };
+  return null;
+}
+
+export function getDodgeConfig(tpl) {
+  const source = resolveDodgeSource(tpl);
+  if (!source || source === false) return null;
+
+  let chance = 0.5;
+  let attempts = null;
+  let keyword = null;
+
+  if (source === true) {
+    chance = 0.5;
+  } else if (typeof source === 'number') {
+    attempts = source;
+  } else if (typeof source === 'string') {
+    const lower = source.toLowerCase();
+    if (lower.includes('attempt')) {
+      attempts = 1;
+    }
+  } else if (typeof source === 'object') {
+    if (source.chance != null) chance = source.chance;
+    else if (source.rate != null) chance = source.rate;
+    else if (source.probability != null) chance = source.probability;
+    if (source.attempts != null) attempts = source.attempts;
+    else if (source.successes != null) attempts = source.successes;
+    else if (source.maxSuccesses != null) attempts = source.maxSuccesses;
+    else if (source.limit != null) attempts = source.limit;
+    if (source.keyword) keyword = source.keyword;
+  }
+
+  const normalizedChance = clampChance(chance);
+  const normalizedAttempts = normalizeAttempts(attempts);
+  const limited = normalizedAttempts != null;
+  const normalizedKeyword = keyword
+    ? String(keyword).toUpperCase()
+    : (limited ? 'DODGE_ATTEMPT' : 'DODGE');
+
+  return {
+    chance: normalizedChance,
+    successes: normalizedAttempts,
+    keyword: normalizedKeyword,
+  };
+}
+
+export function ensureDodgeState(unit, tpl, configOverride = null) {
+  if (!unit) return null;
+  const tplRef = tpl || (unit.tplId ? CARDS[unit.tplId] : null);
+  const cfg = configOverride || getDodgeConfig(tplRef);
+  if (!cfg) {
+    if (unit.dodgeState) delete unit.dodgeState;
+    return null;
+  }
+
+  const limited = cfg.successes != null;
+  const max = limited ? cfg.successes : null;
+  const existing = unit.dodgeState;
+  if (existing && existing.version === 1 && existing.keyword === cfg.keyword &&
+      existing.limited === limited && existing.max === max && existing.chance === cfg.chance) {
+    return existing;
+  }
+
+  const state = {
+    version: 1,
+    keyword: cfg.keyword,
+    chance: cfg.chance,
+    limited,
+    max,
+    remaining: limited ? max : null,
+    successesUsed: 0,
+  };
+  unit.dodgeState = state;
+  return state;
+}
+
+export function attemptDodge(state, r, c, opts = {}) {
+  const board = state?.board;
+  if (!board) {
+    return { success: false, reason: 'NO_BOARD' };
+  }
+  const cell = board?.[r]?.[c];
+  const unit = cell?.unit;
+  if (!unit) {
+    return { success: false, reason: 'NO_UNIT' };
+  }
+  const tpl = unit.tplId ? CARDS[unit.tplId] : null;
+  const cfg = getDodgeConfig(tpl);
+  if (!cfg) {
+    return { success: false, reason: 'NO_DODGE' };
+  }
+
+  const stateObj = ensureDodgeState(unit, tpl, cfg);
+  if (!stateObj) {
+    return { success: false, reason: 'NO_STATE' };
+  }
+
+  const hadAttempts = !stateObj.limited || (stateObj.remaining ?? 0) > 0;
+  if (!hadAttempts) {
+    return {
+      success: false,
+      reason: 'EXHAUSTED',
+      limited: stateObj.limited,
+      attemptsLeft: stateObj.limited ? (stateObj.remaining ?? 0) : null,
+      keyword: stateObj.keyword,
+      attempted: false,
+    };
+  }
+
+  const rng = typeof opts.rng === 'function' ? opts.rng : Math.random;
+  const roll = clampChance(rng());
+  const success = roll < stateObj.chance;
+  if (success) {
+    if (stateObj.limited && stateObj.remaining != null) {
+      stateObj.remaining = Math.max(0, stateObj.remaining - 1);
+    }
+    stateObj.successesUsed = (stateObj.successesUsed || 0) + 1;
+    stateObj.lastSuccessTurn = state?.turn ?? null;
+  }
+
+  return {
+    success,
+    roll,
+    chance: stateObj.chance,
+    limited: stateObj.limited,
+    attemptsLeft: stateObj.limited ? (stateObj.remaining ?? 0) : null,
+    consumed: success,
+    keyword: stateObj.keyword,
+    attempted: true,
+  };
+}

--- a/src/core/abilityHandlers/sacrifice.js
+++ b/src/core/abilityHandlers/sacrifice.js
@@ -1,0 +1,259 @@
+// Модуль обработки способности "жертвоприношение" для кубов и похожих карт
+import { CARDS } from '../cards.js';
+import { computeCellBuff } from '../fieldEffects.js';
+
+const FACING_ORDER = ['N', 'E', 'S', 'W'];
+
+function isValidFacing(facing) {
+  return FACING_ORDER.includes(facing);
+}
+
+function isCubicTemplate(tpl) {
+  if (!tpl) return false;
+  const id = typeof tpl.id === 'string' ? tpl.id : (tpl.tplId || '');
+  const name = typeof tpl.name === 'string' ? tpl.name : '';
+  const idUpper = id.toUpperCase();
+  const nameUpper = name.toUpperCase();
+  return idUpper.includes('CUBIC') || nameUpper.includes('CUBIC');
+}
+
+function normalizeElements(entry, tpl) {
+  const raw = entry?.elements || entry?.element;
+  if (!raw && tpl?.element) {
+    return new Set([String(tpl.element).toUpperCase()]);
+  }
+  const values = Array.isArray(raw) ? raw : [raw];
+  const set = new Set();
+  for (const v of values) {
+    if (typeof v === 'string' && v.trim()) {
+      set.add(v.trim().toUpperCase());
+    }
+  }
+  return set;
+}
+
+function normalizeSacrificeEntry(entry, tpl) {
+  if (!entry) return null;
+  const elements = normalizeElements(entry, tpl);
+  if (!elements.size) return null;
+  return {
+    key: 'SACRIFICE_TRANSFORM',
+    label: entry.label || 'Sacrifice',
+    prompt: entry.prompt || 'Select a unit card in hand for the sacrifice',
+    elements,
+    requireNonCubic: entry.requireNonCubic !== false,
+  };
+}
+
+function collectCandidates(hand, config) {
+  if (!Array.isArray(hand)) return [];
+  const result = [];
+  for (let i = 0; i < hand.length; i += 1) {
+    const card = hand[i];
+    if (!card || card.type !== 'UNIT') continue;
+    const tpl = CARDS[card.id] || card;
+    if (!tpl) continue;
+    if (config.requireNonCubic && isCubicTemplate(tpl)) continue;
+    if (!config.elements.has(String(tpl.element || '').toUpperCase())) continue;
+    result.push({ handIdx: i, tplId: tpl.id, name: tpl.name || tpl.id });
+  }
+  return result;
+}
+
+export function collectSacrificeActions(state, context = {}) {
+  const { unit, tpl, r, c } = context;
+  const actions = [];
+  if (!state || !unit || !tpl) return actions;
+  const entries = Array.isArray(tpl.unitActions) ? tpl.unitActions : [];
+  for (const entry of entries) {
+    if (!entry) continue;
+    const key = entry.key || entry.type;
+    if (key !== 'SACRIFICE_TRANSFORM') continue;
+    const config = normalizeSacrificeEntry(entry, tpl);
+    if (!config) continue;
+    const owner = unit.owner;
+    const player = state.players?.[owner];
+    const candidates = collectCandidates(player?.hand, config);
+    actions.push({
+      type: 'SACRIFICE_TRANSFORM',
+      label: config.label,
+      prompt: config.prompt,
+      requiresHandSelection: true,
+      requiresOrientation: true,
+      available: candidates.length > 0,
+      unavailableReason: candidates.length === 0 ? 'No matching unit in hand' : null,
+      candidates,
+      config,
+      owner,
+      r,
+      c,
+      unitUid: unit.uid ?? null,
+    });
+  }
+  return actions;
+}
+
+function ensureCollection(arr) {
+  return Array.isArray(arr) ? arr : [];
+}
+
+function getTemplateRef(raw) {
+  if (!raw) return null;
+  if (raw.id && CARDS[raw.id]) return CARDS[raw.id];
+  if (raw.tplId && CARDS[raw.tplId]) return CARDS[raw.tplId];
+  if (raw.id && !CARDS[raw.id]) return raw;
+  return raw;
+}
+
+export function executeSacrificeAction(state, action = {}, payload = {}) {
+  if (!state || !state.board) {
+    return { ok: false, reason: 'NO_STATE' };
+  }
+  if (!action || action.type !== 'SACRIFICE_TRANSFORM') {
+    return { ok: false, reason: 'INVALID_ACTION' };
+  }
+  const { r, c, owner, config } = action;
+  if (typeof r !== 'number' || typeof c !== 'number') {
+    return { ok: false, reason: 'INVALID_POSITION' };
+  }
+  const cell = state.board?.[r]?.[c];
+  if (!cell || !cell.unit) {
+    return { ok: false, reason: 'NO_UNIT' };
+  }
+  const unit = cell.unit;
+  if (typeof owner === 'number' && unit.owner !== owner) {
+    return { ok: false, reason: 'UNIT_OWNER_CHANGED' };
+  }
+  const player = state.players?.[unit.owner];
+  if (!player) {
+    return { ok: false, reason: 'NO_PLAYER' };
+  }
+  const handIdx = payload.handIdx;
+  if (typeof handIdx !== 'number' || handIdx < 0 || handIdx >= ensureCollection(player.hand).length) {
+    return { ok: false, reason: 'INVALID_HAND_INDEX' };
+  }
+  const facing = payload.facing;
+  if (!isValidFacing(facing)) {
+    return { ok: false, reason: 'INVALID_FACING' };
+  }
+  const uidFn = typeof payload.uidFn === 'function'
+    ? payload.uidFn
+    : (() => Math.random().toString(36).slice(2, 9));
+
+  const rawCard = player.hand[handIdx];
+  const summonTpl = getTemplateRef(rawCard);
+  if (!summonTpl || summonTpl.type !== 'UNIT') {
+    return { ok: false, reason: 'INVALID_CARD' };
+  }
+  if (config && config.requireNonCubic && isCubicTemplate(summonTpl)) {
+    return { ok: false, reason: 'TARGET_IS_CUBIC' };
+  }
+  if (config) {
+    const el = String(summonTpl.element || '').toUpperCase();
+    if (!config.elements.has(el)) {
+      return { ok: false, reason: 'INVALID_ELEMENT' };
+    }
+  }
+
+  const sacrificeTpl = getTemplateRef(cell.unit);
+  const graveyard = Array.isArray(player.graveyard) ? player.graveyard : (player.graveyard = []);
+  if (sacrificeTpl) {
+    graveyard.push(sacrificeTpl);
+  }
+
+  // Удаляем существо с клетки до появления нового
+  cell.unit = null;
+
+  // Удаляем карту из руки и переносим в сброс
+  const discard = Array.isArray(player.discard) ? player.discard : (player.discard = []);
+  discard.push(summonTpl);
+  player.hand.splice(handIdx, 1);
+
+  // Создаём нового юнита на поле
+  const newUnit = {
+    uid: uidFn(),
+    owner: unit.owner,
+    tplId: summonTpl.id,
+    currentHP: summonTpl.hp,
+    facing,
+    lastAttackTurn: state.turn ?? 0,
+  };
+  cell.unit = newUnit;
+
+  const result = {
+    ok: true,
+    type: 'SACRIFICE_TRANSFORM',
+    owner: unit.owner,
+    r,
+    c,
+    unitUid: newUnit.uid,
+    sacrifice: {
+      tplId: sacrificeTpl?.id ?? unit.tplId ?? null,
+      tplName: sacrificeTpl?.name || null,
+    },
+    replacement: {
+      tplId: summonTpl.id,
+      tplName: summonTpl.name || summonTpl.id,
+      facing,
+      alive: true,
+    },
+    removedHandIdx: handIdx,
+    events: {},
+  };
+
+  const cellElement = cell.element || null;
+  const buff = computeCellBuff(cellElement, summonTpl.element);
+  if (buff.hp !== 0) {
+    const before = newUnit.currentHP;
+    newUnit.currentHP = Math.max(0, before + buff.hp);
+    result.replacement.buff = {
+      element: cellElement,
+      amount: buff.hp,
+      before,
+      after: newUnit.currentHP,
+    };
+  }
+
+  let alive = newUnit.currentHP > 0;
+  let deathReason = null;
+  if (alive && summonTpl.diesOffElement && cellElement !== summonTpl.diesOffElement) {
+    alive = false;
+    deathReason = 'OFF_ELEMENT';
+  }
+  if (alive && summonTpl.diesOnElement && cellElement === summonTpl.diesOnElement) {
+    alive = false;
+    deathReason = 'ON_ELEMENT';
+  }
+
+  if (!alive) {
+    result.replacement.alive = false;
+    result.replacement.deathReason = deathReason;
+    const tplDeath = getTemplateRef(summonTpl);
+    graveyard.push(tplDeath);
+    cell.unit = null;
+
+    if (summonTpl.onDeathAddHPAll) {
+      const amount = summonTpl.onDeathAddHPAll;
+      for (let rr = 0; rr < 3; rr += 1) {
+        for (let cc = 0; cc < 3; cc += 1) {
+          if (rr === r && cc === c) continue;
+          const ally = state.board?.[rr]?.[cc]?.unit;
+          if (!ally || ally.owner !== newUnit.owner) continue;
+          const allyTpl = getTemplateRef(ally);
+          if (!allyTpl) continue;
+          const allyCellElement = state.board?.[rr]?.[cc]?.element || null;
+          const allyBuff = computeCellBuff(allyCellElement, allyTpl.element);
+          ally.bonusHP = (ally.bonusHP || 0) + amount;
+          const maxHp = (allyTpl.hp || 0) + allyBuff.hp + (ally.bonusHP || 0);
+          const beforeHp = typeof ally.currentHP === 'number' ? ally.currentHP : allyTpl.hp || 0;
+          ally.currentHP = Math.min(maxHp, beforeHp + amount);
+        }
+      }
+      result.events.oracleBuff = { owner: newUnit.owner, amount };
+    }
+  }
+
+  return result;
+}
+
+export default { collectSacrificeActions, executeSacrificeAction };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -310,6 +310,18 @@ export const CARDS = {
     ],
     desc: 'Sacrifice Green Cubic to summon a non‑cubic Wood creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
+  NEUTRAL_WHITE_CUBIC: {
+    id: 'NEUTRAL_WHITE_CUBIC', name: 'White Cubic', type: 'UNIT', cost: 1, activation: 1,
+    element: 'NEUTRAL', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['E', 'S', 'W'],
+    dodge50: true,
+    unitActions: [
+      { key: 'SACRIFICE_TRANSFORM', label: 'Sacrifice', allowAnyElement: true, requireNonCubic: false },
+    ],
+    desc: 'White Cubic does not belong to any element. Sacrifice White Cubic to summon any creature in its place (facing any direction) without paying the Summoning Cost. The summoned creature cannot attack this turn. Dodge attempt.'
+  },
 
   BIOLITH_NINJA: {
     id: 'BIOLITH_NINJA', name: 'Biolith Ninja', type: 'UNIT', cost: 4, activation: 2,

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -158,6 +158,18 @@ export const CARDS = {
     desc: 'Attacks the same target twice (counterattack after second attack). While on a Fire field he must use his Magic Attack, which affects the target and all adjacent enemies. The Attack value is equal to the number of Fire fields.'
   },
 
+  FIRE_RED_CUBIC: {
+    id: 'FIRE_RED_CUBIC', name: 'Red Cubic', type: 'UNIT', cost: 1, activation: 1,
+    element: 'FIRE', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['E', 'S', 'W'],
+    unitActions: [
+      { key: 'SACRIFICE_TRANSFORM', element: 'FIRE', label: 'Sacrifice', requireNonCubic: true },
+    ],
+    desc: 'Sacrifice Red Cubic to summon a non‑cubic Fire creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
+  },
+
   FIRE_SCIONDAR_FIRE_GOD: {
     id: 'FIRE_SCIONDAR_FIRE_GOD', name: 'Sciondar Fire God', type: 'UNIT', cost: 9, activation: 5,
     element: 'FIRE', atk: 3, hp: 9,
@@ -234,6 +246,17 @@ export const CARDS = {
     swapWithTargetOnElement: 'EARTH',
     desc: 'Magic attack. Gains Invisibility while at least one allied Wolf Ninja is on the board. If it damages a creature on an Earth field, it switches places with that creature (which cannot counterattack).'
   },
+  EARTH_YELLOW_CUBIC: {
+    id: 'EARTH_YELLOW_CUBIC', name: 'Yellow Cubic', type: 'UNIT', cost: 1, activation: 1,
+    element: 'EARTH', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['E', 'S', 'W'],
+    unitActions: [
+      { key: 'SACRIFICE_TRANSFORM', element: 'EARTH', label: 'Sacrifice', requireNonCubic: true },
+    ],
+    desc: 'Sacrifice Yellow Cubic to summon a non‑cubic Earth creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
+  },
   WATER_WOLF_NINJA: {
     id: 'WATER_WOLF_NINJA', name: 'Wolf Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 1, hp: 3,
@@ -243,6 +266,17 @@ export const CARDS = {
     invisibilityAllies: ['FOREST_SWALLOW_NINJA'],
     swapWithTargetOnElement: 'WATER',
     desc: 'Gains Invisibility while at least one allied Swallow Ninja is on the board. If Wolf Ninja damages a creature on a Water field, it switches places with that creature (which cannot counterattack).'
+  },
+  WATER_BLUE_CUBIC: {
+    id: 'WATER_BLUE_CUBIC', name: 'Blue Cubic', type: 'UNIT', cost: 1, activation: 1,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['E', 'S', 'W'],
+    unitActions: [
+      { key: 'SACRIFICE_TRANSFORM', element: 'WATER', label: 'Sacrifice', requireNonCubic: true },
+    ],
+    desc: 'Sacrifice Blue Cubic to summon a non‑cubic Water creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
   WATER_VENOAN_ASSASSIN: {
     id: 'WATER_VENOAN_ASSASSIN', name: 'Venoan Assassin', type: 'UNIT', cost: 3, activation: 2,
@@ -264,6 +298,17 @@ export const CARDS = {
     invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
     rotateTargetOnDamage: true,
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+  FOREST_GREEN_CUBIC: {
+    id: 'FOREST_GREEN_CUBIC', name: 'Green Cubic', type: 'UNIT', cost: 1, activation: 1,
+    element: 'FOREST', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['E', 'S', 'W'],
+    unitActions: [
+      { key: 'SACRIFICE_TRANSFORM', element: 'FOREST', label: 'Sacrifice', requireNonCubic: true },
+    ],
+    desc: 'Sacrifice Green Cubic to summon a non‑cubic Wood creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
 
   BIOLITH_NINJA: {

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -316,7 +316,8 @@ export const CARDS = {
     attackType: 'STANDARD',
     attacks: [ { dir: 'N', ranges: [1] } ],
     blindspots: ['E', 'S', 'W'],
-    dodge50: true,
+    keywords: ['DODGE_ATTEMPT'],
+    dodge: { chance: 0.5, attempts: 1 },
     unitActions: [
       { key: 'SACRIFICE_TRANSFORM', label: 'Sacrifice', allowAnyElement: true, requireNonCubic: false },
     ],

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -47,7 +47,15 @@ export function attachUIEvents() {
 
   document.getElementById('cancel-action-btn')?.addEventListener('click', () => {
     w.__interactions?.clearSelectedUnit?.();
+    w.__interactions?.clearPendingUnitAbility?.();
+    w.__interactions?.clearPendingAbilityOrientation?.();
+    if (w.__interactions?.interactionState) {
+      w.__interactions.interactionState.pendingDiscardSelection = null;
+    }
+    w.__ui?.panels?.hidePrompt?.();
+    w.__ui?.panels?.hideOrientationPanel?.();
     w.__ui?.panels?.hideUnitActionPanel?.();
+    w.__ui?.cancelButton?.refreshCancelButton?.();
   });
 
   document.getElementById('rotate-cw-btn')?.addEventListener('click', () => {
@@ -66,6 +74,11 @@ export function attachUIEvents() {
   document.querySelectorAll('[data-dir]').forEach(btn => {
     btn.addEventListener('click', () => {
       const direction = btn.getAttribute('data-dir');
+      const abilityOrientation = w.__interactions?.getPendingAbilityOrientation?.();
+      if (abilityOrientation) {
+        w.__ui?.actions?.confirmUnitAbilityOrientation?.(abilityOrientation, direction);
+        return;
+      }
       const pso = w.__interactions?.getPendingSpellOrientation?.();
       const gameState = w.gameState;
       if (pso) {

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -144,6 +144,35 @@ describe('особые способности', () => {
     expect(res.n1.board[1][1].unit).toBeNull();
   });
 
+  it('dodge attempt спасает один раз', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[1][1].unit = { owner:0, tplId:'FIRE_PARTMOLE_FLAME_LIZARD', facing:'E' };
+    state.board[1][2].unit = { owner:1, tplId:'NEUTRAL_WHITE_CUBIC', facing:'W', currentHP:1 };
+    const res1 = stagedAttack(state,1,1,{ rng: () => 0 });
+    const fin1 = res1.finish();
+    const cubicAfterFirst = fin1.n1.board[1][2].unit;
+    expect(cubicAfterFirst).toBeTruthy();
+    const tplCubic = CARDS[cubicAfterFirst.tplId];
+    expect(cubicAfterFirst.currentHP ?? tplCubic.hp).toBe(tplCubic.hp);
+    expect(cubicAfterFirst.dodgeState?.remaining ?? 0).toBe(0);
+
+    const state2 = fin1.n1;
+    state2.board[1][1].unit.lastAttackTurn = 0;
+    state2.turn += 1;
+
+    const res2 = stagedAttack(state2,1,1,{ rng: () => 0 });
+    const fin2 = res2.finish();
+    expect(fin2.n1.board[1][2].unit).toBeNull();
+  });
+
+  it('dodge не защищает от магии', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[1][0].unit = { owner:0, tplId:'FIRE_FLAME_MAGUS', facing:'E' };
+    state.board[1][1].unit = { owner:1, tplId:'NEUTRAL_WHITE_CUBIC', facing:'W', currentHP:1 };
+    const res = magicAttack(state,1,0,1,1);
+    expect(res.n1.board[1][1].unit).toBeNull();
+  });
+
   it('quickness позволяет контратаковать первым', () => {
     const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
     state.board[1][0].unit = { owner:0, tplId:'FIRE_FREEDONIAN_WANDERER', facing:'E', currentHP:1 };


### PR DESCRIPTION
## Summary
- implement reusable sacrifice handler for cubic creatures and hook it into the core ability registry
- add Fire, Water, Earth and Wood cubic cards with the shared sacrifice action
- extend the unit action panel and UI flow to trigger unit abilities, including sacrifice card/orientation selection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9785b79c8330b70e97cd08b92663