### PR TITLE
Fix reposition resync and Taurus multi-hit

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,9 +338,13 @@
     }
 
     // Синхронизирует 3D-модели юнитов с текущим состоянием gameState
-    function updateUnits() {
+    function updateUnits(forceResync = false) {
       if (window.__units && typeof window.__units.updateUnits === 'function') {
-        window.__units.updateUnits(gameState);
+        if (forceResync && typeof window.__units.forceResyncUnits === 'function') {
+          window.__units.forceResyncUnits(gameState);
+        } else {
+          window.__units.updateUnits(gameState);
+        }
         const ctx = window.__scene && typeof window.__scene.getCtx === 'function'
           ? window.__scene.getCtx() : null;
         if (ctx && ctx.unitMeshes) {
@@ -605,6 +609,7 @@
           }
           // Финализация: анимация смерти и орбы перед применением состояния
           const res = staged.finish();
+          const needsResync = !!res.needsFullResync;
           gameState = res.n1;
           try { window.applyGameState(gameState); } catch {}
           if (res.deaths && res.deaths.length) {
@@ -629,7 +634,7 @@
           }
           if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn;
             setTimeout(() => {
-              updateUnits(); updateUI();
+              updateUnits(needsResync); updateUI();
               for (const l of res.logLines.reverse()) addLog(l);
               try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
@@ -637,15 +642,21 @@
                 try { endTurn(); } catch {}
               }
             }, 1000);
+            setTimeout(() => {
+              try { updateUnits(needsResync); } catch {}
+            }, 1400);
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
             setTimeout(() => {
-              updateUnits(); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish', { force: true }); } catch {}
+              updateUnits(needsResync); updateUI(); for (const l of res.logLines.reverse()) addLog(l); if (markAttackTurn && gameState.board[r][c]?.unit) gameState.board[r][c].unit.lastAttackTurn = gameState.turn; try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
                 try { endTurn(); } catch {}
               }
             }, Math.max(0, animDelayMs));
+            setTimeout(() => {
+              try { updateUnits(needsResync); } catch {}
+            }, Math.max(0, animDelayMs) + 420);
           }
         }, 420);
       };
@@ -704,6 +715,7 @@
       const res = magicAttack(gameState, from.r, from.c, tr, tc);
       if (!res) { showNotification('Incorrect target', 'error'); return; }
       for (const l of res.logLines.reverse()) addLog(l);
+      const needsResync = !!res.needsFullResync;
       const aMesh = unitMeshes.find(m => m.userData.row === from.r && m.userData.col === from.c);
       if (aMesh) { gsap.fromTo(aMesh.position, { y: aMesh.position.y }, { y: aMesh.position.y + 0.3, yoyo: true, repeat: 1, duration: 0.12 }); }
       // вспышка по цели
