### PR TITLE
Добавлены карты Анфиса и щупальца с переработкой possession

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -18,6 +18,11 @@ import {
 import { computeTargetCostBonus as computeTargetCostBonusInternal } from './abilityHandlers/attackModifiers.js';
 import { collectRepositionOnDamage } from './abilityHandlers/reposition.js';
 import { extraActivationCostFromAuras } from './abilityHandlers/costModifiers.js';
+import {
+  buildPossessionSourceDescriptor,
+  refreshContinuousPossessions,
+  formatPossessionEvents,
+} from './abilityHandlers/possession.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -363,16 +368,6 @@ function sameSource(possessionSource, deathInfo) {
   return false;
 }
 
-function buildSourceDescriptor(state, r, c, unit, tpl) {
-  return {
-    uid: getUnitUid(unit),
-    tplId: tpl?.id || unit?.tplId || null,
-    owner: unit?.owner,
-    position: { r, c },
-    turn: state?.turn ?? 0,
-  };
-}
-
 function ensureUniqueCells(cells) {
   const seen = new Set();
   const res = [];
@@ -479,7 +474,7 @@ export function applySummonAbilities(state, r, c) {
           targetUnit.possessed = {
             by: unit.owner,
             originalOwner,
-            source: buildSourceDescriptor(state, r, c, unit, tpl),
+            source: buildPossessionSourceDescriptor(state, r, c, unit, tpl),
             sinceTurn: state?.turn ?? 0,
             targetTplId: tplTarget?.id ?? targetUnit.tplId,
           };
@@ -605,6 +600,7 @@ export const evaluateIncarnationSummon = evaluateIncarnationSummonInternal;
 export const applyIncarnationSummon = applyIncarnationSummonInternal;
 export const ensureUnitDodgeState = ensureDodgeState;
 export const attemptUnitDodge = attemptDodgeInternal;
+export { refreshContinuousPossessions, formatPossessionEvents };
 
 export function collectUnitActions(state, r, c) {
   const actions = [];

--- a/src/core/abilityHandlers/possession.js
+++ b/src/core/abilityHandlers/possession.js
@@ -1,0 +1,294 @@
+// Модуль для обработки постоянных эффектов владения (possession)
+import { CARDS } from '../cards.js';
+
+// Вспомогательные структуры — держим локально, чтобы избежать циклических импортов
+const DIR4 = [
+  { dr: -1, dc: 0 },
+  { dr: 0, dc: 1 },
+  { dr: 1, dc: 0 },
+  { dr: 0, dc: -1 },
+];
+const DIAGONALS = [
+  { dr: -1, dc: -1 },
+  { dr: -1, dc: 1 },
+  { dr: 1, dc: -1 },
+  { dr: 1, dc: 1 },
+];
+const FACING_VECTORS = {
+  N: { dr: -1, dc: 0 },
+  E: { dr: 0, dc: 1 },
+  S: { dr: 1, dc: 0 },
+  W: { dr: 0, dc: -1 },
+};
+
+const DEFAULT_EFFECT = {
+  ADJACENT: 'POSSESSION_ADJACENT',
+  ADJACENT_ON_ELEMENT: 'POSSESSION_ADJACENT',
+  FRONT_SINGLE: 'POSSESSION_FRONT_SINGLE',
+};
+
+function inBounds(r, c) {
+  return r >= 0 && r < 3 && c >= 0 && c < 3;
+}
+
+function getUnitTemplate(unit) {
+  if (!unit) return null;
+  return CARDS[unit.tplId] || null;
+}
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeBehavior(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const keyword = raw.toUpperCase();
+    return {
+      keyword,
+      effectKey: DEFAULT_EFFECT[keyword] || `POSSESSION_${keyword}`,
+      includeDiagonals: false,
+      range: 1,
+    };
+  }
+  if (typeof raw === 'object') {
+    const keywordRaw = raw.keyword || raw.type || raw.kind;
+    if (!keywordRaw) return null;
+    const keyword = String(keywordRaw).toUpperCase();
+    const effectKey = raw.effect || raw.effectKey || DEFAULT_EFFECT[keyword] || `POSSESSION_${keyword}`;
+    const elementRaw = raw.element || raw.requireElement;
+    const requireElement = elementRaw ? String(elementRaw).toUpperCase() : null;
+    const includeDiagonals = !!raw.includeDiagonals;
+    const rangeValue = Number.isFinite(raw.range) ? Number(raw.range) : 1;
+    const range = Math.max(1, rangeValue || 1);
+    return {
+      keyword,
+      effectKey,
+      requireElement,
+      includeDiagonals,
+      range,
+    };
+  }
+  return null;
+}
+
+function collectBehaviors(tpl) {
+  const result = [];
+  if (!tpl) return result;
+  for (const raw of toArray(tpl.possessionBehaviors)) {
+    const behavior = normalizeBehavior(raw);
+    if (behavior) result.push(behavior);
+  }
+  for (const raw of toArray(tpl.possessionBehavior)) {
+    const behavior = normalizeBehavior(raw);
+    if (behavior) result.push(behavior);
+  }
+  for (const raw of toArray(tpl.possessionRules)) {
+    const behavior = normalizeBehavior(raw);
+    if (behavior) result.push(behavior);
+  }
+  return result;
+}
+
+function collectAdjacentTargets(r, c, behavior) {
+  const dirs = behavior.includeDiagonals ? DIR4.concat(DIAGONALS) : DIR4;
+  const cells = [];
+  for (const { dr, dc } of dirs) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) continue;
+    cells.push({ r: nr, c: nc });
+  }
+  return cells;
+}
+
+function collectFrontTargets(state, r, c, unit, behavior) {
+  const vec = FACING_VECTORS[unit?.facing] || FACING_VECTORS.N;
+  if (!vec) return [];
+  const cells = [];
+  let nr = r + vec.dr;
+  let nc = c + vec.dc;
+  for (let step = 1; step <= behavior.range; step += 1) {
+    if (!inBounds(nr, nc)) break;
+    cells.push({ r: nr, c: nc });
+    const occupant = state?.board?.[nr]?.[nc]?.unit;
+    if (occupant) break; // дальше по линии не смотрим
+    nr += vec.dr;
+    nc += vec.dc;
+  }
+  return cells;
+}
+
+function collectTargetsForBehavior(state, r, c, unit, behavior) {
+  switch (behavior.keyword) {
+    case 'ADJACENT':
+    case 'ADJACENT_ON_ELEMENT':
+      return collectAdjacentTargets(r, c, behavior);
+    case 'FRONT_SINGLE':
+      return collectFrontTargets(state, r, c, unit, behavior);
+    default:
+      return [];
+  }
+}
+
+export function buildPossessionSourceDescriptor(state, r, c, unit, tpl, extra = {}) {
+  return {
+    uid: unit?.uid ?? null,
+    tplId: tpl?.id || unit?.tplId || null,
+    owner: unit?.owner,
+    position: { r, c },
+    turn: state?.turn ?? 0,
+    ...extra,
+  };
+}
+
+export function refreshContinuousPossessions(state, opts = {}) {
+  const { collectEvents = true } = opts || {};
+  const events = { acquired: [], released: [] };
+  if (!state?.board) return events;
+
+  const desired = new Map();
+  const effectCatalog = new Set();
+
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      const cell = state.board?.[r]?.[c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      if ((unit.currentHP ?? getUnitTemplate(unit)?.hp ?? 0) <= 0) continue;
+      const tpl = getUnitTemplate(unit);
+      const behaviors = collectBehaviors(tpl);
+      if (!behaviors.length) continue;
+      for (const behavior of behaviors) {
+        effectCatalog.add(behavior.effectKey);
+        if (behavior.requireElement) {
+          if (!cell?.element || cell.element !== behavior.requireElement) continue;
+        }
+        const targets = collectTargetsForBehavior(state, r, c, unit, behavior);
+        if (!targets.length) continue;
+        for (const target of targets) {
+          const key = `${target.r},${target.c}`;
+          if (desired.has(key)) continue;
+          const targetUnit = state.board?.[target.r]?.[target.c]?.unit;
+          if (!targetUnit) continue;
+          if ((targetUnit.currentHP ?? getUnitTemplate(targetUnit)?.hp ?? 0) <= 0) continue;
+          if (targetUnit.owner === unit.owner) continue;
+          const tplTarget = getUnitTemplate(targetUnit);
+          const existing = targetUnit.possessed;
+          const originalOwner = existing?.originalOwner ?? targetUnit.owner;
+          const source = buildPossessionSourceDescriptor(state, r, c, unit, tpl, {
+            effect: behavior.effectKey,
+            keyword: behavior.keyword,
+          });
+          desired.set(key, {
+            r: target.r,
+            c: target.c,
+            newOwner: unit.owner,
+            originalOwner,
+            source,
+            effectKey: behavior.effectKey,
+            sourceTplId: tpl?.id || unit.tplId,
+            targetTplId: tplTarget?.id || targetUnit.tplId,
+          });
+        }
+      }
+    }
+  }
+
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      const unit = state.board?.[r]?.[c]?.unit;
+      if (!unit) continue;
+      const key = `${r},${c}`;
+      const desiredEntry = desired.get(key);
+      if (desiredEntry) {
+        const tplTarget = getUnitTemplate(unit);
+        const existing = unit.possessed;
+        const alreadyControlled = existing
+          && existing.by === desiredEntry.newOwner
+          && existing.source?.uid === desiredEntry.source?.uid
+          && existing.source?.effect === desiredEntry.effectKey;
+        if (!alreadyControlled) {
+          const originalOwner = existing?.originalOwner ?? desiredEntry.originalOwner ?? unit.owner;
+          unit.owner = desiredEntry.newOwner;
+          unit.possessed = {
+            by: desiredEntry.newOwner,
+            originalOwner,
+            source: desiredEntry.source,
+            sinceTurn: state?.turn ?? 0,
+            targetTplId: desiredEntry.targetTplId,
+            effect: desiredEntry.effectKey,
+          };
+          unit.lastAttackTurn = state?.turn ?? 0;
+          if (collectEvents) {
+            events.acquired.push({
+              r,
+              c,
+              newOwner: desiredEntry.newOwner,
+              originalOwner,
+              sourceTplId: desiredEntry.sourceTplId,
+              targetTplId: desiredEntry.targetTplId,
+              effect: desiredEntry.effectKey,
+            });
+          }
+        } else {
+          unit.owner = desiredEntry.newOwner;
+          unit.possessed = {
+            ...existing,
+            source: desiredEntry.source,
+            effect: desiredEntry.effectKey,
+            targetTplId: desiredEntry.targetTplId,
+          };
+        }
+        continue;
+      }
+
+      const info = unit.possessed;
+      if (!info) continue;
+      const effectKey = info.effect;
+      if (!effectKey || !effectCatalog.has(effectKey)) continue;
+      const originalOwner = info.originalOwner ?? unit.owner;
+      if (unit.owner !== originalOwner) {
+        unit.owner = originalOwner;
+      }
+      delete unit.possessed;
+      if (collectEvents) {
+        events.released.push({
+          r,
+          c,
+          originalOwner,
+          targetTplId: unit.tplId,
+          effect: effectKey,
+        });
+      }
+    }
+  }
+
+  return events;
+}
+
+export function formatPossessionEvents(events) {
+  const lines = [];
+  if (!events) return lines;
+  const toName = (tplId) => {
+    const tpl = tplId ? CARDS[tplId] : null;
+    return tpl?.name || 'Существо';
+  };
+  for (const ev of events.acquired || []) {
+    const sourceName = toName(ev.sourceTplId);
+    const targetName = toName(ev.targetTplId);
+    const ownerLabel = typeof ev.newOwner === 'number'
+      ? `игроку ${ev.newOwner + 1}`
+      : 'новому владельцу';
+    lines.push(`${sourceName}: ${targetName} переходит под контроль ${ownerLabel}.`);
+  }
+  for (const ev of events.released || []) {
+    const targetName = toName(ev.targetTplId);
+    const ownerLabel = typeof ev.originalOwner === 'number'
+      ? `игрока ${ev.originalOwner + 1}`
+      : 'исходного владельца';
+    lines.push(`${targetName}: контроль возвращается к ${ownerLabel}.`);
+  }
+  return lines;
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -296,6 +296,28 @@ export const CARDS = {
     backAttack: true,
     desc: 'Always attacks the back of its target.'
   },
+  WATER_TENTACLES_OF_POSSESSION: {
+    id: 'WATER_TENTACLES_OF_POSSESSION', name: 'Tentacles of Possession', type: 'UNIT', cost: 2, activation: 1,
+    element: 'WATER', atk: 0, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [],
+    blindspots: ['S'],
+    possessionBehaviors: [
+      { keyword: 'FRONT_SINGLE', range: 1 },
+    ],
+    desc: 'Tentacles of Possession gain Possession of the enemy directly in front of it.'
+  },
+  WATER_IMPOSTER_QUEEN_ANFISA: {
+    id: 'WATER_IMPOSTER_QUEEN_ANFISA', name: 'Imposter Queen Anfisa', type: 'UNIT', cost: 6, activation: 2,
+    element: 'WATER', atk: 2, hp: 5,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    possessionBehaviors: [
+      { keyword: 'ADJACENT_ON_ELEMENT', element: 'WATER' },
+    ],
+    desc: 'Magic Attack. While on a Water field, Imposter Queen Anfisa gains Possession of all adjacent enemies.'
+  },
   FOREST_SWALLOW_NINJA: {
     id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 1, hp: 3,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -15,6 +15,8 @@ import {
   attemptUnitDodge,
   collectDamageInteractions,
   applyDamageInteractionResults,
+  refreshContinuousPossessions,
+  formatPossessionEvents,
 } from './abilities.js';
 import { countUnits } from './board.js';
 import { computeCellBuff } from './fieldEffects.js';
@@ -516,6 +518,14 @@ export function stagedAttack(state, r, c, opts = {}) {
       A.apSpent = (A.apSpent || 0) + attackCostValue;
     }
 
+    const possessionEvents = refreshContinuousPossessions(nFinal);
+    if (possessionEvents) {
+      const messages = formatPossessionEvents(possessionEvents);
+      if (Array.isArray(messages) && messages.length) {
+        logLines.push(...messages);
+      }
+    }
+
     const targets = step1Damages.map(h => ({ r: h.r, c: h.c, dmg: h.dealt || 0 }));
     return {
       n1: nFinal,
@@ -525,6 +535,7 @@ export function stagedAttack(state, r, c, opts = {}) {
       retaliators: ret.retaliators,
       releases: releaseEvents.releases,
       attackerPosUpdate,
+      possessionEvents,
     };
   }
 
@@ -733,7 +744,14 @@ export function magicAttack(state, fr, fc, tr, tc) {
   }
   attacker.lastAttackTurn = n1.turn;
   attacker.apSpent = (attacker.apSpent || 0) + attackCostValue;
-  return { n1, logLines, targets, deaths, releases: releaseEvents.releases, attackerPosUpdate };
+  const possessionEvents = refreshContinuousPossessions(n1);
+  if (possessionEvents) {
+    const messages = formatPossessionEvents(possessionEvents);
+    if (Array.isArray(messages) && messages.length) {
+      logLines.push(...messages);
+    }
+  }
+  return { n1, logLines, targets, deaths, releases: releaseEvents.releases, attackerPosUpdate, possessionEvents };
 }
 
 export { computeCellBuff };

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@
 import * as Constants from './core/constants.js';
 import { CARDS } from './core/cards.js';
 import { DECKS } from './core/decks.js';
+import * as Abilities from './core/abilities.js';
 // Стартовая колода по умолчанию — первая из списка
 const STARTER_FIRESET = DECKS[0]?.cards || [];
 import * as Rules from './core/rules.js';
@@ -171,8 +172,19 @@ try {
     createCard3D: Cards.createCard3D,
     drawCardFace: Cards.drawCardFace,
   };
+  const updateUnitsWithPossession = (state) => {
+    try {
+      const gs = state || (typeof window !== 'undefined' ? window.gameState : null);
+      if (gs) {
+        Abilities.refreshContinuousPossessions(gs, { collectEvents: false });
+      }
+      Units.updateUnits(gs);
+    } catch (err) {
+      console.warn('[main] Не удалось обновить юнитов', err);
+    }
+  };
   window.__units = {
-    updateUnits: Units.updateUnits,
+    updateUnits: updateUnitsWithPossession,
   };
   window.__hand = {
     setHandCardHoverVisual: Hand.setHandCardHoverVisual,
@@ -197,6 +209,7 @@ try {
   window.__ui.deckSelect = DeckSelect;
   window.__ui.deckBuilder = DeckBuilder;
   window.__ui.mainMenu = MainMenu;
+  window.updateUnits = (state) => updateUnitsWithPossession(state);
   window.updateUI = updateUI;
   window.__fx = SceneEffects;
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -9,6 +9,8 @@ import {
   evaluateIncarnationSummon,
   applyIncarnationSummon,
   isIncarnationCard,
+  refreshContinuousPossessions,
+  formatPossessionEvents,
 } from '../core/abilities.js';
 import { capMana } from '../core/constants.js';
 
@@ -684,6 +686,13 @@ export function placeUnitWithDirection(direction) {
     const gained = applyFreedonianAura(gameState, gameState.active);
     if (gained > 0) {
       window.addLog(`Фридонийский Странник приносит ${gained} маны.`);
+    }
+    const possessionEvents = refreshContinuousPossessions(gameState);
+    const possessionMessages = formatPossessionEvents(possessionEvents);
+    if (Array.isArray(possessionMessages) && possessionMessages.length) {
+      for (const line of possessionMessages) {
+        window.addLog?.(line);
+      }
     }
   }
   // Синхронизируем состояние после призыва

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -7,6 +7,8 @@ import {
   shouldUseMagicAttack,
   collectUnitActions,
   executeUnitAction,
+  refreshContinuousPossessions,
+  formatPossessionEvents,
 } from '../core/abilities.js';
 import {
   interactionState,
@@ -46,6 +48,13 @@ export function rotateUnit(unitMesh, dir) {
     const turnCW = window.turnCW || {}; const turnCCW = window.turnCCW || {};
     u.facing = dir === 'cw' ? turnCW[u.facing] : turnCCW[u.facing];
     u.lastRotateTurn = gameState.turn;
+    const possessionEvents = refreshContinuousPossessions(gameState);
+    const possessionMessages = formatPossessionEvents(possessionEvents);
+    if (Array.isArray(possessionMessages) && possessionMessages.length) {
+      for (const line of possessionMessages) {
+        window.addLog?.(line);
+      }
+    }
     window.__units?.updateUnits?.(gameState);
     try { window.selectedUnit = null; window.__ui?.panels?.hideUnitActionPanel(); } catch {}
   } catch {}

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -1,6 +1,7 @@
 // Навешивание обработчиков UI элементов
 
 import { refreshInputLockUI } from './inputLock.js';
+import { refreshContinuousPossessions, formatPossessionEvents } from '../core/abilities.js';
 
 export function attachUIEvents() {
   if (typeof document === 'undefined') return;
@@ -91,6 +92,11 @@ export function attachUIEvents() {
           u.facing = direction;
           w.addLog?.(`${tpl.name}: ${w.CARDS[u.tplId].name} повёрнут в ${direction}.`);
           pl.discard.push(tpl); pl.hand.splice(idx, 1);
+          const possessionEvents = refreshContinuousPossessions(gameState);
+          const possessionMessages = formatPossessionEvents(possessionEvents);
+          if (Array.isArray(possessionMessages) && possessionMessages.length) {
+            for (const line of possessionMessages) w.addLog?.(line);
+          }
           w.__interactions.resetCardSelection(); w.updateHand(); w.updateUnits(); w.updateUI();
         }
         w.__interactions.clearPendingSpellOrientation();


### PR DESCRIPTION
## Summary
- вынес обработку постоянных эффектов possession в отдельный модуль и подключил его к боевой логике и UI
- добавил новые карты Water Tentacles of Possession и Imposter Queen Anfisa с конфигурацией possessionBehaviors
- обновил поворот, призыв и заклинания, чтобы пересчитывать владение и выводить сообщения, а также обернул обновление юнитов

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccf5b963a08330b0e6c0fae8877422