### PR TITLE
Add reposition abilities and integrate new unit cards

### DIFF
--- a/src/core/abilityHandlers/reposition.js
+++ b/src/core/abilityHandlers/reposition.js
@@ -1,0 +1,267 @@
+// Модуль, отвечающий за перемещения после нанесения урона (обмен местами, отталкивание)
+// Держим здесь чистую логику без привязки к визуализации для дальнейшей миграции на другие движки.
+import { CARDS } from '../cards.js';
+import { applyFieldTransitionToUnit } from '../fieldEffects.js';
+
+const BOARD_SIZE = 3;
+const inBounds = (r, c) => r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE;
+
+function toElementSet(raw) {
+  const set = new Set();
+  if (!raw) return set;
+  const list = Array.isArray(raw) ? raw : [raw];
+  for (const val of list) {
+    if (typeof val === 'string' && val.trim()) {
+      set.add(val.trim().toUpperCase());
+    }
+  }
+  return set;
+}
+
+function lookupUnit(state, ref = {}) {
+  if (!state?.board) return { unit: null, r: null, c: null };
+  const { uid, r, c } = ref || {};
+  if (uid != null) {
+    for (let rr = 0; rr < BOARD_SIZE; rr++) {
+      for (let cc = 0; cc < BOARD_SIZE; cc++) {
+        const unit = state.board?.[rr]?.[cc]?.unit;
+        if (unit && unit.uid != null && unit.uid === uid) {
+          return { unit, r: rr, c: cc };
+        }
+      }
+    }
+  }
+  if (typeof r === 'number' && typeof c === 'number') {
+    const unit = state.board?.[r]?.[c]?.unit || null;
+    return { unit, r, c };
+  }
+  return { unit: null, r: null, c: null };
+}
+
+function describeFieldShift(shift, name) {
+  if (!shift) return null;
+  const fieldLabel = shift.nextElement ? `поле ${shift.nextElement}` : 'нейтральном поле';
+  const prev = shift.beforeHp;
+  const next = shift.afterHp;
+  if (shift.deltaHp > 0) {
+    return `${name} усиливается на ${fieldLabel}: HP ${prev}→${next}.`;
+  }
+  return `${name} теряет силу на ${fieldLabel}: HP ${prev}→${next}.`;
+}
+
+function normalizeSwapFlags(raw) {
+  if (raw && typeof raw === 'object') {
+    return {
+      allowMultiple: !!raw.allowMultiple,
+      preventRetaliation: raw.preventRetaliation !== false,
+    };
+  }
+  return { allowMultiple: false, preventRetaliation: true };
+}
+
+export function normalizeSwapConfig(tpl) {
+  if (!tpl) return null;
+  if (tpl.swapWithTargetOnDamage) {
+    const flags = normalizeSwapFlags(tpl.swapWithTargetOnDamage);
+    return { type: 'ANY', ...flags };
+  }
+  const rawList = tpl.swapWithTargetOnElement || (tpl.switchOnDamage ? tpl.element : null);
+  const elements = toElementSet(rawList);
+  if (!elements.size) return null;
+  const flags = normalizeSwapFlags({
+    allowMultiple: !!tpl.swapWithTargetAllowMultiple,
+    preventRetaliation: tpl.swapWithTargetPreventRetaliation !== false,
+  });
+  return { type: 'ELEMENT', elements, ...flags };
+}
+
+function normalizePushFlags(raw) {
+  if (raw && typeof raw === 'object') {
+    return {
+      distance: Math.max(1, raw.distance || raw.steps || 1),
+      preventRetaliation: raw.preventRetaliation !== false,
+    };
+  }
+  if (typeof raw === 'number') {
+    return { distance: Math.max(1, raw), preventRetaliation: true };
+  }
+  if (raw) {
+    return { distance: 1, preventRetaliation: true };
+  }
+  return null;
+}
+
+export function normalizePushConfig(tpl) {
+  if (!tpl || !tpl.pushTargetOnDamage) return null;
+  return normalizePushFlags(tpl.pushTargetOnDamage);
+}
+
+export function planSwapOnDamage(state, context = {}) {
+  const { attackerRef, targetUnit, targetPos, swapConfig } = context;
+  if (!swapConfig || !state || !targetUnit || !targetPos) return null;
+  const tplTarget = CARDS[targetUnit.tplId];
+  const alive = (targetUnit.currentHP ?? tplTarget?.hp ?? 0) > 0;
+  if (!alive) return null;
+  if (swapConfig.type === 'ELEMENT') {
+    const cellEl = state.board?.[targetPos.r]?.[targetPos.c]?.element;
+    if (!cellEl || !swapConfig.elements?.has(cellEl)) return null;
+  }
+  const evt = {
+    type: 'SWAP_POSITIONS',
+    attacker: attackerRef,
+    target: {
+      uid: targetUnit.uid ?? null,
+      r: targetPos.r,
+      c: targetPos.c,
+      tplId: targetUnit.tplId,
+    },
+  };
+  return {
+    event: evt,
+    preventRetaliation: swapConfig.preventRetaliation !== false,
+    consume: !swapConfig.allowMultiple,
+  };
+}
+
+function computePushDestination(attackerPos, targetPos, distance = 1) {
+  if (!attackerPos || !targetPos) return null;
+  const drRaw = targetPos.r - attackerPos.r;
+  const dcRaw = targetPos.c - attackerPos.c;
+  const stepR = Math.sign(drRaw);
+  const stepC = Math.sign(dcRaw);
+  if (stepR === 0 && stepC === 0) return null;
+  let destR = targetPos.r;
+  let destC = targetPos.c;
+  for (let i = 0; i < distance; i++) {
+    destR += stepR;
+    destC += stepC;
+  }
+  return { r: destR, c: destC };
+}
+
+export function planPushOnDamage(state, context = {}) {
+  const { attackerRef, attackerPos, targetUnit, targetPos, pushConfig } = context;
+  if (!pushConfig || !state || !attackerPos || !targetUnit || !targetPos) return null;
+  const tplTarget = CARDS[targetUnit.tplId];
+  const alive = (targetUnit.currentHP ?? tplTarget?.hp ?? 0) > 0;
+  if (!alive) {
+    return null;
+  }
+  const dest = computePushDestination(attackerPos, targetPos, pushConfig.distance || 1);
+  const preventRetaliation = pushConfig.preventRetaliation !== false;
+  if (!dest || !inBounds(dest.r, dest.c)) {
+    return { event: null, preventRetaliation };
+  }
+  const cell = state.board?.[dest.r]?.[dest.c];
+  if (!cell) {
+    return { event: null, preventRetaliation };
+  }
+  const occupant = cell.unit;
+  if (occupant) {
+    const tplOcc = CARDS[occupant.tplId];
+    const occAlive = (occupant.currentHP ?? tplOcc?.hp ?? 0) > 0;
+    if (occAlive) {
+      return { event: null, preventRetaliation };
+    }
+  }
+  const evt = {
+    type: 'PUSH_TARGET',
+    attacker: attackerRef,
+    target: {
+      uid: targetUnit.uid ?? null,
+      tplId: targetUnit.tplId,
+    },
+    from: { r: targetPos.r, c: targetPos.c },
+    to: dest,
+  };
+  return { event: evt, preventRetaliation };
+}
+
+export function applyRepositionEvent(state, event) {
+  if (!event || !state) return null;
+  const logs = [];
+  let attackerPosUpdate = null;
+  if (event.type === 'SWAP_POSITIONS') {
+    const attackerRef = lookupUnit(state, event.attacker);
+    const targetRef = lookupUnit(state, event.target);
+    if (!attackerRef.unit || !targetRef.unit) {
+      return { attackerPosUpdate: null, logLines: [] };
+    }
+    const tplAttacker = CARDS[attackerRef.unit.tplId];
+    const tplTarget = CARDS[targetRef.unit.tplId];
+    const aliveAtt = (attackerRef.unit.currentHP ?? tplAttacker?.hp ?? 0) > 0;
+    const aliveTarget = (targetRef.unit.currentHP ?? tplTarget?.hp ?? 0) > 0;
+    if (!aliveAtt || !aliveTarget) {
+      return { attackerPosUpdate: null, logLines: [] };
+    }
+    const attackerPrevElement = state.board?.[attackerRef.r]?.[attackerRef.c]?.element || null;
+    const targetPrevElement = state.board?.[targetRef.r]?.[targetRef.c]?.element || null;
+    state.board[attackerRef.r][attackerRef.c].unit = targetRef.unit;
+    state.board[targetRef.r][targetRef.c].unit = attackerRef.unit;
+    attackerPosUpdate = { r: targetRef.r, c: targetRef.c };
+    const attackerName = tplAttacker?.name || 'Атакующий';
+    const targetName = tplTarget?.name || 'Цель';
+    logs.push(`${attackerName} меняется местами с ${targetName}.`);
+    const shiftAttacker = applyFieldTransitionToUnit(
+      attackerRef.unit,
+      tplAttacker,
+      attackerPrevElement,
+      targetPrevElement,
+    );
+    const shiftTarget = applyFieldTransitionToUnit(
+      targetRef.unit,
+      tplTarget,
+      targetPrevElement,
+      attackerPrevElement,
+    );
+    const attackerLog = describeFieldShift(shiftAttacker, attackerName);
+    if (attackerLog) logs.push(attackerLog);
+    const targetLog = describeFieldShift(shiftTarget, targetName);
+    if (targetLog) logs.push(targetLog);
+    return { attackerPosUpdate, logLines: logs };
+  }
+  if (event.type === 'PUSH_TARGET') {
+    const targetRef = lookupUnit(state, event.target);
+    if (!targetRef.unit) {
+      return { attackerPosUpdate: null, logLines: [] };
+    }
+    const tplTarget = CARDS[targetRef.unit.tplId];
+    const aliveTarget = (targetRef.unit.currentHP ?? tplTarget?.hp ?? 0) > 0;
+    if (!aliveTarget) {
+      return { attackerPosUpdate: null, logLines: [] };
+    }
+    const fromCell = state.board?.[event.from?.r]?.[event.from?.c];
+    const toCell = state.board?.[event.to?.r]?.[event.to?.c];
+    if (!fromCell || !toCell) {
+      return { attackerPosUpdate: null, logLines: [] };
+    }
+    if (fromCell.unit !== targetRef.unit) {
+      return { attackerPosUpdate: null, logLines: [] };
+    }
+    const destOcc = toCell.unit;
+    if (destOcc) {
+      const tplOcc = CARDS[destOcc.tplId];
+      const occAlive = (destOcc.currentHP ?? tplOcc?.hp ?? 0) > 0;
+      if (occAlive) {
+        return { attackerPosUpdate: null, logLines: [] };
+      }
+      toCell.unit = null;
+    }
+    const attackerRef = lookupUnit(state, event.attacker);
+    const attackerName = attackerRef.unit ? (CARDS[attackerRef.unit.tplId]?.name || 'Атакующий') : 'Атакующий';
+    const targetName = tplTarget?.name || 'Цель';
+    toCell.unit = targetRef.unit;
+    fromCell.unit = null;
+    logs.push(`${attackerName} отталкивает ${targetName}.`);
+    const shiftTarget = applyFieldTransitionToUnit(
+      targetRef.unit,
+      tplTarget,
+      fromCell.element || null,
+      toCell.element || null,
+    );
+    const targetLog = describeFieldShift(shiftTarget, targetName);
+    if (targetLog) logs.push(targetLog);
+    return { attackerPosUpdate: null, logLines: logs };
+  }
+  return null;
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -350,6 +350,26 @@ export const CARDS = {
     desc: 'Adds 2 to its Attack if the target creature has a Summoning Cost of 2 or lower.'
   },
 
+  BIOLITH_DARK_YOKOZUNA_SEKIMARU: {
+    id: 'BIOLITH_DARK_YOKOZUNA_SEKIMARU', name: 'Dark Yokozuna Sekimaru', type: 'UNIT', cost: 3, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    pushTargetOnDamage: { distance: 1 },
+    desc: 'If Dark Yokozuna Sekimaru attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'
+  },
+
+  BIOLITH_TAURUS_MONOLITH: {
+    id: 'BIOLITH_TAURUS_MONOLITH', name: 'Taurus Monolith', type: 'UNIT', cost: 5, activation: 3,
+    element: 'BIOLITH', atk: 3, hp: 6,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2] } ],
+    blindspots: ['S'],
+    pushTargetOnDamage: { distance: 1 },
+    desc: 'If Taurus Monolith attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'
+  },
+
   BIOLITH_BATTLE_CHARIOT: {
     id: 'BIOLITH_BATTLE_CHARIOT', name: 'Biolith Battle Chariot', type: 'UNIT', cost: 4, activation: 4,
     element: 'BIOLITH', atk: 3, hp: 5,
@@ -375,6 +395,17 @@ export const CARDS = {
     ],
     blindspots: ['S'],
     desc: 'Magic Attack: choose one highlighted cell in front, back, left or right to target.'
+  },
+
+  FOREST_ELVEN_DEATH_DANCER: {
+    id: 'FOREST_ELVEN_DEATH_DANCER', name: 'Elven Death Dancer', type: 'UNIT', cost: 5, activation: 4,
+    element: 'FOREST', atk: 3, hp: 1,
+    attackType: 'MAGIC',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    swapWithTargetOnDamage: true,
+    increaseEnemyActivationAdjacent: 3,
+    desc: 'Magic Attack. If Elven Death Dancer damages (but does not destroy) a creature, she switches locations with that creature (which cannot counterattack). Enemies on adjacent fields add 3 to their Activation Cost.'
   },
 
   FOREST_TWIN_GOBLINS: {

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -34,7 +34,7 @@ export const capMana = (m) => Math.min(10, m);
 import { activationCost, rotateCost as rawRotateCost } from './abilities.js';
 
 // Стоимость атаки с учётом скидок
-export const attackCost = (tpl, fieldElement) => activationCost(tpl, fieldElement);
+export const attackCost = (tpl, fieldElement, opts = {}) => activationCost(tpl, fieldElement, opts);
 
 // Стоимость поворота без скидок
 export const rotateCost = (tpl) => rawRotateCost(tpl);

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -459,7 +459,11 @@ export function stagedAttack(state, r, c, opts = {}) {
     if (A) {
       A.lastAttackTurn = nFinal.turn;
       const cellEl = nFinal.board?.[r]?.[c]?.element;
-      A.apSpent = (A.apSpent || 0) + attackCost(tplA, cellEl);
+      A.apSpent = (A.apSpent || 0) + attackCost(tplA, cellEl, {
+        state: nFinal,
+        position: { r, c },
+        unit: A,
+      });
     }
 
     const targets = step1Damages.map(h => ({ r: h.r, c: h.c, dmg: h.dealt || 0 }));
@@ -661,7 +665,11 @@ export function magicAttack(state, fr, fc, tr, tc) {
   }
   attacker.lastAttackTurn = n1.turn;
   const cellEl = n1.board?.[fr]?.[fc]?.element;
-  attacker.apSpent = (attacker.apSpent || 0) + attackCost(tplA, cellEl);
+  attacker.apSpent = (attacker.apSpent || 0) + attackCost(tplA, cellEl, {
+    state: n1,
+    position: { r: fr, c: fc },
+    unit: attacker,
+  });
   return { n1, logLines, targets, deaths, releases: releaseEvents.releases };
 }
 

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -71,7 +71,10 @@ export function performUnitAttack(unitMesh) {
       window.__ui?.notifications?.show('This unit has already attacked this turn', 'error');
       return;
     }
-    const cost = typeof window.attackCost === 'function' ? window.attackCost(tpl) : 0;
+    const cellEl = gameState.board?.[r]?.[c]?.element;
+    const cost = typeof window.attackCost === 'function'
+      ? window.attackCost(tpl, cellEl, { state: gameState, position: { r, c }, unit })
+      : 0;
     const iState = window.__interactions?.interactionState;
     const mustUseMagic = shouldUseMagicAttack(gameState, r, c, tpl);
     if (tpl?.attackType === 'MAGIC' || mustUseMagic) {

--- a/src/ui/panels.js
+++ b/src/ui/panels.js
@@ -15,7 +15,12 @@ export function showUnitActionPanel(unitMesh){
     const attackBtn = document.getElementById('attack-btn'); if (attackBtn) {
       const cannot = !canAttack(cardData);
       attackBtn.disabled = !!alreadyAttacked || cannot;
-      const cost = (typeof window !== 'undefined' && typeof window.attackCost === 'function') ? window.attackCost(cardData) : 1;
+      const row = unitMesh.userData.row;
+      const col = unitMesh.userData.col;
+      const fieldElement = gs.board?.[row]?.[col]?.element;
+      const cost = (typeof window !== 'undefined' && typeof window.attackCost === 'function')
+        ? window.attackCost(cardData, fieldElement, { state: gs, position: { r: row, c: col }, unit: unitData })
+        : 1;
       attackBtn.textContent = cannot ? 'Cannot attack' : alreadyAttacked ? 'Already attacked' : `Attack (-${cost})`;
     }
     const extraActions = collectUnitActions(gs, unitMesh.userData.row, unitMesh.userData.col);


### PR DESCRIPTION
## Summary
- вынес обработку обмена позициями и отталкивания после атаки в модуль abilityHandlers/reposition
- реализовал механику отталкивания и ауры увеличения стоимости активации, добавил карты Dark Yokozuna Sekimaru, Elven Death Dancer и Taurus Monolith
- обновил расчёт стоимости атаки и UI, чтобы учитывать новые способности

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbfe4afb008330be680dbdf3421535