### PR TITLE
Add Biolith expansion units and summon cost bonus handling

### DIFF
--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -324,6 +324,58 @@ export const CARDS = {
     desc: 'White Cubic does not belong to any element. Sacrifice White Cubic to summon any creature in its place (facing any direction) without paying the Summoning Cost. The summoned creature cannot attack this turn. Dodge attempt.'
   },
 
+  FOREST_TWIN_GOBLINS: {
+    id: 'FOREST_TWIN_GOBLINS', name: 'Twin Goblins', type: 'UNIT', cost: 2, activation: 1,
+    element: 'FOREST', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1] },
+      { dir: 'S', ranges: [1] },
+    ],
+    friendlyFire: true,
+    blindspots: [],
+    desc: 'Атакует одновременно клетки перед и позади себя. Может задевать союзников.'
+  },
+
+  BIOLITH_BIOLITH_BOMBER: {
+    id: 'BIOLITH_BIOLITH_BOMBER', name: 'Biolith Bomber', type: 'UNIT', cost: 3, activation: 2,
+    element: 'BIOLITH', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    plusAtkVsSummonCost: { max: 2, amount: 2 },
+    desc: 'Добавляет 2 к атаке, если цель имеет стоимость призыва 2 или меньше.'
+  },
+
+  BIOLITH_BIOLITH_BATTLE_CHARIOT: {
+    id: 'BIOLITH_BIOLITH_BATTLE_CHARIOT', name: 'Biolith Battle Chariot', type: 'UNIT', cost: 4, activation: 4,
+    element: 'BIOLITH', atk: 3, hp: 5,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1, 2] },
+      { dir: 'E', ranges: [1, 2] },
+    ],
+    blindspots: ['S'],
+    friendlyFire: true,
+    pierce: true,
+    desc: 'Выберите направление: телега поражает две клетки по выбранной линии (впереди или справа), задев и союзников, и врагов.'
+  },
+
+  BIOLITH_ARC_SATELLITE_CANNON: {
+    id: 'BIOLITH_ARC_SATELLITE_CANNON', name: 'Arc Satellite Cannon', type: 'UNIT', cost: 5, activation: 4,
+    element: 'BIOLITH', atk: 4, hp: 5,
+    attackType: 'MAGIC', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [2] },
+      { dir: 'E', ranges: [2] },
+      { dir: 'S', ranges: [2] },
+      { dir: 'W', ranges: [2] },
+    ],
+    blindspots: ['S'],
+    pierce: true,
+    desc: 'Магическая атака: выберите одну из подсвеченных клеток и нанесите урон цели на расстоянии.'
+  },
+
   BIOLITH_NINJA: {
     id: 'BIOLITH_NINJA', name: 'Biolith Ninja', type: 'UNIT', cost: 4, activation: 2,
     element: 'BIOLITH', atk: 4, hp: 2,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -6,6 +6,7 @@ import {
   hasDoubleAttack,
   canAttack,
   getTargetElementBonus,
+  getTargetSummonCostBonus,
   collectMagicTargetCells,
   computeDynamicMagicAttack,
   releasePossessionsAfterDeaths,
@@ -196,6 +197,12 @@ export function stagedAttack(state, r, c, opts = {}) {
       atk += amount;
       logLines.push(`${tplA.name}: +${amount} ATK по целям на поле ${el}`);
     }
+  }
+  const costBonus = getTargetSummonCostBonus(tplA, base, hitsRaw, { attacker, attackerOwner: attacker?.owner });
+  if (costBonus) {
+    atk += costBonus.amount;
+    const cond = costBonus.condition ? ` (стоимость ${costBonus.condition})` : '';
+    logLines.push(`${tplA.name}: +${costBonus.amount} ATK по цели${cond}`);
   }
   if (targetBonus) {
     atk += targetBonus.amount;
@@ -518,9 +525,15 @@ export function magicAttack(state, fr, fc, tr, tc) {
   }
 
   const elementBonus = getTargetElementBonus(tplA, n1, cells);
+  const costBonusMagic = getTargetSummonCostBonus(tplA, n1, cells, { attacker, attackerOwner: attacker?.owner });
   if (elementBonus) {
     atk += elementBonus.amount;
     logLines.push(`${tplA.name}: +${elementBonus.amount} ATK против существ стихии ${elementBonus.element}`);
+  }
+  if (costBonusMagic) {
+    atk += costBonusMagic.amount;
+    const cond = costBonusMagic.condition ? ` (стоимость ${costBonusMagic.condition})` : '';
+    logLines.push(`${tplA.name}: +${costBonusMagic.amount} ATK по цели${cond}`);
   }
 
   const randomBonus = (tplA.randomPlus2 && Math.random() < 0.5) ? 2 : 0;


### PR DESCRIPTION
## Summary
- add card definitions for Biolith Bomber, Arc Satellite Cannon, Biolith Battle Chariot and Twin Goblins
- extend ability helpers to support attack bonuses versus targets by summoning cost
- update combat rules and tests for the new units and mechanics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbbed522e483308e644e4c71709268