### PR TITLE
Add reposition mechanics for new cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,6 +469,7 @@
        Split into logic (src/core/battle.js), FX (src/scene/battleFx.js)
        and net sync (src/net/battleSync.js). */
     async function performBattleSequence(r, c, markAttackTurn, opts = {}) {
+      let attackerPosAfter = { r, c };
       const staged = stagedAttack(gameState, r, c, opts);
       if (!staged || staged.empty) return;
       // flashy заставка BATTLE (сокращённая)
@@ -605,6 +606,11 @@
           }
           // Финализация: анимация смерти и орбы перед применением состояния
           const res = staged.finish();
+          attackerPosAfter = res.attackerPosUpdate || attackerPosAfter;
+          if (res.attackerPosUpdate) {
+            r = attackerPosAfter.r;
+            c = attackerPosAfter.c;
+          }
           gameState = res.n1;
           try { window.applyGameState(gameState); } catch {}
           if (res.deaths && res.deaths.length) {
@@ -627,7 +633,9 @@
               window.__interactions?.showOracleDeathBuff?.(d.owner, tplDead.onDeathAddHPAll);
             }
           }
-          if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
+          if (markAttackTurn && gameState.board[r][c]?.unit) {
+            gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
+          }
             setTimeout(() => {
               updateUnits(); updateUI();
               for (const l of res.logLines.reverse()) addLog(l);
@@ -643,7 +651,19 @@
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
-              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish', { force: true }); } catch {}
+              updateUnits();
+              updateUI();
+              const syncUnitsAfter = () => { try { window.__units?.updateUnits?.(gameState); } catch {}; };
+              if (typeof requestAnimationFrame === 'function') {
+                requestAnimationFrame(syncUnitsAfter);
+              } else {
+                setTimeout(syncUnitsAfter, 0);
+              }
+              for (const l of res.logLines.reverse()) addLog(l);
+              if (markAttackTurn && gameState.board[r][c]?.unit) {
+                gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
+              }
+              try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
@@ -706,9 +726,16 @@
     function performMagicAttack(from, targetMesh) {
       const tr = targetMesh.userData.row; const tc = targetMesh.userData.col;
       const attacker = gameState.board?.[from.r]?.[from.c]?.unit;
-      if (!attacker || attacker.lastAttackTurn === gameState.turn) { showNotification('Incorrect target', 'error'); return; }
+      if (!attacker || attacker.lastAttackTurn === gameState.turn) {
+        showNotification('Incorrect target', 'error');
+        return false;
+      }
       const res = magicAttack(gameState, from.r, from.c, tr, tc);
-      if (!res) { showNotification('Incorrect target', 'error'); return; }
+      if (!res) {
+        showNotification('Incorrect target', 'error');
+        return false;
+      }
+      const attackerFinal = res.attackerPosUpdate || from;
       for (const l of res.logLines.reverse()) addLog(l);
       const aMesh = unitMeshes.find(m => m.userData.row === from.r && m.userData.col === from.c);
       if (aMesh) { gsap.fromTo(aMesh.position, { y: aMesh.position.y }, { y: aMesh.position.y + 0.3, yoyo: true, repeat: 1, duration: 0.12 }); }
@@ -746,9 +773,17 @@
         }
         gameState = res.n1;
         try { window.applyGameState(gameState); } catch {}
-        const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
+        const attackerUnit = gameState.board?.[attackerFinal.r]?.[attackerFinal.c]?.unit;
+        if (attackerUnit) attackerUnit.lastAttackTurn = gameState.turn;
         setTimeout(() => {
-          updateUnits(); updateUI();
+          updateUnits();
+          updateUI();
+          const syncUnits = () => { try { window.__units?.updateUnits?.(gameState); } catch {}; };
+          if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(syncUnits);
+          } else {
+            setTimeout(syncUnits, 0);
+          }
           try { schedulePush('magic-battle-finish', { force: true }); } catch {}
           if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
             window.__interactions.interactionState.autoEndTurnAfterAttack = false;
@@ -758,14 +793,23 @@
       } else {
         // Если смертей нет — применяем состояние сразу
         gameState = res.n1; try { window.applyGameState(gameState); } catch {}
-        updateUnits(); updateUI();
-        const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
+        updateUnits();
+        updateUI();
+        const syncUnits = () => { try { window.__units?.updateUnits?.(gameState); } catch {}; };
+        if (typeof requestAnimationFrame === 'function') {
+          requestAnimationFrame(syncUnits);
+        } else {
+          setTimeout(syncUnits, 0);
+        }
+        const attackerUnit = gameState.board?.[attackerFinal.r]?.[attackerFinal.c]?.unit;
+        if (attackerUnit) attackerUnit.lastAttackTurn = gameState.turn;
         try { schedulePush('magic-battle-finish', { force: true }); } catch {}
         if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
           window.__interactions.interactionState.autoEndTurnAfterAttack = false;
           try { endTurn(); } catch {}
         }
       }
+      return true;
     }
     // Вспомогательные утилиты: задержка и яркая заставка BATTLE на 3 секунды
     function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }

