### PR TITLE
Добавить обработчики перерасположения и активационных аур

### DIFF
--- a/src/core/abilityHandlers/costModifiers.js
+++ b/src/core/abilityHandlers/costModifiers.js
@@ -1,0 +1,72 @@
+// Обработчики стоимости активации и аур, влияющих на AP
+// Логика отделена от визуальной части и может переиспользоваться на других движках
+
+import { CARDS } from '../cards.js';
+
+function normalizeAuraConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) return { amount: 1, vs: 'ENEMY', radius: 1 };
+  if (typeof raw === 'number') {
+    return { amount: raw, vs: 'ENEMY', radius: 1 };
+  }
+  if (typeof raw === 'object') {
+    const amount = Number(raw.amount ?? raw.value ?? 0);
+    const vs = typeof raw.vs === 'string' ? raw.vs.toUpperCase() : (raw.target ? String(raw.target).toUpperCase() : 'ENEMY');
+    const radius = Math.max(0, raw.radius != null ? Math.floor(raw.radius) : 1);
+    const affectSelf = raw.affectSelf === true;
+    const stackable = raw.stackable !== false;
+    return { amount, vs, radius, affectSelf, stackable };
+  }
+  return null;
+}
+
+function appliesToTarget(cfg, auraUnit, targetUnit) {
+  if (!cfg || !auraUnit || !targetUnit) return false;
+  if (cfg.vs === 'ALLY' && auraUnit.owner !== targetUnit.owner) return false;
+  if (cfg.vs === 'ENEMY' && auraUnit.owner === targetUnit.owner) return false;
+  return true;
+}
+
+function manhattanDistance(r1, c1, r2, c2) {
+  return Math.abs((r1 ?? 0) - (r2 ?? 0)) + Math.abs((c1 ?? 0) - (c2 ?? 0));
+}
+
+export function collectActivationTax(state, r, c, unitOverride = null) {
+  const result = { total: 0, breakdown: [] };
+  if (!state?.board) return result;
+  const unit = unitOverride || state.board?.[r]?.[c]?.unit;
+  if (!unit) return result;
+  const tplUnit = CARDS[unit.tplId];
+  if (!tplUnit) return result;
+
+  const seenSources = new Set();
+
+  for (let rr = 0; rr < 3; rr++) {
+    for (let cc = 0; cc < 3; cc++) {
+      const auraUnit = state.board?.[rr]?.[cc]?.unit;
+      if (!auraUnit) continue;
+      if ((auraUnit.currentHP ?? CARDS[auraUnit.tplId]?.hp ?? 0) <= 0) continue;
+      const auraTpl = CARDS[auraUnit.tplId];
+      const cfg = normalizeAuraConfig(auraTpl?.activationTaxAura);
+      if (!cfg || cfg.amount === 0) continue;
+      if (!cfg.affectSelf && auraUnit === unit) continue;
+      if (!appliesToTarget(cfg, auraUnit, unit)) continue;
+      const dist = manhattanDistance(rr, cc, r, c);
+      if (dist > cfg.radius) continue;
+      const key = `${rr},${cc}`;
+      if (!cfg.stackable && seenSources.has(key)) continue;
+      result.total += cfg.amount;
+      result.breakdown.push({
+        amount: cfg.amount,
+        source: {
+          tplId: auraTpl?.id ?? auraUnit.tplId ?? null,
+          name: auraTpl?.name || null,
+          position: { r: rr, c: cc },
+        },
+      });
+      seenSources.add(key);
+    }
+  }
+
+  return result;
+}

