### PR TITLE
Добавлены новые карты Biolith и гоблинов

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -15,6 +15,7 @@ import {
   ensureDodgeState,
   attemptDodge as attemptDodgeInternal,
 } from './abilityHandlers/dodge.js';
+import { computeTargetCostBonus as computeTargetCostBonusInternal } from './abilityHandlers/attackModifiers.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -532,6 +533,10 @@ export function getTargetElementBonus(tpl, state, hits) {
   });
   if (!has) return null;
   return { amount, element: cfg.element };
+}
+
+export function getTargetCostBonus(state, tpl, hits) {
+  return computeTargetCostBonusInternal(state, tpl, hits);
 }
 
 export { isIncarnationCard };

--- a/src/core/abilityHandlers/attackModifiers.js
+++ b/src/core/abilityHandlers/attackModifiers.js
@@ -1,0 +1,70 @@
+// Обработчики модификаторов атаки, зависящих от параметров цели
+import { CARDS } from '../cards.js';
+
+function normalizeLimit(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'object') {
+    if (typeof value.limit === 'number') return value.limit;
+    if (typeof value.maxCost === 'number') return value.maxCost;
+    if (typeof value.threshold === 'number') return value.threshold;
+    if (typeof value.cost === 'number') return value.cost;
+    if (typeof value.max === 'number') return value.max;
+  }
+  return null;
+}
+
+function normalizeAmount(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'object') {
+    if (typeof value.amount === 'number') return value.amount;
+    if (typeof value.bonus === 'number') return value.bonus;
+    if (typeof value.plus === 'number') return value.plus;
+    if (typeof value.value === 'number') return value.value;
+  }
+  return null;
+}
+
+function normalizeConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'number') {
+    return { limit: raw, amount: 1 };
+  }
+  if (typeof raw === 'object') {
+    const limit = normalizeLimit(raw);
+    const amount = normalizeAmount(raw);
+    if (limit == null || amount == null) return null;
+    return { limit, amount };
+  }
+  return null;
+}
+
+function targetCost(state, hit) {
+  if (!state || !hit) return null;
+  const unit = state.board?.[hit.r]?.[hit.c]?.unit;
+  if (!unit) return null;
+  const tpl = CARDS[unit.tplId];
+  if (!tpl) return null;
+  const cost = tpl.cost;
+  return (typeof cost === 'number' && Number.isFinite(cost)) ? cost : null;
+}
+
+export function computeTargetCostBonus(state, tpl, hits) {
+  if (!tpl || !Array.isArray(hits) || !hits.length) return null;
+  const cfgRaw = tpl.plusAtkVsSummonCostAtMost || tpl.plusAtkIfTargetCostLeq;
+  const cfg = normalizeConfig(cfgRaw);
+  if (!cfg) return null;
+  const { limit, amount } = cfg;
+  if (!Number.isFinite(limit) || !Number.isFinite(amount) || amount === 0) {
+    return null;
+  }
+  const qualifies = hits.some(hit => {
+    const cost = targetCost(state, hit);
+    return cost != null && cost <= limit;
+  });
+  if (!qualifies) return null;
+  return { amount, limit };
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -335,6 +335,61 @@ export const CARDS = {
     desc: 'While on a Biolith field it gains Perfect Dodge. Always attacks the back of its target.'
   },
 
+  BIOLITH_BOMBER: {
+    id: 'BIOLITH_BOMBER', name: 'Biolith Bomber', type: 'UNIT', cost: 3, activation: 2,
+    element: 'BIOLITH', atk: 1, hp: 3,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1, 2], mode: 'ANY' },
+      { dir: 'E', ranges: [1, 2], mode: 'ANY' },
+      { dir: 'S', ranges: [1, 2], mode: 'ANY' },
+      { dir: 'W', ranges: [1, 2], mode: 'ANY' },
+    ],
+    blindspots: ['S'],
+    plusAtkVsSummonCostAtMost: { limit: 2, amount: 2 },
+    desc: 'Adds 2 to its Attack if the target creature has a Summoning Cost of 2 or lower.'
+  },
+
+  BIOLITH_BATTLE_CHARIOT: {
+    id: 'BIOLITH_BATTLE_CHARIOT', name: 'Biolith Battle Chariot', type: 'UNIT', cost: 4, activation: 4,
+    element: 'BIOLITH', atk: 3, hp: 5,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1] },
+      { dir: 'E', ranges: [1] },
+    ],
+    friendlyFire: true,
+    blindspots: ['S'],
+    desc: ''
+  },
+
+  BIOLITH_ARC_SATELLITE_CANNON: {
+    id: 'BIOLITH_ARC_SATELLITE_CANNON', name: 'Arc Satellite Cannon', type: 'UNIT', cost: 5, activation: 4,
+    element: 'BIOLITH', atk: 4, hp: 5,
+    attackType: 'MAGIC', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1, 2], mode: 'ANY' },
+      { dir: 'E', ranges: [1, 2], mode: 'ANY' },
+      { dir: 'S', ranges: [1, 2], mode: 'ANY' },
+      { dir: 'W', ranges: [1, 2], mode: 'ANY' },
+    ],
+    blindspots: ['S'],
+    desc: 'Magic Attack: choose one highlighted cell in front, back, left or right to target.'
+  },
+
+  FOREST_TWIN_GOBLINS: {
+    id: 'FOREST_TWIN_GOBLINS', name: 'Twin Goblins', type: 'UNIT', cost: 2, activation: 1,
+    element: 'FOREST', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1] },
+      { dir: 'S', ranges: [1] },
+    ],
+    blindspots: [],
+    friendlyFire: true,
+    desc: ''
+  },
+
   // Spells (subset)
   RAISE_STONE: { id:'RAISE_STONE', name:'Raise Stone', type:'SPELL', cost:2, element:'EARTH', text:'+2 HP to a friendly unit.' },
   SPELL_FISSURES_OF_GOGHLIE: { id: 'SPELL_FISSURES_OF_GOGHLIE', name: 'Fissures of Goghlie', type: 'SPELL', element: 'NEUTRAL', spellType: 'CONJURATION', cost: 2, text: 'Fieldquake any one field.' },

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -6,6 +6,7 @@ import {
   hasDoubleAttack,
   canAttack,
   getTargetElementBonus,
+  getTargetCostBonus,
   collectMagicTargetCells,
   computeDynamicMagicAttack,
   releasePossessionsAfterDeaths,
@@ -196,6 +197,11 @@ export function stagedAttack(state, r, c, opts = {}) {
       atk += amount;
       logLines.push(`${tplA.name}: +${amount} ATK по целям на поле ${el}`);
     }
+  }
+  const costBonus = getTargetCostBonus(base, tplA, hitsRaw);
+  if (costBonus) {
+    atk += costBonus.amount;
+    logLines.push(`${tplA.name}: +${costBonus.amount} ATK против существ с ценой призыва <= ${costBonus.limit}`);
   }
   if (targetBonus) {
     atk += targetBonus.amount;
@@ -485,6 +491,13 @@ export function magicAttack(state, fr, fc, tr, tc) {
     const { element: el, amount } = plusCfg2;
     const cellEl = n1.board?.[tr]?.[tc]?.element;
     if (cellEl === el) atk += amount;
+  }
+  if (mainTarget) {
+    const costBonus2 = getTargetCostBonus(n1, tplA, [ { r: tr, c: tc } ]);
+    if (costBonus2) {
+      atk += costBonus2.amount;
+      logLines.push(`${tplA.name}: +${costBonus2.amount} ATK против существ с ценой призыва <= ${costBonus2.limit}`);
+    }
   }
 
   const seenCells = new Set();

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -469,7 +469,7 @@ function getAttackSchemes(cardData) {
 }
 
 function drawBlindspotGrid(ctx, cardData, x, y, cell, gap) {
-  const blind = (cardData.blindspots && cardData.blindspots.length) ? cardData.blindspots : ['S'];
+  const blind = Array.isArray(cardData.blindspots) ? cardData.blindspots : ['S'];
   const baseLine = Math.max(1, Math.round(cell * 0.18));
   const accentLine = Math.max(1, Math.round(cell * 0.2));
   for (let r = 0; r < 3; r++) {

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -118,11 +118,65 @@ describe('guards and hits', () => {
     const hits = computeHits(state, 1, 1);
     expect(hits.some(h => h.r === 0 && h.c === 1)).toBe(true);
   });
+
+  it('Twin Goblins бьют вперёд и назад, включая союзников', () => {
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][1].unit = { owner: 0, tplId: 'FOREST_TWIN_GOBLINS', facing: 'N' };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_HELLFIRE_SPITTER', facing: 'S', currentHP: 1 };
+    state.board[2][1].unit = { owner: 0, tplId: 'FIRE_HELLFIRE_SPITTER', facing: 'N', currentHP: 1 };
+    const res = stagedAttack(state, 1, 1);
+    const fin = res.finish();
+    expect(fin.n1.board[0][1].unit).toBeNull();
+    expect(fin.n1.board[2][1].unit).toBeNull();
+  });
+
+  it('Biolith Battle Chariot поражает клетки впереди и справа одновременно', () => {
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][1].unit = { owner: 0, tplId: 'BIOLITH_BATTLE_CHARIOT', facing: 'N' };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_HELLFIRE_SPITTER', facing: 'S', currentHP: 1 };
+    state.board[1][2].unit = { owner: 0, tplId: 'FIRE_HELLFIRE_SPITTER', facing: 'W', currentHP: 1 };
+    state.board[0][2].unit = { owner: 1, tplId: 'FIRE_HELLFIRE_SPITTER', facing: 'S', currentHP: 1 };
+    const res = stagedAttack(state, 1, 1);
+    const fin = res.finish();
+    expect(fin.n1.board[0][1].unit).toBeNull();
+    expect(fin.n1.board[1][2].unit).toBeNull();
+    // соседняя по диагонали клетка не получает урона
+    expect(fin.n1.board[0][2].unit).not.toBeNull();
+  });
 });
 
 describe('особые способности', () => {
   it('Hellfire Spitter имеет способность quickness', () => {
     expect(hasFirstStrike(CARDS.FIRE_HELLFIRE_SPITTER)).toBe(true);
+  });
+
+  it('Biolith Bomber получает бонус атаки против дешёвой цели', () => {
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][1].unit = { owner: 0, tplId: 'BIOLITH_BOMBER', facing: 'N' };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_PARTMOLE_FLAME_LIZARD', facing: 'S', currentHP: 2 };
+    const res = stagedAttack(state, 1, 1, { chosenDir: 'N' });
+    const fin = res.finish();
+    expect(fin.n1.board[0][1].unit).toBeNull();
+  });
+
+  it('Biolith Bomber может целиться на расстоянии двух клеток', () => {
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[2][1].unit = { owner: 0, tplId: 'BIOLITH_BOMBER', facing: 'N' };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_HELLFIRE_SPITTER', facing: 'S', currentHP: 1 };
+    const res = stagedAttack(state, 2, 1, { chosenDir: 'N', rangeChoices: { N: 2 } });
+    const fin = res.finish();
+    expect(fin.n1.board[0][1].unit).toBeNull();
+  });
+
+  it('Arc Satellite Cannon поражает только одну выбранную цель', () => {
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][1].unit = { owner: 0, tplId: 'BIOLITH_ARC_SATELLITE_CANNON', facing: 'N' };
+    state.board[0][1].unit = { owner: 1, tplId: 'FIRE_PARTMOLE_FLAME_LIZARD', facing: 'S', currentHP: 1 };
+    state.board[1][2].unit = { owner: 1, tplId: 'FIRE_PARTMOLE_FLAME_LIZARD', facing: 'W', currentHP: 1 };
+    const res = stagedAttack(state, 1, 1, { chosenDir: 'N', rangeChoices: { N: 1 } });
+    const fin = res.finish();
+    expect(fin.n1.board[0][1].unit).toBeNull();
+    expect(fin.n1.board[1][2].unit).not.toBeNull();
   });
 
   it('perfect dodge защищает от обычных атак', () => {


### PR DESCRIPTION
## Summary
- добавлены новые карты Biolith Bomber, Arc Satellite Cannon, Battle Chariot и Twin Goblins с их паттернами атак
- вынесена в отдельный модуль логика бонуса атаки по дешёвым целям и подключена в расчёты ближних и магических атак
- расширены unit-тесты, покрывающие новые свойства карт и бонусы
- уточнены паттерны атак и описания для Biolith Battle Chariot, Twin Goblins, Arc Satellite Cannon и Biolith Bomber

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbbed522e483308e644e4c71709268