--- a/index.html
+++ b/index.html
@@ -637,6 +637,9 @@
                 try { endTurn(); } catch {}
               }
             }, 1000);
+            setTimeout(() => {
+              try { updateUnits(); } catch {}
+            }, 1400);
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
@@ -646,6 +649,9 @@
                 try { endTurn(); } catch {}
               }
             }, Math.max(0, animDelayMs));
+            setTimeout(() => {
+              try { updateUnits(); } catch {}
+            }, Math.max(0, animDelayMs) + 420);
           }
         }, 420);
       };

--- a/src/core/abilityHandlers/costModifiers.js
+++ b/src/core/abilityHandlers/costModifiers.js
@@ -1,0 +1,46 @@
+// Модуль для расчёта модификаторов стоимости активации от аур существ
+// Держим отдельно от визуала для удобства портирования логики
+import { CARDS } from '../cards.js';
+
+const inBounds = (r, c) => r >= 0 && r < 3 && c >= 0 && c < 3;
+
+const ADJACENT_DIRS = [
+  { dr: -1, dc: 0 },
+  { dr: 1, dc: 0 },
+  { dr: 0, dc: -1 },
+  { dr: 0, dc: 1 },
+];
+
+function normalizeTax(value) {
+  if (value == null) return 0;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'object') {
+    if (typeof value.amount === 'number') return value.amount;
+    if (typeof value.value === 'number') return value.value;
+    if (typeof value.plus === 'number') return value.plus;
+  }
+  return 0;
+}
+
+export function extraActivationCostFromAuras(state, r, c, opts = {}) {
+  if (!state?.board) return 0;
+  const attackerUnit = opts.unit || state.board?.[r]?.[c]?.unit || null;
+  const owner = opts.owner ?? attackerUnit?.owner ?? null;
+  let total = 0;
+  for (const { dr, dc } of ADJACENT_DIRS) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) continue;
+    const auraUnit = state.board?.[nr]?.[nc]?.unit;
+    if (!auraUnit) continue;
+    const tplAura = CARDS[auraUnit.tplId];
+    if (!tplAura) continue;
+    if (owner != null && auraUnit.owner === owner) continue;
+    const alive = (auraUnit.currentHP ?? tplAura.hp ?? 0) > 0;
+    if (!alive) continue;
+    const tax = normalizeTax(tplAura.enemyActivationTaxAdjacent);
+    if (!tax) continue;
+    total += tax;
+  }
+  return total;
+}