--- a/src/core/abilityHandlers/reposition.js
+++ b/src/core/abilityHandlers/reposition.js
@@ -1,0 +1,295 @@
+// Модуль обработки перемещений существ после атаки
+// Логика вынесена отдельно, чтобы облегчить переиспользование при миграции
+// и не смешивать механику с визуализацией.
+
+import { CARDS } from '../cards.js';
+import { applyFieldTransitionToUnit } from '../fieldEffects.js';
+import { inBounds } from '../constants.js';
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeElements(value) {
+  const set = new Set();
+  for (const raw of toArray(value)) {
+    if (typeof raw === 'string' && raw) {
+      set.add(raw.toUpperCase());
+    }
+  }
+  return set;
+}
+
+function normalizeSwapConfig(tpl) {
+  if (!tpl) return null;
+  if (tpl.swapWithTargetOnElement) {
+    const elements = normalizeElements(tpl.swapWithTargetOnElement);
+    if (elements.size) {
+      return { type: 'ELEMENT', elements };
+    }
+    return null;
+  }
+  if (tpl.swapOnDamageElements) {
+    const elements = normalizeElements(tpl.swapOnDamageElements);
+    if (elements.size) {
+      return { type: 'ELEMENT', elements };
+    }
+    return null;
+  }
+  const swapOnDamage = tpl.swapOnDamage;
+  if (swapOnDamage === true) {
+    return { type: 'ANY' };
+  }
+  if (typeof swapOnDamage === 'string') {
+    if (swapOnDamage.toUpperCase() === 'ANY') {
+      return { type: 'ANY' };
+    }
+    const elements = normalizeElements(swapOnDamage);
+    if (elements.size) return { type: 'ELEMENT', elements };
+  }
+  if (Array.isArray(swapOnDamage)) {
+    const elements = normalizeElements(swapOnDamage);
+    if (elements.size) return { type: 'ELEMENT', elements };
+  }
+  if (tpl.switchOnDamage) {
+    if (tpl.switchOnDamage === true) {
+      const elements = normalizeElements(tpl.element);
+      if (elements.size) {
+        return { type: 'ELEMENT', elements };
+      }
+    } else if (typeof tpl.switchOnDamage === 'string') {
+      if (tpl.switchOnDamage.toUpperCase() === 'ANY') {
+        return { type: 'ANY' };
+      }
+      const elements = normalizeElements(tpl.switchOnDamage);
+      if (elements.size) return { type: 'ELEMENT', elements };
+    }
+  }
+  return null;
+}
+
+function shouldSwap(config, cellElement) {
+  if (!config) return false;
+  if (config.type === 'ANY') return true;
+  if (config.type === 'ELEMENT') {
+    const el = typeof cellElement === 'string' ? cellElement.toUpperCase() : '';
+    return config.elements.has(el);
+  }
+  return false;
+}
+
+function normalizePushConfig(tpl) {
+  if (!tpl?.pushTargetOnDamage) return null;
+  const raw = tpl.pushTargetOnDamage;
+  if (raw === false) return null;
+  if (raw === true) return { distance: 1, requireEmpty: true };
+  if (typeof raw === 'number') {
+    return { distance: Math.max(1, Math.floor(raw)), requireEmpty: true };
+  }
+  if (typeof raw === 'object') {
+    const distance = raw.distance != null ? Math.max(1, Math.floor(raw.distance)) : 1;
+    const requireEmpty = raw.requireEmpty !== false;
+    return { distance, requireEmpty };
+  }
+  return null;
+}
+
+function computeStep(attackerPos, targetPos) {
+  if (!attackerPos || !targetPos) return null;
+  const drRaw = (targetPos.r ?? 0) - (attackerPos.r ?? 0);
+  const dcRaw = (targetPos.c ?? 0) - (attackerPos.c ?? 0);
+  const dr = Math.sign(drRaw);
+  const dc = Math.sign(dcRaw);
+  if ((dr !== 0 && dc !== 0) || (dr === 0 && dc === 0)) return null;
+  return { dr, dc };
+}
+
+function computePushDestination(state, attackerPos, targetCell, cfg) {
+  const step = computeStep(attackerPos, targetCell);
+  if (!step) return null;
+  const distance = cfg.distance || 1;
+  const destR = targetCell.r + step.dr * distance;
+  const destC = targetCell.c + step.dc * distance;
+  if (!inBounds(destR, destC)) return null;
+  const destCell = state.board?.[destR]?.[destC];
+  if (!destCell) return null;
+  if (cfg.requireEmpty !== false && destCell.unit) return null;
+  return { r: destR, c: destC };
+}
+
+function describeFieldShift(shift, name) {
+  if (!shift) return null;
+  const fieldLabel = shift.nextElement ? `поле ${shift.nextElement}` : 'нейтральное поле';
+  const prev = shift.beforeHp;
+  const next = shift.afterHp;
+  if (shift.deltaHp > 0) {
+    return `${name} усиливается на ${fieldLabel}: HP ${prev}→${next}.`;
+  }
+  if (shift.deltaHp < 0) {
+    return `${name} теряет силу на ${fieldLabel}: HP ${prev}→${next}.`;
+  }
+  return null;
+}
+
+function directionLabel(fromR, fromC, toR, toC) {
+  const dr = (toR ?? 0) - (fromR ?? 0);
+  const dc = (toC ?? 0) - (fromC ?? 0);
+  if (dr === -1 && dc === 0) return 'на север';
+  if (dr === 1 && dc === 0) return 'на юг';
+  if (dr === 0 && dc === 1) return 'на восток';
+  if (dr === 0 && dc === -1) return 'на запад';
+  return '';
+}
+
+export function getUnitUid(unit) {
+  return (unit && unit.uid != null) ? unit.uid : null;
+}
+
+export function findUnitRef(state, ref = {}) {
+  if (!state?.board) return { unit: null, r: null, c: null };
+  const { uid, r, c } = ref || {};
+  if (uid != null) {
+    for (let rr = 0; rr < 3; rr++) {
+      for (let cc = 0; cc < 3; cc++) {
+        const unit = state.board?.[rr]?.[cc]?.unit;
+        if (unit && getUnitUid(unit) === uid) {
+          return { unit, r: rr, c: cc };
+        }
+      }
+    }
+  }
+  if (typeof r === 'number' && typeof c === 'number') {
+    const unit = state.board?.[r]?.[c]?.unit || null;
+    return { unit, r, c };
+  }
+  return { unit: null, r: null, c: null };
+}
+
+export function evaluateSwapOnDamage(options = {}) {
+  const { tpl, attackerRef, targetUnit, targetTpl, targetCell, alreadySwapped } = options;
+  if (!tpl || !targetUnit || !targetTpl || !targetCell || alreadySwapped) {
+    return { event: null, triggered: false };
+  }
+  const cfg = normalizeSwapConfig(tpl);
+  if (!cfg) return { event: null, triggered: false };
+  if (!shouldSwap(cfg, targetCell.element)) {
+    return { event: null, triggered: false };
+  }
+  const event = {
+    type: 'SWAP_POSITIONS',
+    attacker: attackerRef ? { ...attackerRef } : null,
+    target: {
+      uid: getUnitUid(targetUnit),
+      r: targetCell.r,
+      c: targetCell.c,
+      tplId: targetTpl?.id ?? targetUnit.tplId ?? null,
+    },
+  };
+  return { event, triggered: true };
+}
+
+export function evaluatePushOnDamage(options = {}) {
+  const { state, tpl, attackerPos, attackerRef, targetUnit, targetTpl, targetCell } = options;
+  if (!state || !tpl || !attackerPos || !targetUnit || !targetTpl || !targetCell) return null;
+  const cfg = normalizePushConfig(tpl);
+  if (!cfg) return null;
+  const dest = computePushDestination(state, attackerPos, targetCell, cfg);
+  if (!dest) return null;
+  return {
+    type: 'PUSH_TARGET',
+    attacker: attackerRef ? { ...attackerRef } : null,
+    target: {
+      uid: getUnitUid(targetUnit),
+      r: targetCell.r,
+      c: targetCell.c,
+      tplId: targetTpl?.id ?? targetUnit.tplId ?? null,
+    },
+    dest,
+    requireEmpty: cfg.requireEmpty !== false,
+  };
+}
+
+function resolveSwap(state, event) {
+  const logs = [];
+  const attacker = findUnitRef(state, event.attacker);
+  const target = findUnitRef(state, event.target);
+  if (!attacker.unit || !target.unit) return { logLines: logs };
+  const tplAttacker = CARDS[attacker.unit.tplId];
+  const tplTarget = CARDS[target.unit.tplId];
+  const aliveAttacker = (attacker.unit.currentHP ?? tplAttacker?.hp ?? 0) > 0;
+  const aliveTarget = (target.unit.currentHP ?? tplTarget?.hp ?? 0) > 0;
+  if (!aliveAttacker || !aliveTarget) return { logLines: logs };
+  const attackerCell = state.board?.[attacker.r]?.[attacker.c];
+  const targetCell = state.board?.[target.r]?.[target.c];
+  if (!attackerCell || !targetCell) return { logLines: logs };
+  const attackerPrevElement = attackerCell.element || null;
+  const targetPrevElement = targetCell.element || null;
+  const attackerUnit = attacker.unit;
+  const targetUnit = target.unit;
+  attackerCell.unit = targetUnit;
+  targetCell.unit = attackerUnit;
+  const attackerName = tplAttacker?.name || 'Атакующий';
+  const targetName = tplTarget?.name || 'Цель';
+  logs.push(`${attackerName} меняется местами с ${targetName}.`);
+  const shiftAttacker = applyFieldTransitionToUnit(
+    attackerUnit,
+    tplAttacker,
+    attackerPrevElement,
+    targetPrevElement,
+  );
+  const shiftTarget = applyFieldTransitionToUnit(
+    targetUnit,
+    tplTarget,
+    targetPrevElement,
+    attackerPrevElement,
+  );
+  const attackerLog = describeFieldShift(shiftAttacker, attackerName);
+  if (attackerLog) logs.push(attackerLog);
+  const targetLog = describeFieldShift(shiftTarget, targetName);
+  if (targetLog) logs.push(targetLog);
+  return { attackerPosUpdate: { r: target.r, c: target.c }, logLines: logs };
+}
+
+function resolvePush(state, event) {
+  const logs = [];
+  const target = findUnitRef(state, event.target);
+  if (!target.unit) return { logLines: logs };
+  const tplTarget = CARDS[target.unit.tplId];
+  const aliveTarget = (target.unit.currentHP ?? tplTarget?.hp ?? 0) > 0;
+  if (!aliveTarget) return { logLines: logs };
+  const dest = event.dest;
+  if (!dest || !inBounds(dest.r, dest.c)) return { logLines: logs };
+  const fromCell = state.board?.[target.r]?.[target.c];
+  const destCell = state.board?.[dest.r]?.[dest.c];
+  if (!fromCell || !destCell) return { logLines: logs };
+  if (destCell.unit) return { logLines: logs };
+  const attacker = event.attacker ? findUnitRef(state, event.attacker) : { unit: null };
+  const tplAttacker = attacker.unit ? CARDS[attacker.unit.tplId] : null;
+  const attackerName = tplAttacker?.name || 'Атакующий';
+  const targetName = tplTarget?.name || 'Цель';
+  const dirText = directionLabel(target.r, target.c, dest.r, dest.c);
+  fromCell.unit = null;
+  destCell.unit = target.unit;
+  logs.push(`${attackerName} отбрасывает ${targetName}${dirText ? ` ${dirText}` : ''}.`);
+  const shiftTarget = applyFieldTransitionToUnit(
+    target.unit,
+    tplTarget,
+    fromCell.element || null,
+    destCell.element || null,
+  );
+  const shiftLog = describeFieldShift(shiftTarget, targetName);
+  if (shiftLog) logs.push(shiftLog);
+  return { logLines: logs };
+}
+
+export function applyRepositionEvent(state, event) {
+  if (!event || !state) return null;
+  if (event.type === 'SWAP_POSITIONS') {
+    return resolveSwap(state, event);
+  }
+  if (event.type === 'PUSH_TARGET') {
+    return resolvePush(state, event);
+  }
+  return null;
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -203,6 +203,16 @@ export const CARDS = {
     desc: 'Incarnation. Novogus Gravekeeper’s Magic Attack targets all enemies on non-Earth fields. Destroy Novogus Gravekeeper if it is on a Biolith field.'
   },
 
+  EARTH_DARK_YOKOZUNA_SEKIMARU: {
+    id: 'EARTH_DARK_YOKOZUNA_SEKIMARU', name: 'Dark Yokozuna Sekimaru', type: 'UNIT', cost: 3, activation: 2,
+    element: 'EARTH', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    pushTargetOnDamage: { distance: 1, requireEmpty: true },
+    desc: 'When he damages (but does not destroy) a creature, push it one field back in the direction of the attack if the destination is empty. The target cannot counterattack.'
+  },
+
   FOREST_EXALTED_ELVEN_DEITY: {
     id: 'FOREST_EXALTED_ELVEN_DEITY', name: 'Exalted Elven Deity', type: 'UNIT', cost: 9, activation: 5,
     element: 'FOREST', atk: 3, hp: 9,
@@ -299,6 +309,19 @@ export const CARDS = {
     rotateTargetOnDamage: true,
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
   },
+  FOREST_ELVEN_DEATH_DANCER: {
+    id: 'FOREST_ELVEN_DEATH_DANCER', name: 'Elven Death Dancer', type: 'UNIT', cost: 5, activation: 4,
+    element: 'FOREST', atk: 1, hp: 3,
+    attackType: 'MAGIC', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1], mode: 'ANY' },
+      { dir: 'E', ranges: [1], mode: 'ANY' },
+    ],
+    blindspots: ['S'],
+    swapOnDamage: true,
+    activationTaxAura: { amount: 3, vs: 'ENEMY', radius: 1 },
+    desc: 'Magic Attack. If she damages (but does not destroy) a creature, switch places with it; that creature cannot counterattack. Enemies on adjacent fields add 3 to their Activation Cost.'
+  },
   FOREST_GREEN_CUBIC: {
     id: 'FOREST_GREEN_CUBIC', name: 'Green Cubic', type: 'UNIT', cost: 1, activation: 1,
     element: 'FOREST', atk: 1, hp: 1,
@@ -322,6 +345,17 @@ export const CARDS = {
       { key: 'SACRIFICE_TRANSFORM', label: 'Sacrifice', allowAnyElement: true, requireNonCubic: false },
     ],
     desc: 'White Cubic does not belong to any element. Sacrifice White Cubic to summon any creature in its place (facing any direction) without paying the Summoning Cost. The summoned creature cannot attack this turn. Dodge attempt.'
+  },
+
+  BIOLITH_TAURUS_MONOLITH: {
+    id: 'BIOLITH_TAURUS_MONOLITH', name: 'Taurus Monolith', type: 'UNIT', cost: 5, activation: 3,
+    element: 'BIOLITH', atk: 3, hp: 6,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    pierce: true,
+    blindspots: ['S'],
+    pushTargetOnDamage: { distance: 1, requireEmpty: true },
+    desc: 'Attacks both fields straight ahead. If it damages (but does not destroy) a creature, push it one field back in the direction of the attack if the destination is empty. The target cannot counterattack.'
   },
 
   BIOLITH_NINJA: {


### PR DESCRIPTION
## Summary
- вынесена логика обмена позициями и отбрасывания целей в отдельный модуль `reposition`
- добавлен обработчик активационных аур и интеграция с расчётом стоимости атак
- исправлена передача шаблона цели при расчёте эффектов урона, что устраняет ReferenceError в тестах
- добавлены карты Dark Yokozuna Sekimaru, Elven Death Dancer и Taurus Monolith

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe9b3ba1883309510e3a5595448b5