@@ -742,7 +754,7 @@
         try { window.applyGameState(gameState); } catch {}
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         setTimeout(() => {
-          updateUnits(); updateUI();
+          updateUnits(needsResync); updateUI();
           try { schedulePush('magic-battle-finish', { force: true }); } catch {}
           if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
             window.__interactions.interactionState.autoEndTurnAfterAttack = false;
@@ -752,7 +764,7 @@
       } else {
         // Если смертей нет — применяем состояние сразу
         gameState = res.n1; try { window.applyGameState(gameState); } catch {}
-        updateUnits(); updateUI();
+        updateUnits(needsResync); updateUI();
         const attacker = gameState.board[from.r][from.c] && gameState.board[from.r][from.c].unit; if (attacker) attacker.lastAttackTurn = gameState.turn;
         try { schedulePush('magic-battle-finish', { force: true }); } catch {}
         if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {

--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -16,6 +16,8 @@ import {
   attemptDodge as attemptDodgeInternal,
 } from './abilityHandlers/dodge.js';
 import { computeTargetCostBonus as computeTargetCostBonusInternal } from './abilityHandlers/attackModifiers.js';
+import { collectRepositionOnDamage } from './abilityHandlers/reposition.js';
+import { extraActivationCostFromAuras } from './abilityHandlers/costModifiers.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -158,24 +160,9 @@ export function collectDamageInteractions(state, context = {}) {
   const { attackerPos, attackerUnit, tpl, hits } = context;
   if (!tpl || !attackerUnit || !Array.isArray(hits) || !hits.length) return result;
 
-  const attackerRef = {
-    uid: getUnitUid(attackerUnit),
-    r: attackerPos?.r,
-    c: attackerPos?.c,
-    tplId: tpl.id,
-  };
-
-  let swapHandled = false;
-  const swapElements = normalizeElements(
-    tpl.swapWithTargetOnElement || (tpl.switchOnDamage ? tpl.element : null)
-  );
-
+  const processed = [];
   for (const h of hits) {
     if (!h) continue;
-    const key = `${h.r},${h.c}`;
-    if (tpl.backAttack) {
-      result.preventRetaliation.add(key);
-    }
     const dealt = h.dealt ?? h.dmg ?? 0;
     if (dealt <= 0) continue;
     const cell = state.board?.[h.r]?.[h.c];
@@ -183,28 +170,55 @@ export function collectDamageInteractions(state, context = {}) {
     if (!target) continue;
     const tplTarget = getUnitTemplate(target);
     const alive = (target.currentHP ?? tplTarget?.hp ?? 0) > 0;
-
-    if (!swapHandled && swapElements.size && alive && cell?.element && swapElements.has(cell.element)) {
-      result.events.push({
-        type: 'SWAP_POSITIONS',
-        attacker: attackerRef,
-        target: { uid: getUnitUid(target), r: h.r, c: h.c, tplId: tplTarget?.id },
-      });
-      swapHandled = true;
+    if (!alive) continue;
+    const key = `${h.r},${h.c}`;
+    processed.push({
+      r: h.r,
+      c: h.c,
+      dealt,
+      target,
+      tplTarget,
+      cellElement: cell?.element ?? null,
+      key,
+    });
+    if (tpl.backAttack) {
       result.preventRetaliation.add(key);
     }
-
-    if (tpl.rotateTargetOnDamage && alive) {
-      result.events.push({
-        type: 'ROTATE_TARGET',
-        target: { uid: getUnitUid(target), r: h.r, c: h.c, tplId: tplTarget?.id },
-        faceAwayFrom: attackerRef,
-      });
-      result.preventRetaliation.add(key);
-    }
-
     if (tpl.preventRetaliationOnDamage) {
       result.preventRetaliation.add(key);
+    }
+  }
+
+  if (!processed.length) {
+    return result;
+  }
+
+  const attackerRef = {
+    uid: getUnitUid(attackerUnit),
+    r: attackerPos?.r,
+    c: attackerPos?.c,
+    tplId: tpl.id,
+  };
+
+  const reposition = collectRepositionOnDamage(state, {
+    attackerRef,
+    attackerPos: attackerPos || { r: attackerRef.r, c: attackerRef.c },
+    tpl,
+    hits: processed,
+  });
+
+  if (reposition) {
+    if (Array.isArray(reposition.events) && reposition.events.length) {
+      result.events.push(...reposition.events);
+    }
+    let preventList = [];
+    if (reposition.preventRetaliation instanceof Set) {
+      preventList = Array.from(reposition.preventRetaliation);
+    } else if (Array.isArray(reposition.preventRetaliation)) {
+      preventList = reposition.preventRetaliation;
+    }
+    for (const key of preventList) {
+      if (key) result.preventRetaliation.add(key);
     }
   }
 
@@ -214,6 +228,7 @@ export function collectDamageInteractions(state, context = {}) {
 export function applyDamageInteractionResults(state, effects = {}) {
   const logs = [];
   let attackerPosUpdate = null;
+  let needsFullResync = false;
   const events = Array.isArray(effects?.events) ? effects.events : [];
 
   for (const ev of events) {
@@ -262,6 +277,7 @@ export function applyDamageInteractionResults(state, effects = {}) {
       if (attackerLog) logs.push(attackerLog);
       const targetLog = describeShift(shiftTarget, targetName);
       if (targetLog) logs.push(targetLog);
+      needsFullResync = true;
     } else if (ev?.type === 'ROTATE_TARGET') {
       const target = findUnitRef(state, ev.target);
       if (!target.unit) continue;
@@ -274,10 +290,49 @@ export function applyDamageInteractionResults(state, effects = {}) {
         const name = CARDS[target.unit.tplId]?.name || 'Цель';
         logs.push(`${name} поворачивается спиной к атакующему.`);
       }
+    } else if (ev?.type === 'PUSH_TARGET') {
+      const target = findUnitRef(state, ev.target);
+      if (!target.unit) continue;
+      const tplTarget = CARDS[target.unit.tplId];
+      const aliveTarget = (target.unit.currentHP ?? tplTarget?.hp ?? 0) > 0;
+      if (!aliveTarget) continue;
+      const to = ev.to || {};
+      if (!inBounds(to.r, to.c)) continue;
+      const destCell = state.board?.[to.r]?.[to.c];
+      if (destCell?.unit) {
+        const destUnit = destCell.unit;
+        const tplDest = CARDS[destUnit.tplId];
+        const aliveDest = (destUnit.currentHP ?? tplDest?.hp ?? 0) > 0;
+        if (aliveDest) continue;
+      }
+      const fromElement = state.board?.[target.r]?.[target.c]?.element ?? null;
+      const toElement = state.board?.[to.r]?.[to.c]?.element ?? null;
+      state.board[target.r][target.c].unit = null;
+      state.board[to.r][to.c].unit = target.unit;
+      const attackerName = ev.source?.tplId ? (CARDS[ev.source.tplId]?.name || 'Атакующий') : 'Атакующий';
+      const targetName = CARDS[target.unit.tplId]?.name || 'Цель';
+      logs.push(`${attackerName} отталкивает ${targetName} назад.`);
+      const shiftTarget = applyFieldTransitionToUnit(
+        target.unit,
+        tplTarget,
+        fromElement,
+        toElement,
+      );
+      if (shiftTarget) {
+        const fieldLabel = shiftTarget.nextElement ? `поле ${shiftTarget.nextElement}` : 'нейтральное поле';
+        const prev = shiftTarget.beforeHp;
+        const next = shiftTarget.afterHp;
+        if (shiftTarget.deltaHp > 0) {
+          logs.push(`${targetName} усиливается на ${fieldLabel}: HP ${prev}→${next}.`);
+        } else if (shiftTarget.deltaHp < 0) {
+          logs.push(`${targetName} теряет силу на ${fieldLabel}: HP ${prev}→${next}.`);
+        }
+      }
+      needsFullResync = true;
     }
   }
 
-  return { attackerPosUpdate, logLines: logs };
+  return { attackerPosUpdate, logLines: logs, needsFullResync };
 }
 
 function normalizeElementConfig(value, defaults = {}) {
@@ -342,7 +397,7 @@ function baseActivationCost(tpl) {
 }
 
 // фактическая стоимость атаки с учётом скидок (например, "активация на X меньше")
-export function activationCost(tpl, fieldElement) {
+export function activationCost(tpl, fieldElement, ctx = {}) {
   let cost = baseActivationCost(tpl);
   if (tpl && tpl.activationReduction) {
     cost = Math.max(0, cost - tpl.activationReduction);
@@ -351,7 +406,16 @@ export function activationCost(tpl, fieldElement) {
   if (onElem && fieldElement === onElem.element) {
     cost = Math.max(0, cost - onElem.reduction);
   }
-  return cost;
+  if (ctx && ctx.state && typeof ctx.r === 'number' && typeof ctx.c === 'number') {
+    const extra = extraActivationCostFromAuras(ctx.state, ctx.r, ctx.c, {
+      unit: ctx.unit,
+      owner: ctx.owner,
+    });
+    if (extra) {
+      cost += extra;
+    }
+  }
+  return Math.max(0, cost);
 }
 
 // стоимость поворота/обычной активации — без скидок

--- a/src/core/abilityHandlers/costModifiers.js
+++ b/src/core/abilityHandlers/costModifiers.js
@@ -1,0 +1,46 @@
+// Модуль для расчёта модификаторов стоимости активации от аур существ
+// Держим отдельно от визуала для удобства портирования логики
+import { CARDS } from '../cards.js';
+
+const inBounds = (r, c) => r >= 0 && r < 3 && c >= 0 && c < 3;
+
+const ADJACENT_DIRS = [
+  { dr: -1, dc: 0 },
+  { dr: 1, dc: 0 },
+  { dr: 0, dc: -1 },
+  { dr: 0, dc: 1 },
+];
+
+function normalizeTax(value) {
+  if (value == null) return 0;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'object') {
+    if (typeof value.amount === 'number') return value.amount;
+    if (typeof value.value === 'number') return value.value;
+    if (typeof value.plus === 'number') return value.plus;
+  }
+  return 0;
+}
+
+export function extraActivationCostFromAuras(state, r, c, opts = {}) {
+  if (!state?.board) return 0;
+  const attackerUnit = opts.unit || state.board?.[r]?.[c]?.unit || null;
+  const owner = opts.owner ?? attackerUnit?.owner ?? null;
+  let total = 0;
+  for (const { dr, dc } of ADJACENT_DIRS) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) continue;
+    const auraUnit = state.board?.[nr]?.[nc]?.unit;
+    if (!auraUnit) continue;
+    const tplAura = CARDS[auraUnit.tplId];
+    if (!tplAura) continue;
+    if (owner != null && auraUnit.owner === owner) continue;
+    const alive = (auraUnit.currentHP ?? tplAura.hp ?? 0) > 0;
+    if (!alive) continue;
+    const tax = normalizeTax(tplAura.enemyActivationTaxAdjacent);
+    if (!tax) continue;
+    total += tax;
+  }
+  return total;
+}

--- a/src/core/abilityHandlers/reposition.js
+++ b/src/core/abilityHandlers/reposition.js
@@ -1,0 +1,159 @@
+// Модуль обработки эффектов, меняющих положение существ после атаки
+// Логика изолирована от визуальной части для дальнейшего переиспользования
+import { CARDS } from '../cards.js';
+
+const inBounds = (r, c) => r >= 0 && r < 3 && c >= 0 && c < 3;
+
+function getUnitUid(unit) {
+  return (unit && unit.uid != null) ? unit.uid : null;
+}
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
+function normalizeElements(value) {
+  const set = new Set();
+  for (const raw of toArray(value)) {
+    if (typeof raw === 'string' && raw) {
+      set.add(raw.toUpperCase());
+    }
+  }
+  return set;
+}
+
+function normalizePushConfig(raw) {
+  if (!raw) return null;
+  const base = {
+    distance: 1,
+    preventRetaliation: true,
+    requireEmpty: true,
+    elements: null,
+  };
+  if (raw === true) return base;
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return { ...base, distance: Math.max(1, Math.abs(Math.trunc(raw))) };
+  }
+  if (typeof raw === 'object') {
+    const cfg = { ...base };
+    if (typeof raw.distance === 'number' && Number.isFinite(raw.distance)) {
+      cfg.distance = Math.max(1, Math.abs(Math.trunc(raw.distance)));
+    }
+    if (raw.preventRetaliation === false) cfg.preventRetaliation = false;
+    if (raw.requireEmpty === false) cfg.requireEmpty = false;
+    const elems = normalizeElements(raw.onlyOnElement || raw.element || raw.elements);
+    cfg.elements = elems.size ? elems : null;
+    return cfg;
+  }
+  return base;
+}
+
+function directionBetween(from, to) {
+  if (!from || !to) return null;
+  const dr = (to.r ?? 0) - (from.r ?? 0);
+  const dc = (to.c ?? 0) - (from.c ?? 0);
+  if (dr === 0 && dc === 0) return null;
+  if (dr !== 0 && dc !== 0) return null;
+  if (dr < 0) return { dir: 'N', dr: -1, dc: 0 };
+  if (dr > 0) return { dir: 'S', dr: 1, dc: 0 };
+  if (dc < 0) return { dir: 'W', dr: 0, dc: -1 };
+  if (dc > 0) return { dir: 'E', dr: 0, dc: 1 };
+  return null;
+}
+
+export function collectRepositionOnDamage(state, context = {}) {
+  const events = [];
+  const prevent = new Set();
+  if (!state?.board) return { events, preventRetaliation: [] };
+
+  const { attackerRef, attackerPos, tpl, hits } = context;
+  if (!tpl || !Array.isArray(hits) || !hits.length) {
+    return { events, preventRetaliation: [] };
+  }
+
+  const swapElements = normalizeElements(
+    tpl.swapWithTargetOnElement || (tpl.switchOnDamage ? tpl.element : null)
+  );
+  const allowSwapAny = !!tpl.swapOnDamage;
+  const pushCfg = normalizePushConfig(tpl.pushTargetOnDamage);
+  const rotateOnDamage = !!tpl.rotateTargetOnDamage;
+
+  let swapTriggered = false;
+
+  for (const hit of hits) {
+    if (!hit) continue;
+    const target = hit.target;
+    const tplTarget = hit.tplTarget;
+    if (!target || !tplTarget) continue;
+    const key = hit.key || `${hit.r},${hit.c}`;
+    const cellElement = hit.cellElement ?? state.board?.[hit.r]?.[hit.c]?.element ?? null;
+
+    if (!swapTriggered) {
+      let shouldSwap = false;
+      if (allowSwapAny) {
+        shouldSwap = true;
+      } else if (swapElements.size && cellElement && swapElements.has(cellElement)) {
+        shouldSwap = true;
+      }
+      if (shouldSwap) {
+        events.push({
+          type: 'SWAP_POSITIONS',
+          attacker: attackerRef,
+          target: { uid: getUnitUid(target), r: hit.r, c: hit.c, tplId: tplTarget?.id ?? target.tplId },
+        });
+        swapTriggered = true;
+        prevent.add(key);
+      }
+    }
+
+    if (rotateOnDamage) {
+      events.push({
+        type: 'ROTATE_TARGET',
+        target: { uid: getUnitUid(target), r: hit.r, c: hit.c, tplId: tplTarget?.id ?? target.tplId },
+        faceAwayFrom: attackerRef,
+      });
+      prevent.add(key);
+    }
+
+    if (pushCfg) {
+      if (pushCfg.elements && cellElement && !pushCfg.elements.has(cellElement)) {
+        // поле не подходит — пропускаем перемещение, но возможность контратаки всё равно блокируем
+        if (pushCfg.preventRetaliation) prevent.add(key);
+        continue;
+      }
+      const dirInfo = directionBetween(attackerPos || attackerRef, { r: hit.r, c: hit.c });
+      if (!dirInfo) {
+        if (pushCfg.preventRetaliation) prevent.add(key);
+        continue;
+      }
+      const destR = hit.r + dirInfo.dr * pushCfg.distance;
+      const destC = hit.c + dirInfo.dc * pushCfg.distance;
+      if (!inBounds(destR, destC)) {
+        if (pushCfg.preventRetaliation) prevent.add(key);
+        continue;
+      }
+      const destUnit = state.board?.[destR]?.[destC]?.unit;
+      let blocked = false;
+      if (destUnit) {
+        const tplDest = CARDS[destUnit.tplId];
+        const aliveDest = (destUnit.currentHP ?? tplDest?.hp ?? 0) > 0;
+        if (aliveDest && pushCfg.requireEmpty) {
+          blocked = true;
+        }
+      }
+      if (!blocked) {
+        events.push({
+          type: 'PUSH_TARGET',
+          target: { uid: getUnitUid(target), r: hit.r, c: hit.c, tplId: tplTarget?.id ?? target.tplId },
+          to: { r: destR, c: destC },
+          direction: dirInfo.dir,
+          source: attackerRef,
+        });
+      }
+      if (pushCfg.preventRetaliation) prevent.add(key);
+    }
+  }
+
+  return { events, preventRetaliation: Array.from(prevent) };
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -257,6 +257,15 @@ export const CARDS = {
     ],
     desc: 'Sacrifice Yellow Cubic to summon a non‑cubic Earth creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
+  EARTH_DARK_YOKOZUNA_SEKIMARU: {
+    id: 'EARTH_DARK_YOKOZUNA_SEKIMARU', name: 'Dark Yokozuna Sekimaru', type: 'UNIT', cost: 3, activation: 2,
+    element: 'EARTH', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    pushTargetOnDamage: { distance: 1 },
+    desc: 'If Dark Yokozuna Sekimaru attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'
+  },
   WATER_WOLF_NINJA: {
     id: 'WATER_WOLF_NINJA', name: 'Wolf Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 1, hp: 3,
@@ -298,6 +307,16 @@ export const CARDS = {
     invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
     rotateTargetOnDamage: true,
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+  FOREST_ELVEN_DEATH_DANCER: {
+    id: 'FOREST_ELVEN_DEATH_DANCER', name: 'Elven Death Dancer', type: 'UNIT', cost: 5, activation: 4,
+    element: 'FOREST', atk: 1, hp: 3,
+    attackType: 'MAGIC',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY' } ],
+    blindspots: ['S'],
+    swapOnDamage: true,
+    enemyActivationTaxAdjacent: 3,
+    desc: 'Magic Attack. If Elven Death Dancer damages (but does not destroy) a creature, she switches locations with that creature (which cannot counterattack). Enemies on adjacent fields add 3 to their Activation Cost.'
   },
   FOREST_GREEN_CUBIC: {
     id: 'FOREST_GREEN_CUBIC', name: 'Green Cubic', type: 'UNIT', cost: 1, activation: 1,
@@ -361,6 +380,16 @@ export const CARDS = {
     friendlyFire: true,
     blindspots: ['S'],
     desc: ''
+  },
+
+  BIOLITH_TAURUS_MONOLITH: {
+    id: 'BIOLITH_TAURUS_MONOLITH', name: 'Taurus Monolith', type: 'UNIT', cost: 5, activation: 3,
+    element: 'BIOLITH', atk: 3, hp: 6,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], ignoreBlocking: true } ],
+    blindspots: ['S'],
+    pushTargetOnDamage: { distance: 1 },
+    desc: 'If Taurus Monolith attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'
   },
 
   BIOLITH_ARC_SATELLITE_CANNON: {

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -34,7 +34,7 @@ export const capMana = (m) => Math.min(10, m);
 import { activationCost, rotateCost as rawRotateCost } from './abilities.js';
 
 // Стоимость атаки с учётом скидок
-export const attackCost = (tpl, fieldElement) => activationCost(tpl, fieldElement);
+export const attackCost = (tpl, fieldElement, ctx) => activationCost(tpl, fieldElement, ctx);
 
 // Стоимость поворота без скидок
 export const rotateCost = (tpl) => rawRotateCost(tpl);

--- a/src/main.js
+++ b/src/main.js
@@ -173,6 +173,7 @@ try {
   };
   window.__units = {
     updateUnits: Units.updateUnits,
+    forceResyncUnits: Units.forceResyncUnits,
   };
   window.__hand = {
     setHandCardHoverVisual: Hand.setHandCardHoverVisual,

--- a/src/scene/delta.js
+++ b/src/scene/delta.js
@@ -1,6 +1,6 @@
 // Анимация различий между предыдущим и новым состоянием
 
-export function playDeltaAnimations(prevState, nextState) {
+export function playDeltaAnimations(prevState, nextState, opts = {}) {
   try {
     if (!prevState || !nextState) return;
 
@@ -17,16 +17,61 @@ export function playDeltaAnimations(prevState, nextState) {
     const capMana = window.capMana || (x => x);
     const CARDS = window.CARDS || {};
 
+    const includeActive = !!opts.includeActive;
     const isActivePlayer = (typeof window.MY_SEAT === 'number' && gameState && typeof gameState.active === 'number' && window.MY_SEAT === gameState.active);
+
+    if (!includeActive && isActivePlayer) {
+      return;
+    }
+
+    const skipDeathFx = !!opts.skipDeathFx || (includeActive && isActivePlayer);
+
+    const makeSignature = (unit) => {
+      if (!unit) return null;
+      if (unit.uid != null) return `UID:${unit.uid}`;
+      const owner = unit.owner != null ? unit.owner : 'x';
+      const tpl = unit.tplId || 'unknown';
+      const hp = (typeof unit.currentHP === 'number') ? unit.currentHP : (typeof unit.hp === 'number' ? unit.hp : 'x');
+      const facing = unit.facing || 'N';
+      return `SIG:${owner}:${tpl}:${hp}:${facing}`;
+    };
 
     const prevB = prevState.board || [];
     const nextB = nextState.board || [];
+
+    const nextPosByUid = new Map();
+    const nextSigPositions = new Map();
+
+    for (let r = 0; r < 3; r++) {
+      for (let c = 0; c < 3; c++) {
+        const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
+        if (!nu) continue;
+        if (nu.uid != null) {
+          nextPosByUid.set(nu.uid, { r, c });
+        } else {
+          const sig = makeSignature(nu);
+          if (!sig) continue;
+          if (!nextSigPositions.has(sig)) nextSigPositions.set(sig, []);
+          nextSigPositions.get(sig).push({ r, c });
+        }
+      }
+    }
 
     for (let r = 0; r < 3; r++) {
       for (let c = 0; c < 3; c++) {
         const pu = (prevB[r] && prevB[r][c] && prevB[r][c].unit) ? prevB[r][c].unit : null;
         const nu = (nextB[r] && nextB[r][c] && nextB[r][c].unit) ? nextB[r][c].unit : null;
         if (pu && !nu) {
+          const sigPrev = makeSignature(pu);
+          let moved = false;
+          if (pu.uid != null) {
+            const pos = nextPosByUid.get(pu.uid);
+            if (pos && (pos.r !== r || pos.c !== c)) moved = true;
+          } else if (sigPrev) {
+            const positions = nextSigPositions.get(sigPrev) || [];
+            moved = positions.some(pos => pos.r !== r || pos.c !== c);
+          }
+          if (moved) continue;
           try {
             const prevPl = prevState?.players?.[pu.owner];
             const nextPl = nextState?.players?.[pu.owner];
@@ -36,6 +81,7 @@ export function playDeltaAnimations(prevState, nextState) {
               prevPl.discard.length > nextPl.discard.length &&
               nextPl.hand.length > prevPl.hand.length;
             if (!canceled) {
+              if (skipDeathFx) continue;
               const tile = tileMeshes?.[r]?.[c]; if (!tile) continue;
               const ghost = createCard3D ? createCard3D(CARDS[pu.tplId], false) : null;
               if (ghost && window.THREE) {
@@ -67,7 +113,7 @@ export function playDeltaAnimations(prevState, nextState) {
       }
     }
 
-    if (isActivePlayer) {
+    if (!includeActive && isActivePlayer) {
       return;
     }
 

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -71,7 +71,10 @@ export function performUnitAttack(unitMesh) {
       window.__ui?.notifications?.show('This unit has already attacked this turn', 'error');
       return;
     }
-    const cost = typeof window.attackCost === 'function' ? window.attackCost(tpl) : 0;
+    const fieldElement = gameState.board?.[r]?.[c]?.element;
+    const cost = typeof window.attackCost === 'function'
+      ? window.attackCost(tpl, fieldElement, { state: gameState, r, c, unit, owner: unit.owner })
+      : 0;
     const iState = window.__interactions?.interactionState;
     const mustUseMagic = shouldUseMagicAttack(gameState, r, c, tpl);
     if (tpl?.attackType === 'MAGIC' || mustUseMagic) {

--- a/src/ui/panels.js
+++ b/src/ui/panels.js
@@ -10,12 +10,17 @@ export function showUnitActionPanel(unitMesh){
     try { if (typeof window !== 'undefined') window.selectedUnit = unitMesh; } catch {}
     const unitData = unitMesh.userData?.unitData; const cardData = unitMesh.userData?.cardData; const gs = (typeof window !== 'undefined') ? window.gameState : null;
     if (!gs || !unitData || !cardData) return;
+    const row = unitMesh.userData?.row;
+    const col = unitMesh.userData?.col;
     const el = document.getElementById('unit-info'); if (el) el.textContent = `${cardData.name} (${(unitMesh.userData.row||0) + 1},${(unitMesh.userData.col||0) + 1})`;
     const alreadyAttacked = unitData.lastAttackTurn === gs.turn;
     const attackBtn = document.getElementById('attack-btn'); if (attackBtn) {
       const cannot = !canAttack(cardData);
       attackBtn.disabled = !!alreadyAttacked || cannot;
-      const cost = (typeof window !== 'undefined' && typeof window.attackCost === 'function') ? window.attackCost(cardData) : 1;
+      const fieldElement = (typeof row === 'number' && typeof col === 'number') ? gs.board?.[row]?.[col]?.element : undefined;
+      const cost = (typeof window !== 'undefined' && typeof window.attackCost === 'function')
+        ? window.attackCost(cardData, fieldElement, { state: gs, r: row, c: col, unit: unitData, owner: unitData?.owner })
+        : 1;
       attackBtn.textContent = cannot ? 'Cannot attack' : alreadyAttacked ? 'Already attacked' : `Attack (-${cost})`;
     }
     const extraActions = collectUnitActions(gs, unitMesh.userData.row, unitMesh.userData.col);

--- a/tests/constants.test.js
+++ b/tests/constants.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { inBounds, capMana, attackCost, rotateCost } from '../src/core/constants.js';
+import { CARDS } from '../src/core/cards.js';
 
 describe('constants helpers', () => {
   it('inBounds: within 3x3 grid', () => {
@@ -30,6 +31,23 @@ describe('constants helpers', () => {
     const tpl = { activation: 3, activationReduction: 2 };
     expect(attackCost(tpl)).toBe(1);
     expect(rotateCost(tpl)).toBe(3);
+  });
+
+  it('attackCost: учитывает ауры, повышающие стоимость соседей', () => {
+    const state = {
+      board: Array.from({ length: 3 }, () => Array.from({ length: 3 }, () => ({ element: 'NEUTRAL', unit: null }))),
+    };
+    state.board[1][1].unit = { owner: 1, tplId: 'FOREST_ELVEN_DEATH_DANCER', currentHP: CARDS.FOREST_ELVEN_DEATH_DANCER.hp };
+    state.board[1][0].unit = { owner: 0, tplId: 'FIRE_HELLFIRE_SPITTER', currentHP: CARDS.FIRE_HELLFIRE_SPITTER.hp };
+    const cellEl = state.board[1][0].element;
+    const cost = attackCost(CARDS.FIRE_HELLFIRE_SPITTER, cellEl, {
+      state,
+      r: 1,
+      c: 0,
+      unit: state.board[1][0].unit,
+      owner: 0,
+    });
+    expect(cost).toBe(4); // базовая стоимость 1 + налог ауры 3
   });
 });
 

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -393,6 +393,130 @@ describe('особые способности', () => {
     expect(dmgEntry?.dmg).toBe(1);
   });
 
+  it('Dark Yokozuna Sekimaru отталкивает цель и блокирует контратаку', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].unit = {
+      owner:0,
+      tplId:'EARTH_DARK_YOKOZUNA_SEKIMARU',
+      facing:'N',
+      currentHP:CARDS.EARTH_DARK_YOKOZUNA_SEKIMARU.hp,
+    };
+    state.board[1][1].unit = {
+      owner:1,
+      tplId:'FIRE_TRICEPTAUR_BEHEMOTH',
+      facing:'S',
+      currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp,
+    };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    expect(fin.n1.board[2][1].unit?.tplId).toBe('EARTH_DARK_YOKOZUNA_SEKIMARU');
+    expect(fin.n1.board[1][1].unit).toBeNull();
+    const pushed = fin.n1.board[0][1].unit;
+    expect(pushed?.tplId).toBe('FIRE_TRICEPTAUR_BEHEMOTH');
+    expect(pushed?.currentHP).toBe(CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp);
+    expect(fin.retaliators.length).toBe(0);
+  });
+
+  it('Taurus Monolith не даёт врагу контратаковать даже без свободной клетки для отталкивания', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].unit = {
+      owner:0,
+      tplId:'BIOLITH_TAURUS_MONOLITH',
+      facing:'N',
+      currentHP:CARDS.BIOLITH_TAURUS_MONOLITH.hp,
+    };
+    state.board[1][1].unit = {
+      owner:1,
+      tplId:'FIRE_TRICEPTAUR_BEHEMOTH',
+      facing:'S',
+      currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp,
+    };
+    state.board[0][1].unit = {
+      owner:1,
+      tplId:'FIRE_PURSUER_OF_SAINT_DHEES',
+      facing:'S',
+      currentHP:CARDS.FIRE_PURSUER_OF_SAINT_DHEES.hp + 2,
+    };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    const target = fin.n1.board[1][1].unit;
+    expect(target?.tplId).toBe('FIRE_TRICEPTAUR_BEHEMOTH');
+    expect(target?.currentHP).toBe(CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp - CARDS.BIOLITH_TAURUS_MONOLITH.atk);
+    const rear = fin.n1.board[0][1].unit;
+    expect(rear?.tplId).toBe('FIRE_PURSUER_OF_SAINT_DHEES');
+    expect(rear?.currentHP).toBe((CARDS.FIRE_PURSUER_OF_SAINT_DHEES.hp + 2) - CARDS.BIOLITH_TAURUS_MONOLITH.atk);
+    expect(fin.retaliators.length).toBe(0);
+  });
+
+  it('Taurus Monolith отталкивает цель, и клиенту нужен полный ресинк позиций', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:3 };
+    state.board[2][1].unit = {
+      owner:0,
+      tplId:'BIOLITH_TAURUS_MONOLITH',
+      facing:'N',
+      currentHP:CARDS.BIOLITH_TAURUS_MONOLITH.hp,
+    };
+    state.board[1][1].unit = {
+      owner:1,
+      tplId:'FIRE_TRICEPTAUR_BEHEMOTH',
+      facing:'S',
+      currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp + 1,
+    };
+    const staged = stagedAttack(state,2,1);
+    expect(staged).toBeTruthy();
+    const fin = staged.finish();
+    expect(fin.needsFullResync).toBe(true);
+    expect(fin.n1.board[1][1].unit).toBeNull();
+    const pushed = fin.n1.board[0][1].unit;
+    expect(pushed?.tplId).toBe('FIRE_TRICEPTAUR_BEHEMOTH');
+    expect(pushed?.currentHP).toBe(((CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp + 1) - CARDS.BIOLITH_TAURUS_MONOLITH.atk) + 2);
+  });
+
+  it('магические существа не контратакуют по умолчанию', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[2][1].unit = {
+      owner:0,
+      tplId:'FIRE_PARTMOLE_FLAME_LIZARD',
+      facing:'N',
+      currentHP:CARDS.FIRE_PARTMOLE_FLAME_LIZARD.hp,
+    };
+    state.board[1][1].unit = {
+      owner:1,
+      tplId:'FIRE_FLAME_MAGUS',
+      facing:'S',
+      currentHP:CARDS.FIRE_FLAME_MAGUS.hp + 2,
+    };
+    const res = stagedAttack(state,2,1);
+    const fin = res.finish();
+    expect(fin.retaliators.length).toBe(0);
+  });
+
+  it('Elven Death Dancer меняется местами с целью после магической атаки', () => {
+    const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
+    state.board[1][1].unit = {
+      owner:0,
+      tplId:'FOREST_ELVEN_DEATH_DANCER',
+      facing:'N',
+      currentHP:CARDS.FOREST_ELVEN_DEATH_DANCER.hp,
+    };
+    state.board[0][1].unit = {
+      owner:1,
+      tplId:'FIRE_TRICEPTAUR_BEHEMOTH',
+      facing:'S',
+      currentHP:CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp + 2,
+    };
+    const res = magicAttack(state,1,1,0,1);
+    expect(res).toBeTruthy();
+    expect(res.needsFullResync).toBe(true);
+    const board = res.n1.board;
+    expect(board[0][1].unit?.tplId).toBe('FOREST_ELVEN_DEATH_DANCER');
+    const swapped = board[1][1].unit;
+    expect(swapped?.tplId).toBe('FIRE_TRICEPTAUR_BEHEMOTH');
+    expect(swapped?.currentHP).toBe((CARDS.FIRE_TRICEPTAUR_BEHEMOTH.hp + 2) - CARDS.FOREST_ELVEN_DEATH_DANCER.atk - 2);
+    const dmgEntry = res.targets.find(t => t.r === 0 && t.c === 1);
+    expect(dmgEntry?.dmg).toBe(CARDS.FOREST_ELVEN_DEATH_DANCER.atk);
+  });
+
   it('способность backAttack наносит удар в спину и блокирует ответный урон', () => {
     const state = { board: makeBoard(), players:[{mana:0},{mana:0}], turn:1 };
     state.board[0][1].element = 'BIOLITH';


### PR DESCRIPTION
## Summary
- add a force-resync path for unit meshes after swaps and pushes and invoke it from battle and magic flows
- propagate a needsFullResync flag from combat resolution and expose the helper through the window bridge
- let Taurus Monolith ignore blocking to damage both targets and extend combat tests accordingly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbfe4afb008330be680dbdf3421535