--- a/src/core/abilityHandlers/reposition.js
+++ b/src/core/abilityHandlers/reposition.js
@@ -1,0 +1,159 @@
+// Модуль обработки эффектов, меняющих положение существ после атаки
+// Логика изолирована от визуальной части для дальнейшего переиспользования
+import { CARDS } from '../cards.js';
+
+const inBounds = (r, c) => r >= 0 && r < 3 && c >= 0 && c < 3;
+
+function getUnitUid(unit) {
+  return (unit && unit.uid != null) ? unit.uid : null;
+}
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
+function normalizeElements(value) {
+  const set = new Set();
+  for (const raw of toArray(value)) {
+    if (typeof raw === 'string' && raw) {
+      set.add(raw.toUpperCase());
+    }
+  }
+  return set;
+}
+
+function normalizePushConfig(raw) {
+  if (!raw) return null;
+  const base = {
+    distance: 1,
+    preventRetaliation: true,
+    requireEmpty: true,
+    elements: null,
+  };
+  if (raw === true) return base;
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return { ...base, distance: Math.max(1, Math.abs(Math.trunc(raw))) };
+  }
+  if (typeof raw === 'object') {
+    const cfg = { ...base };
+    if (typeof raw.distance === 'number' && Number.isFinite(raw.distance)) {
+      cfg.distance = Math.max(1, Math.abs(Math.trunc(raw.distance)));
+    }
+    if (raw.preventRetaliation === false) cfg.preventRetaliation = false;
+    if (raw.requireEmpty === false) cfg.requireEmpty = false;
+    const elems = normalizeElements(raw.onlyOnElement || raw.element || raw.elements);
+    cfg.elements = elems.size ? elems : null;
+    return cfg;
+  }
+  return base;
+}
+
+function directionBetween(from, to) {
+  if (!from || !to) return null;
+  const dr = (to.r ?? 0) - (from.r ?? 0);
+  const dc = (to.c ?? 0) - (from.c ?? 0);
+  if (dr === 0 && dc === 0) return null;
+  if (dr !== 0 && dc !== 0) return null;
+  if (dr < 0) return { dir: 'N', dr: -1, dc: 0 };
+  if (dr > 0) return { dir: 'S', dr: 1, dc: 0 };
+  if (dc < 0) return { dir: 'W', dr: 0, dc: -1 };
+  if (dc > 0) return { dir: 'E', dr: 0, dc: 1 };
+  return null;
+}
+
+export function collectRepositionOnDamage(state, context = {}) {
+  const events = [];
+  const prevent = new Set();
+  if (!state?.board) return { events, preventRetaliation: [] };
+
+  const { attackerRef, attackerPos, tpl, hits } = context;
+  if (!tpl || !Array.isArray(hits) || !hits.length) {
+    return { events, preventRetaliation: [] };
+  }
+
+  const swapElements = normalizeElements(
+    tpl.swapWithTargetOnElement || (tpl.switchOnDamage ? tpl.element : null)
+  );
+  const allowSwapAny = !!tpl.swapOnDamage;
+  const pushCfg = normalizePushConfig(tpl.pushTargetOnDamage);
+  const rotateOnDamage = !!tpl.rotateTargetOnDamage;
+
+  let swapTriggered = false;
+
+  for (const hit of hits) {
+    if (!hit) continue;
+    const target = hit.target;
+    const tplTarget = hit.tplTarget;
+    if (!target || !tplTarget) continue;
+    const key = hit.key || `${hit.r},${hit.c}`;
+    const cellElement = hit.cellElement ?? state.board?.[hit.r]?.[hit.c]?.element ?? null;
+
+    if (!swapTriggered) {
+      let shouldSwap = false;
+      if (allowSwapAny) {
+        shouldSwap = true;
+      } else if (swapElements.size && cellElement && swapElements.has(cellElement)) {
+        shouldSwap = true;
+      }
+      if (shouldSwap) {
+        events.push({
+          type: 'SWAP_POSITIONS',
+          attacker: attackerRef,
+          target: { uid: getUnitUid(target), r: hit.r, c: hit.c, tplId: tplTarget?.id ?? target.tplId },
+        });
+        swapTriggered = true;
+        prevent.add(key);
+      }
+    }
+
+    if (rotateOnDamage) {
+      events.push({
+        type: 'ROTATE_TARGET',
+        target: { uid: getUnitUid(target), r: hit.r, c: hit.c, tplId: tplTarget?.id ?? target.tplId },
+        faceAwayFrom: attackerRef,
+      });
+      prevent.add(key);
+    }
+
+    if (pushCfg) {
+      if (pushCfg.elements && cellElement && !pushCfg.elements.has(cellElement)) {
+        // поле не подходит — пропускаем перемещение, но возможность контратаки всё равно блокируем
+        if (pushCfg.preventRetaliation) prevent.add(key);
+        continue;
+      }
+      const dirInfo = directionBetween(attackerPos || attackerRef, { r: hit.r, c: hit.c });
+      if (!dirInfo) {
+        if (pushCfg.preventRetaliation) prevent.add(key);
+        continue;
+      }
+      const destR = hit.r + dirInfo.dr * pushCfg.distance;
+      const destC = hit.c + dirInfo.dc * pushCfg.distance;
+      if (!inBounds(destR, destC)) {
+        if (pushCfg.preventRetaliation) prevent.add(key);
+        continue;
+      }
+      const destUnit = state.board?.[destR]?.[destC]?.unit;
+      let blocked = false;
+      if (destUnit) {
+        const tplDest = CARDS[destUnit.tplId];
+        const aliveDest = (destUnit.currentHP ?? tplDest?.hp ?? 0) > 0;
+        if (aliveDest && pushCfg.requireEmpty) {
+          blocked = true;
+        }
+      }
+      if (!blocked) {
+        events.push({
+          type: 'PUSH_TARGET',
+          target: { uid: getUnitUid(target), r: hit.r, c: hit.c, tplId: tplTarget?.id ?? target.tplId },
+          to: { r: destR, c: destC },
+          direction: dirInfo.dir,
+          source: attackerRef,
+        });
+      }
+      if (pushCfg.preventRetaliation) prevent.add(key);
+    }
+  }
+
+  return { events, preventRetaliation: Array.from(prevent) };
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -261,7 +261,7 @@ export const CARDS = {
     id: 'EARTH_DARK_YOKOZUNA_SEKIMARU', name: 'Dark Yokozuna Sekimaru', type: 'UNIT', cost: 3, activation: 2,
     element: 'EARTH', atk: 2, hp: 3,
     attackType: 'STANDARD',
-    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    attacks: [ { dir: 'N', ranges: [1] } ],
     blindspots: ['S'],
     pushTargetOnDamage: { distance: 1 },
     desc: 'If Dark Yokozuna Sekimaru attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'
@@ -310,7 +310,7 @@ export const CARDS = {
   },
   FOREST_ELVEN_DEATH_DANCER: {
     id: 'FOREST_ELVEN_DEATH_DANCER', name: 'Elven Death Dancer', type: 'UNIT', cost: 5, activation: 4,
-    element: 'FOREST', atk: 3, hp: 4,
+    element: 'FOREST', atk: 1, hp: 3,
     attackType: 'MAGIC',
     attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY' } ],
     blindspots: ['S'],

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -257,6 +257,15 @@ export const CARDS = {
     ],
     desc: 'Sacrifice Yellow Cubic to summon a non‑cubic Earth creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
+  EARTH_DARK_YOKOZUNA_SEKIMARU: {
+    id: 'EARTH_DARK_YOKOZUNA_SEKIMARU', name: 'Dark Yokozuna Sekimaru', type: 'UNIT', cost: 3, activation: 2,
+    element: 'EARTH', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    blindspots: ['S'],
+    pushTargetOnDamage: { distance: 1 },
+    desc: 'If Dark Yokozuna Sekimaru attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'
+  },
   WATER_WOLF_NINJA: {
     id: 'WATER_WOLF_NINJA', name: 'Wolf Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 1, hp: 3,
@@ -298,6 +307,16 @@ export const CARDS = {
     invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
     rotateTargetOnDamage: true,
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+  FOREST_ELVEN_DEATH_DANCER: {
+    id: 'FOREST_ELVEN_DEATH_DANCER', name: 'Elven Death Dancer', type: 'UNIT', cost: 5, activation: 4,
+    element: 'FOREST', atk: 3, hp: 4,
+    attackType: 'MAGIC',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY' } ],
+    blindspots: ['S'],
+    swapOnDamage: true,
+    enemyActivationTaxAdjacent: 3,
+    desc: 'Magic Attack. If Elven Death Dancer damages (but does not destroy) a creature, she switches locations with that creature (which cannot counterattack). Enemies on adjacent fields add 3 to their Activation Cost.'
   },
   FOREST_GREEN_CUBIC: {
     id: 'FOREST_GREEN_CUBIC', name: 'Green Cubic', type: 'UNIT', cost: 1, activation: 1,
@@ -361,6 +380,16 @@ export const CARDS = {
     friendlyFire: true,
     blindspots: ['S'],
     desc: ''
+  },
+
+  BIOLITH_TAURUS_MONOLITH: {
+    id: 'BIOLITH_TAURUS_MONOLITH', name: 'Taurus Monolith', type: 'UNIT', cost: 5, activation: 3,
+    element: 'BIOLITH', atk: 3, hp: 6,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    blindspots: ['S'],
+    pushTargetOnDamage: { distance: 1 },
+    desc: 'If Taurus Monolith attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'
   },
 
   BIOLITH_ARC_SATELLITE_CANNON: {

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -45,7 +45,7 @@ export const CARDS = {
     element: 'FIRE', atk: 2, hp: 1,
     attackType: 'STANDARD',
     // бьёт сразу по двум клеткам впереди, игнорируя преграды и задевая союзников
-    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    attacks: [ { dir: 'N', ranges: [1, 2], group: 'FRONT_LINE', ignoreBlocking: true } ],
     blindspots: ['S'], perfectDodge: true, activationReduction: 1, diesOffElement: 'FIRE',
     friendlyFire: true, pierce: true,
     desc: 'Perfect Dodge. The activation cost to attack is 1 less. Destroy Great Minos if he is on a non‑Fire field.'
@@ -137,7 +137,7 @@ export const CARDS = {
     id: 'FIRE_WARDEN_HILDA', name: 'Warden Hilda', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 2, hp: 4,
     attackType: 'STANDARD',
-    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    attacks: [ { dir: 'N', ranges: [1, 2], group: 'FRONT_LINE', ignoreBlocking: true } ],
     blindspots: ['S'],
     plusAtkVsElement: { element: 'FIRE', amount: 1 },
     gainPossessionEnemiesOnElement: { element: 'FIRE', requireDifferentField: true },
@@ -386,7 +386,7 @@ export const CARDS = {
     id: 'BIOLITH_TAURUS_MONOLITH', name: 'Taurus Monolith', type: 'UNIT', cost: 5, activation: 3,
     element: 'BIOLITH', atk: 3, hp: 6,
     attackType: 'STANDARD',
-    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    attacks: [ { dir: 'N', ranges: [1, 2], group: 'FRONT_LINE', ignoreBlocking: true } ],
     blindspots: ['S'],
     pushTargetOnDamage: { distance: 1 },
     desc: 'If Taurus Monolith attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -34,7 +34,7 @@ export const capMana = (m) => Math.min(10, m);
 import { activationCost, rotateCost as rawRotateCost } from './abilities.js';
 
 // Стоимость атаки с учётом скидок
-export const attackCost = (tpl, fieldElement) => activationCost(tpl, fieldElement);
+export const attackCost = (tpl, fieldElement, ctx) => activationCost(tpl, fieldElement, ctx);
 
 // Стоимость поворота без скидок
 export const rotateCost = (tpl) => rawRotateCost(tpl);

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -382,6 +382,7 @@ export function stagedAttack(state, r, c, opts = {}) {
       const tplB = CARDS[B.tplId];
       const alive = (B.currentHP ?? B.hp) > 0;
       if (!alive) continue;
+      if (tplB?.attackType === 'MAGIC' && !tplB?.allowMagicRetaliation) continue;
       // быстрота защитника уже сработала на stepQuick, если атакующий не был быстрым
       if (!attackerQuick && hasFirstStrike(tplB)) continue;
       const hitsB = computeHits(n1, h.r, h.c, { target: { r, c }, union: true });

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -188,6 +188,15 @@ export function stagedAttack(state, r, c, opts = {}) {
   const tplA = CARDS[attacker.tplId];
   if (!canAttack(tplA)) return null;
 
+  const startElement = base.board?.[r]?.[c]?.element;
+  const attackCostValue = attackCost(tplA, startElement, {
+    state: base,
+    r,
+    c,
+    unit: attacker,
+    owner: attacker?.owner,
+  });
+
   const baseStats = effectiveStats(base.board[r][c], attacker);
   let atk = baseStats.atk;
   let logLines = [];
@@ -458,8 +467,7 @@ export function stagedAttack(state, r, c, opts = {}) {
 
     if (A) {
       A.lastAttackTurn = nFinal.turn;
-      const cellEl = nFinal.board?.[r]?.[c]?.element;
-      A.apSpent = (A.apSpent || 0) + attackCost(tplA, cellEl);
+      A.apSpent = (A.apSpent || 0) + attackCostValue;
     }
 
     const targets = step1Damages.map(h => ({ r: h.r, c: h.c, dmg: h.dealt || 0 }));
@@ -488,6 +496,15 @@ export function magicAttack(state, fr, fc, tr, tc) {
   if (attacker.lastAttackTurn === n1.turn) return null;
   const tplA = CARDS[attacker.tplId];
   if (!canAttack(tplA)) return null;
+
+  const startElement = n1.board?.[fr]?.[fc]?.element;
+  const attackCostValue = attackCost(tplA, startElement, {
+    state: n1,
+    r: fr,
+    c: fc,
+    unit: attacker,
+    owner: attacker?.owner,
+  });
   const allowFriendly = !!tplA.friendlyFire;
   const mainTarget = n1.board?.[tr]?.[tc]?.unit;
   if (!allowFriendly && (!mainTarget || mainTarget.owner === attacker.owner)) return null;
@@ -660,8 +677,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
     logLines.push(...applied.logLines);
   }
   attacker.lastAttackTurn = n1.turn;
-  const cellEl = n1.board?.[fr]?.[fc]?.element;
-  attacker.apSpent = (attacker.apSpent || 0) + attackCost(tplA, cellEl);
+  attacker.apSpent = (attacker.apSpent || 0) + attackCostValue;
   return { n1, logLines, targets, deaths, releases: releaseEvents.releases };
 }
 

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -403,9 +403,14 @@ export function stagedAttack(state, r, c, opts = {}) {
     const ret = step2();
 
     const applied = applyDamageInteractionResults(nFinal, damageEffects);
+    let attackerPosUpdate = null;
     if (applied?.attackerPosUpdate) {
-      r = applied.attackerPosUpdate.r;
-      c = applied.attackerPosUpdate.c;
+      attackerPosUpdate = {
+        r: applied.attackerPosUpdate.r,
+        c: applied.attackerPosUpdate.c,
+      };
+      r = attackerPosUpdate.r;
+      c = attackerPosUpdate.c;
     }
     if (Array.isArray(applied?.logLines) && applied.logLines.length) {
       logLines.push(...applied.logLines);
@@ -472,7 +477,15 @@ export function stagedAttack(state, r, c, opts = {}) {
     }
 
     const targets = step1Damages.map(h => ({ r: h.r, c: h.c, dmg: h.dealt || 0 }));
-    return { n1: nFinal, logLines, targets, deaths, retaliators: ret.retaliators, releases: releaseEvents.releases };
+    return {
+      n1: nFinal,
+      logLines,
+      targets,
+      deaths,
+      retaliators: ret.retaliators,
+      releases: releaseEvents.releases,
+      attackerPosUpdate,
+    };
   }
 
   return {
@@ -670,16 +683,28 @@ export function magicAttack(state, fr, fc, tr, tc) {
     }
   }
   const applied = applyDamageInteractionResults(n1, damageEffects);
+  let attackerPosUpdate = null;
   if (applied?.attackerPosUpdate) {
-    fr = applied.attackerPosUpdate.r;
-    fc = applied.attackerPosUpdate.c;
+    attackerPosUpdate = {
+      r: applied.attackerPosUpdate.r,
+      c: applied.attackerPosUpdate.c,
+    };
+    fr = attackerPosUpdate.r;
+    fc = attackerPosUpdate.c;
   }
   if (Array.isArray(applied?.logLines) && applied.logLines.length) {
     logLines.push(...applied.logLines);
   }
   attacker.lastAttackTurn = n1.turn;
   attacker.apSpent = (attacker.apSpent || 0) + attackCostValue;
-  return { n1, logLines, targets, deaths, releases: releaseEvents.releases };
+  return {
+    n1,
+    logLines,
+    targets,
+    deaths,
+    releases: releaseEvents.releases,
+    attackerPosUpdate,
+  };
 }
 
 export { computeCellBuff };

--- a/src/scene/delta.js
+++ b/src/scene/delta.js
@@ -1,6 +1,6 @@
 // Анимация различий между предыдущим и новым состоянием
 
-export function playDeltaAnimations(prevState, nextState) {
+export function playDeltaAnimations(prevState, nextState, opts = {}) {
   try {
     if (!prevState || !nextState) return;
 
@@ -17,16 +17,61 @@ export function playDeltaAnimations(prevState, nextState) {
     const capMana = window.capMana || (x => x);
     const CARDS = window.CARDS || {};
 
+    const includeActive = !!opts.includeActive;
     const isActivePlayer = (typeof window.MY_SEAT === 'number' && gameState && typeof gameState.active === 'number' && window.MY_SEAT === gameState.active);
+
+    if (!includeActive && isActivePlayer) {
+      return;
+    }
+
+    const skipDeathFx = !!opts.skipDeathFx || (includeActive && isActivePlayer);
+
+    const makeSignature = (unit) => {
+      if (!unit) return null;
+      if (unit.uid != null) return `UID:${unit.uid}`;
+      const owner = unit.owner != null ? unit.owner : 'x';
+      const tpl = unit.tplId || 'unknown';
+      const hp = (typeof unit.currentHP === 'number') ? unit.currentHP : (typeof unit.hp === 'number' ? unit.hp : 'x');
+      const facing = unit.facing || 'N';
+      return `SIG:${owner}:${tpl}:${hp}:${facing}`;
+    };
 
     const prevB = prevState.board || [];
     const nextB = nextState.board || [];
+
+    const nextPosByUid = new Map();
+    const nextSigPositions = new Map();
+
+    for (let r = 0; r < 3; r++) {
+      for (let c = 0; c < 3; c++) {
+        const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
+        if (!nu) continue;
+        if (nu.uid != null) {
+          nextPosByUid.set(nu.uid, { r, c });
+        } else {
+          const sig = makeSignature(nu);
+          if (!sig) continue;
+          if (!nextSigPositions.has(sig)) nextSigPositions.set(sig, []);
+          nextSigPositions.get(sig).push({ r, c });
+        }
+      }
+    }
 
     for (let r = 0; r < 3; r++) {
       for (let c = 0; c < 3; c++) {
         const pu = (prevB[r] && prevB[r][c] && prevB[r][c].unit) ? prevB[r][c].unit : null;
         const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
         if (pu && !nu) {
+          const sigPrev = makeSignature(pu);
+          let moved = false;
+          if (pu.uid != null) {
+            const pos = nextPosByUid.get(pu.uid);
+            if (pos && (pos.r !== r || pos.c !== c)) moved = true;
+          } else if (sigPrev) {
+            const positions = nextSigPositions.get(sigPrev) || [];
+            moved = positions.some(pos => pos.r !== r || pos.c !== c);
+          }
+          if (moved) continue;
           try {
             const prevPl = prevState?.players?.[pu.owner];
             const nextPl = nextState?.players?.[pu.owner];
@@ -36,6 +81,7 @@ export function playDeltaAnimations(prevState, nextState) {
               prevPl.discard.length > nextPl.discard.length &&
               nextPl.hand.length > prevPl.hand.length;
             if (!canceled) {
+              if (skipDeathFx) continue;
               const tile = tileMeshes?.[r]?.[c]; if (!tile) continue;
               const ghost = createCard3D ? createCard3D(CARDS[pu.tplId], false) : null;
               if (ghost && window.THREE) {
@@ -67,7 +113,7 @@ export function playDeltaAnimations(prevState, nextState) {
       }
     }
 
-    if (isActivePlayer) {
+    if (!includeActive && isActivePlayer) {
       return;
     }
 

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -71,7 +71,10 @@ export function performUnitAttack(unitMesh) {
       window.__ui?.notifications?.show('This unit has already attacked this turn', 'error');
       return;
     }
-    const cost = typeof window.attackCost === 'function' ? window.attackCost(tpl) : 0;
+    const fieldElement = gameState.board?.[r]?.[c]?.element;
+    const cost = typeof window.attackCost === 'function'
+      ? window.attackCost(tpl, fieldElement, { state: gameState, r, c, unit, owner: unit.owner })
+      : 0;
     const iState = window.__interactions?.interactionState;
     const mustUseMagic = shouldUseMagicAttack(gameState, r, c, tpl);
     if (tpl?.attackType === 'MAGIC' || mustUseMagic) {

--- a/src/ui/panels.js
+++ b/src/ui/panels.js
@@ -10,12 +10,17 @@ export function showUnitActionPanel(unitMesh){
     try { if (typeof window !== 'undefined') window.selectedUnit = unitMesh; } catch {}
     const unitData = unitMesh.userData?.unitData; const cardData = unitMesh.userData?.cardData; const gs = (typeof window !== 'undefined') ? window.gameState : null;
     if (!gs || !unitData || !cardData) return;
+    const row = unitMesh.userData?.row;
+    const col = unitMesh.userData?.col;
     const el = document.getElementById('unit-info'); if (el) el.textContent = `${cardData.name} (${(unitMesh.userData.row||0) + 1},${(unitMesh.userData.col||0) + 1})`;
     const alreadyAttacked = unitData.lastAttackTurn === gs.turn;
     const attackBtn = document.getElementById('attack-btn'); if (attackBtn) {
       const cannot = !canAttack(cardData);
       attackBtn.disabled = !!alreadyAttacked || cannot;
-      const cost = (typeof window !== 'undefined' && typeof window.attackCost === 'function') ? window.attackCost(cardData) : 1;
+      const fieldElement = (typeof row === 'number' && typeof col === 'number') ? gs.board?.[row]?.[col]?.element : undefined;
+      const cost = (typeof window !== 'undefined' && typeof window.attackCost === 'function')
+        ? window.attackCost(cardData, fieldElement, { state: gs, r: row, c: col, unit: unitData, owner: unitData?.owner })
+        : 1;
       attackBtn.textContent = cannot ? 'Cannot attack' : alreadyAttacked ? 'Already attacked' : `Attack (-${cost})`;
     }
     const extraActions = collectUnitActions(gs, unitMesh.userData.row, unitMesh.userData.col);

--- a/tests/constants.test.js
+++ b/tests/constants.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { inBounds, capMana, attackCost, rotateCost } from '../src/core/constants.js';
+import { CARDS } from '../src/core/cards.js';
 
 describe('constants helpers', () => {
   it('inBounds: within 3x3 grid', () => {
@@ -30,6 +31,23 @@ describe('constants helpers', () => {
     const tpl = { activation: 3, activationReduction: 2 };
     expect(attackCost(tpl)).toBe(1);
     expect(rotateCost(tpl)).toBe(3);
+  });
+
+  it('attackCost: учитывает ауры, повышающие стоимость соседей', () => {
+    const state = {
+      board: Array.from({ length: 3 }, () => Array.from({ length: 3 }, () => ({ element: 'NEUTRAL', unit: null }))),
+    };
+    state.board[1][1].unit = { owner: 1, tplId: 'FOREST_ELVEN_DEATH_DANCER', currentHP: CARDS.FOREST_ELVEN_DEATH_DANCER.hp };
+    state.board[1][0].unit = { owner: 0, tplId: 'FIRE_HELLFIRE_SPITTER', currentHP: CARDS.FIRE_HELLFIRE_SPITTER.hp };
+    const cellEl = state.board[1][0].element;
+    const cost = attackCost(CARDS.FIRE_HELLFIRE_SPITTER, cellEl, {
+      state,
+      r: 1,
+      c: 0,
+      unit: state.board[1][0].unit,
+      owner: 0,
+    });
+    expect(cost).toBe(4); // базовая стоимость 1 + налог ауры 3
   });
 });
 

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -446,6 +446,25 @@ describe('особые способности', () => {
     expect(fin.retaliators.length).toBe(0);
   });
 
+  it('магические существа не контратакуют по умолчанию', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].unit = {
+      owner:0,
+      tplId:'FIRE_PARTMOLE_FLAME_LIZARD',
+      facing:'N',
+      currentHP:CARDS.FIRE_PARTMOLE_FLAME_LIZARD.hp,
+    };
+    state.board[1][1].unit = {
+      owner:1,
+      tplId:'FIRE_FLAME_MAGUS',
+      facing:'S',
+      currentHP:CARDS.FIRE_FLAME_MAGUS.hp + 2,
+    };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    expect(fin.retaliators.length).toBe(0);
+  });
+
   it('Elven Death Dancer меняется местами с целью после магической атаки', () => {
     const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
     state.board[1][1].unit = {

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -446,6 +446,34 @@ describe('особые способности', () => {
     expect(fin.retaliators.length).toBe(0);
   });
 
+  it('Taurus Monolith поражает обе клетки перед собой одновременно', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].unit = {
+      owner:0,
+      tplId:'BIOLITH_TAURUS_MONOLITH',
+      facing:'N',
+      currentHP:CARDS.BIOLITH_TAURUS_MONOLITH.hp,
+    };
+    state.board[1][1].unit = {
+      owner:1,
+      tplId:'FIRE_TRICEPTAUR_BEHEMOTH',
+      facing:'S',
+      currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp,
+    };
+    state.board[0][1].unit = {
+      owner:1,
+      tplId:'FIRE_PARTMOLE_FLAME_LIZARD',
+      facing:'S',
+      currentHP:CARDS.FIRE_PARTMOLE_FLAME_LIZARD.hp,
+    };
+    const res = stagedAttack(state,2,1);
+    res.step1();
+    const mid = res.n1.board[1][1].unit;
+    const far = res.n1.board[0][1].unit;
+    expect(mid?.currentHP).toBe(CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp - CARDS.BIOLITH_TAURUS_MONOLITH.atk);
+    expect(far?.currentHP).toBe(Math.max(0, CARDS.FIRE_PARTMOLE_FLAME_LIZARD.hp - CARDS.BIOLITH_TAURUS_MONOLITH.atk));
+  });
+
   it('магические существа не контратакуют по умолчанию', () => {
     const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
     state.board[2][1].unit = {
@@ -488,6 +516,7 @@ describe('особые способности', () => {
     expect(swapped?.currentHP).toBe((CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp + 2) - CARDS.FOREST_ELVEN_DEATH_DANCER.atk - 2);
     const dmgEntry = res.targets.find(t => t.r === 0 && t.c === 1);
     expect(dmgEntry?.dmg).toBe(CARDS.FOREST_ELVEN_DEATH_DANCER.atk);
+    expect(res.attackerPosUpdate).toEqual({ r: 0, c: 1 });
   });
 
   it('способность backAttack наносит удар в спину и блокирует ответный урон', () => {

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -393,6 +393,84 @@ describe('особые способности', () => {
     expect(dmgEntry?.dmg).toBe(1);
   });
 
+  it('Dark Yokozuna Sekimaru отталкивает цель и блокирует контратаку', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].unit = {
+      owner:0,
+      tplId:'EARTH_DARK_YOKOZUNA_SEKIMARU',
+      facing:'N',
+      currentHP:CARDS.EARTH_DARK_YOKOZUNA_SEKIMARU.hp,
+    };
+    state.board[1][1].unit = {
+      owner:1,
+      tplId:'FIRE_TRICEPTAUR_BEHEMOTH',
+      facing:'S',
+      currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp,
+    };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    expect(fin.n1.board[2][1].unit?.tplId).toBe('EARTH_DARK_YOKOZUNA_SEKIMARU');
+    expect(fin.n1.board[1][1].unit).toBeNull();
+    const pushed = fin.n1.board[0][1].unit;
+    expect(pushed?.tplId).toBe('FIRE_TRICEPTAUR_BEHEMOTH');
+    expect(pushed?.currentHP).toBe(CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp);
+    expect(fin.retaliators.length).toBe(0);
+  });
+
+  it('Taurus Monolith не даёт врагу контратаковать даже без свободной клетки для отталкивания', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].unit = {
+      owner:0,
+      tplId:'BIOLITH_TAURUS_MONOLITH',
+      facing:'N',
+      currentHP:CARDS.BIOLITH_TAURUS_MONOLITH.hp,
+    };
+    state.board[1][1].unit = {
+      owner:1,
+      tplId:'FIRE_TRICEPTAUR_BEHEMOTH',
+      facing:'S',
+      currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp,
+    };
+    state.board[0][1].unit = {
+      owner:1,
+      tplId:'FIRE_PURSUER_OF_SAINT_DHEES',
+      facing:'S',
+      currentHP:CARDS.FIRE_PURSUER_OF_SAINT_DHEES.hp + 2,
+    };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    const target = fin.n1.board[1][1].unit;
+    expect(target?.tplId).toBe('FIRE_TRICEPTAUR_BEHEMOTH');
+    expect(target?.currentHP).toBe(CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp - CARDS.BIOLITH_TAURUS_MONOLITH.atk);
+    expect(fin.n1.board[0][1].unit?.tplId).toBe('FIRE_PURSUER_OF_SAINT_DHEES');
+    expect(fin.retaliators.length).toBe(0);
+  });
+
+  it('Elven Death Dancer меняется местами с целью после магической атаки', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[1][1].unit = {
+      owner:0,
+      tplId:'FOREST_ELVEN_DEATH_DANCER',
+      facing:'N',
+      currentHP:CARDS.FOREST_ELVEN_DEATH_DANCER.hp,
+    };
+    state.board[0][1].unit = {
+      owner:1,
+      tplId:'FIRE_TRICEPTAUR_BEHEMOTH',
+      facing:'S',
+      currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp + 2,
+    };
+    const res = magicAttack(state,1,1,0,1);
+    expect(res).toBeTruthy();
+    const board = res.n1.board;
+    expect(board[0][1].unit?.tplId).toBe('FOREST_ELVEN_DEATH_DANCER');
+    const swapped = board[1][1].unit;
+    expect(swapped?.tplId).toBe('FIRE_TRICEPTAUR_BEHEMOTH');
+    expect(swapped?.currentHP).toBe((CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp + 2) - CARDS.FOREST_ELVEN_DEATH_DANCER.atk - 2);
+    const dmgEntry = res.targets.find(t => t.r === 0 && t.c === 1);
+    expect(dmgEntry?.dmg).toBe(CARDS.FOREST_ELVEN_DEATH_DANCER.atk);
+  });
+
   it('способность backAttack наносит удар в спину и блокирует ответный урон', () => {
     const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
     state.board[0][1].element = 'BIOLITH';


### PR DESCRIPTION
## Summary
- add dedicated ability handlers for reposition effects and activation-cost auras reused by multiple creatures
- integrate the new mechanics into attack resolution, card templates, and UI cost calculations
- register the three new cards and cover their push/swap behaviours plus aura taxes with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbfe4afb008330be680dbdf3421535