### PR TITLE
Add new water units with draw and dodge mechanics

### DIFF
--- a/src/core/abilityHandlers/attackSchemes.js
+++ b/src/core/abilityHandlers/attackSchemes.js
@@ -1,0 +1,81 @@
+// Модуль выбора активной схемы атаки
+import { CARDS } from '../cards.js';
+
+function normalizeElement(value) {
+  if (!value) return null;
+  return String(value).toUpperCase();
+}
+
+function normalizeElementMap(raw) {
+  const map = new Map();
+  if (!raw) return map;
+  const list = Array.isArray(raw) ? raw : [raw];
+  for (const entry of list) {
+    if (!entry) continue;
+    const element = typeof entry === 'string'
+      ? entry
+      : entry.element;
+    const scheme = typeof entry === 'string'
+      ? null
+      : entry.scheme || entry.key;
+    if (!element || !scheme) continue;
+    map.set(String(element).toUpperCase(), String(scheme));
+  }
+  return map;
+}
+
+function findScheme(tpl, key) {
+  if (!tpl || !key) return null;
+  const schemes = Array.isArray(tpl.attackSchemes) ? tpl.attackSchemes : [];
+  return schemes.find(s => (s.key || s.label) === key) || null;
+}
+
+export function resolveAttackProfile(state, ctx = {}) {
+  const { tpl: tplRaw, unit, r, c } = ctx;
+  const tpl = tplRaw || (unit ? CARDS[unit.tplId] : null);
+  if (!tpl) return null;
+  const schemes = Array.isArray(tpl.attackSchemes) ? tpl.attackSchemes : [];
+  if (!schemes.length) return null;
+
+  const requested = ctx.schemeKey || ctx.requestedKey || null;
+  if (requested) {
+    const direct = findScheme(tpl, requested);
+    if (direct) return direct;
+  }
+
+  let element = null;
+  if (state?.board && typeof r === 'number' && typeof c === 'number') {
+    element = normalizeElement(state.board?.[r]?.[c]?.element || null);
+  }
+
+  if (element) {
+    const map = normalizeElementMap(tpl.forceSchemeOnElement || tpl.mustUseSchemeOnElement);
+    const forced = map.get(element);
+    if (forced) {
+      const scheme = findScheme(tpl, forced);
+      if (scheme) return scheme;
+    }
+    const mustMagic = normalizeElement(tpl.mustUseMagicOnElement);
+    if (mustMagic && mustMagic === element) {
+      const magicScheme = schemes.find(s => {
+        if (s?.attackType) return s.attackType === 'MAGIC';
+        if (s?.key) return String(s.key).toUpperCase() === 'MAGIC';
+        return false;
+      });
+      if (magicScheme) return magicScheme;
+    }
+  }
+
+  const defaultKey = tpl.defaultSchemeKey;
+  if (defaultKey) {
+    const scheme = findScheme(tpl, defaultKey);
+    if (scheme) return scheme;
+  }
+
+  return schemes[0] || null;
+}
+
+export function getAllSchemes(tpl) {
+  if (!tpl) return [];
+  return Array.isArray(tpl.attackSchemes) ? tpl.attackSchemes : [];
+}

--- a/src/core/abilityHandlers/dodge.js
+++ b/src/core/abilityHandlers/dodge.js
@@ -89,6 +89,7 @@ export function ensureDodgeState(unit, tpl, configOverride = null) {
     chance: cfg.chance,
     limited,
     max,
+    baseMax: limited ? max : null,
     remaining: limited ? max : null,
     successesUsed: 0,
   };
@@ -150,4 +151,136 @@ export function attemptDodge(state, r, c, opts = {}) {
     keyword: stateObj.keyword,
     attempted: true,
   };
+}
+
+function amountFromConfig(cfg) {
+  if (cfg == null) return 0;
+  if (typeof cfg === 'number' && Number.isFinite(cfg)) {
+    return Math.max(0, Math.floor(cfg));
+  }
+  if (typeof cfg === 'object') {
+    if (typeof cfg.amount === 'number') return Math.max(0, Math.floor(cfg.amount));
+    if (typeof cfg.value === 'number') return Math.max(0, Math.floor(cfg.value));
+    if (typeof cfg.plus === 'number') return Math.max(0, Math.floor(cfg.plus));
+  }
+  return 0;
+}
+
+const FALLBACK_DODGE_CFG = { chance: 0.5, attempts: 0, keyword: 'DODGE_ATTEMPT' };
+
+function ensureStateWithFallback(unit, tpl) {
+  let state = ensureDodgeState(unit, tpl);
+  if (!state) {
+    state = ensureDodgeState(unit, tpl, FALLBACK_DODGE_CFG);
+  }
+  return state;
+}
+
+function addExtra(map, unit, amount) {
+  if (!unit || amount <= 0) return;
+  const entry = map.get(unit) || { extra: 0 };
+  entry.extra += amount;
+  map.set(unit, entry);
+}
+
+function normalizeElement(value) {
+  if (!value) return null;
+  return String(value).toUpperCase();
+}
+
+function neighbors(r, c) {
+  return [ [r-1, c], [r+1, c], [r, c-1], [r, c+1] ];
+}
+
+export function refreshDodgeBonuses(state) {
+  if (!state?.board) return;
+  const extras = new Map();
+
+  const ensure = ensureStateWithFallback;
+
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const cell = state.board?.[r]?.[c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      const tpl = unit.tplId ? CARDS[unit.tplId] : null;
+      if (!tpl) continue;
+      const stateObj = ensure(unit, tpl);
+      if (!stateObj) continue;
+
+      const selfBonus = tpl.dodgeBonusOnElement || tpl.extraDodgeOnElement;
+      if (selfBonus) {
+        const element = normalizeElement(selfBonus.element || selfBonus);
+        const amount = amountFromConfig(selfBonus);
+        if (element && amount > 0 && cell.element === element) {
+          addExtra(extras, unit, amount);
+        }
+      }
+
+      if (tpl.dodgeGainPerAdjacentEnemy) {
+        const per = amountFromConfig(tpl.dodgeGainPerAdjacentEnemy) || 1;
+        let count = 0;
+        for (const [nr, nc] of neighbors(r, c)) {
+          const neigh = state.board?.[nr]?.[nc]?.unit;
+          if (neigh && neigh.owner !== unit.owner) count += 1;
+        }
+        if (count > 0) addExtra(extras, unit, per * count);
+      }
+
+      if (tpl.dodgeAuraAdjacentAllies) {
+        const amount = amountFromConfig(tpl.dodgeAuraAdjacentAllies) || 1;
+        if (amount > 0) {
+          for (const [nr, nc] of neighbors(r, c)) {
+            const neigh = state.board?.[nr]?.[nc]?.unit;
+            if (!neigh || neigh.owner !== unit.owner || neigh === unit) continue;
+            ensure(neigh, CARDS[neigh.tplId]);
+            addExtra(extras, neigh, amount);
+          }
+        }
+      }
+
+      if (tpl.dodgeAuraAlliesOnElement) {
+        const cfg = tpl.dodgeAuraAlliesOnElement;
+        const element = normalizeElement(cfg.element || cfg);
+        const amount = amountFromConfig(cfg) || 1;
+        const includeSelf = cfg.includeSelf === true;
+        if (element && amount > 0) {
+          for (let rr = 0; rr < 3; rr++) {
+            for (let cc = 0; cc < 3; cc++) {
+              const allyCell = state.board?.[rr]?.[cc];
+              const ally = allyCell?.unit;
+              if (!ally || ally.owner !== unit.owner) continue;
+              if (!includeSelf && ally === unit) continue;
+              if (allyCell.element !== element) continue;
+              ensure(ally, CARDS[ally.tplId]);
+              addExtra(extras, ally, amount);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const unit = state.board?.[r]?.[c]?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      const stateObj = unit.dodgeState;
+      if (!stateObj) continue;
+      const extra = extras.get(unit)?.extra || 0;
+      stateObj.bonusAttempts = extra;
+      if (!stateObj.limited) continue;
+      const base = typeof stateObj.baseMax === 'number' ? stateObj.baseMax : (stateObj.max ?? 0);
+      const used = stateObj.successesUsed ?? 0;
+      const newMax = Math.max(base, base + extra);
+      stateObj.max = newMax;
+      if (used > newMax) {
+        stateObj.successesUsed = newMax;
+        stateObj.remaining = 0;
+      } else {
+        stateObj.remaining = Math.max(0, newMax - used);
+      }
+    }
+  }
 }

--- a/src/core/abilityHandlers/draw.js
+++ b/src/core/abilityHandlers/draw.js
@@ -1,0 +1,59 @@
+// Модуль обработки добора карт при призыве существ
+import { drawOne } from '../board.js';
+
+function normalizeElement(value) {
+  if (!value) return null;
+  if (typeof value === 'string') return value.toUpperCase();
+  if (typeof value === 'object' && value.element) {
+    return String(value.element).toUpperCase();
+  }
+  return null;
+}
+
+function countFields(state, predicate) {
+  if (!state?.board) return 0;
+  let total = 0;
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const cell = state.board?.[r]?.[c];
+      if (cell && predicate(cell, r, c)) total += 1;
+    }
+  }
+  return total;
+}
+
+function drawMultiple(state, owner, amount) {
+  const events = [];
+  if (!state?.players?.[owner]) return events;
+  for (let i = 0; i < amount; i++) {
+    const drawn = drawOne(state, owner);
+    if (!drawn) break;
+    events.push(drawn);
+  }
+  return events;
+}
+
+export function applySummonDraw(state, { owner, tpl }) {
+  if (!state || !tpl || owner == null) return null;
+  const cfg = tpl.drawCardsOnSummon;
+  if (!cfg) return null;
+
+  if (cfg.type === 'FIELDS_OF_ELEMENT' || typeof cfg === 'string') {
+    const element = normalizeElement(cfg.element || (typeof cfg === 'string' ? cfg : null));
+    if (!element) return null;
+    const amount = countFields(state, cell => cell?.element === element);
+    if (amount <= 0) return null;
+    const cards = drawMultiple(state, owner, amount);
+    if (!cards.length) return null;
+    return { owner, cards, element, amount: cards.length };
+  }
+
+  if (typeof cfg === 'number' && Number.isFinite(cfg) && cfg > 0) {
+    const amount = Math.floor(cfg);
+    const cards = drawMultiple(state, owner, amount);
+    if (!cards.length) return null;
+    return { owner, cards, amount: cards.length };
+  }
+
+  return null;
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -320,6 +320,105 @@ export const CARDS = {
     ],
     desc: 'Magic Attack. While on a Water field, Imposter Queen Anfisa gains Possession of all enemies on adjacent fields.'
   },
+  WATER_CLOUD_RUNNER: {
+    id: 'WATER_CLOUD_RUNNER', name: 'Cloud Runner', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY' } ],
+    blindspots: ['S'],
+    keywords: ['DODGE_ATTEMPT'],
+    dodge: { chance: 0.5, attempts: 1 },
+    drawCardsOnSummon: { type: 'FIELDS_OF_ELEMENT', element: 'WATER' },
+    desc: 'When Cloud Runner is summoned, draw cards equal to the number of Water fields. Dodge attempt.'
+  },
+  WATER_DON_OF_VENOA: {
+    id: 'WATER_DON_OF_VENOA', name: 'Don of Venoa', type: 'UNIT', cost: 5, activation: 3,
+    element: 'WATER', atk: 3, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1], group: 'DUAL_STRIKE' },
+      { dir: 'S', ranges: [1], group: 'DUAL_STRIKE' },
+    ],
+    attackSchemes: [
+      { key: 'BASE', label: 'Base', attacks: [
+        { dir: 'N', ranges: [1], group: 'DUAL_STRIKE' },
+        { dir: 'S', ranges: [1], group: 'DUAL_STRIKE' },
+      ] },
+      { key: 'WATER', label: 'Water', attacks: [
+        { dir: 'N', ranges: [1], group: 'WATER_SWEEP' },
+        { dir: 'S', ranges: [1], group: 'WATER_SWEEP' },
+        { dir: 'E', ranges: [1], group: 'WATER_SWEEP' },
+        { dir: 'W', ranges: [1], group: 'WATER_SWEEP' },
+      ] },
+    ],
+    forceSchemeOnElement: { element: 'WATER', scheme: 'WATER' },
+    blindspots: ['S'],
+    keywords: ['DODGE_ATTEMPT'],
+    dodge: { chance: 0.5, attempts: 1 },
+    dodgeGainPerAdjacentEnemy: 1,
+    dodgeAuraAdjacentAllies: { amount: 1 },
+    desc: 'While on a Water field, Don must use his secondary attack hitting all adjacent fields. Don gains one Dodge attempt for each adjacent enemy. Adjacent allied creatures gain one Dodge attempt.'
+  },
+  WATER_MERCENARY_SAVIOR_LATOO: {
+    id: 'WATER_MERCENARY_SAVIOR_LATOO', name: 'Mercenary Savior Latoo', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1], group: 'FRONT_LINE', ignoreBlocking: true },
+      { dir: 'N', ranges: [2], group: 'FRONT_LINE', ignoreBlocking: true },
+    ],
+    attackSchemes: [
+      { key: 'BASE', label: 'Base', attacks: [
+        { dir: 'N', ranges: [1], group: 'FRONT_LINE', ignoreBlocking: true },
+        { dir: 'N', ranges: [2], group: 'FRONT_LINE', ignoreBlocking: true },
+      ] },
+      { key: 'EARTH', label: 'Earth', attacks: [
+        { dir: 'N', ranges: [1], ignoreBlocking: true },
+      ] },
+    ],
+    forceSchemeOnElement: { element: 'EARTH', scheme: 'EARTH' },
+    blindspots: ['S'],
+    keywords: ['DODGE_ATTEMPT'],
+    dodge: { chance: 0.5, attempts: 1 },
+    dodgeAuraAlliesOnElement: { element: 'WATER', amount: 1 },
+    plusAtkIfTargetOnElement: { element: 'WATER', amount: 1 },
+    desc: 'Dodge attempt. Latoo adds 1 to his Attack if at least one target creature is on a Water field. While Latoo is on the board, all other allied creatures on Water fields gain one Dodge attempt.'
+  },
+  WATER_TRITONAN_HARPOONSMAN: {
+    id: 'WATER_TRITONAN_HARPOONSMAN', name: 'Tritonan Harpoonsman', type: 'UNIT', cost: 2, activation: 1,
+    element: 'WATER', atk: 2, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1], group: 'HARPOON_LINE', ignoreBlocking: true },
+      { dir: 'N', ranges: [2], group: 'HARPOON_LINE', ignoreBlocking: true },
+    ],
+    attackSchemes: [
+      { key: 'BASE', label: 'Base', attacks: [
+        { dir: 'N', ranges: [1], group: 'HARPOON_LINE', ignoreBlocking: true },
+        { dir: 'N', ranges: [2], group: 'HARPOON_LINE', ignoreBlocking: true },
+      ] },
+      { key: 'EARTH', label: 'Earth', attacks: [
+        { dir: 'N', ranges: [1], ignoreBlocking: true },
+      ] },
+    ],
+    forceSchemeOnElement: { element: 'EARTH', scheme: 'EARTH' },
+    blindspots: ['S'],
+    keywords: ['DODGE_ATTEMPT'],
+    dodge: { chance: 0.5, attempts: 1 },
+    dodgeBonusOnElement: { element: 'WATER', amount: 1 },
+    desc: 'Dodge attempt. While on a Water field, Tritonan Harpoonsman gains one Dodge attempt. On an Earth field he can only attack the first space in front of him.'
+  },
+  WATER_ALUHJA_PRIESTESS: {
+    id: 'WATER_ALUHJA_PRIESTESS', name: 'Aluhja Priestess', type: 'UNIT', cost: 2, activation: 1,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'MAGIC',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY' } ],
+    blindspots: ['N','E','S','W'],
+    keywords: ['DODGE_ATTEMPT'],
+    dodge: { chance: 0.5, attempts: 1 },
+    dodgeBonusOnElement: { element: 'WATER', amount: 1 },
+    desc: 'Magic Attack. While on a Water field, Aluhja Priestess gains one Dodge attempt.'
+  },
   FOREST_SWALLOW_NINJA: {
     id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 1, hp: 3,

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { DECKS } from './core/decks.js';
 // Стартовая колода по умолчанию — первая из списка
 const STARTER_FIRESET = DECKS[0]?.cards || [];
 import * as Rules from './core/rules.js';
+import * as Abilities from './core/abilities.js';
 import { reducer, A, startGame, drawOne, drawOneNoAdd, shuffle, countControlled, countUnits } from './core/state.js';
 import { netState, NET_ON } from './core/netState.js';
 import { createStore, makeMiddleware } from './lib/store.js';
@@ -71,6 +72,7 @@ try {
   window.computeHits = Rules.computeHits;
   window.stagedAttack = Rules.stagedAttack;
   window.magicAttack = Rules.magicAttack;
+  window.resolveUnitAttackProfile = Abilities.resolveUnitAttackProfile;
 
   window.shuffle = shuffle;
   window.drawOne = drawOne;

--- a/src/ui/domEvents.js
+++ b/src/ui/domEvents.js
@@ -72,11 +72,11 @@ export function attachUIEvents() {
   });
 
   document.querySelectorAll('[data-dir]').forEach(btn => {
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', async () => {
       const direction = btn.getAttribute('data-dir');
       const abilityOrientation = w.__interactions?.getPendingAbilityOrientation?.();
       if (abilityOrientation) {
-        w.__ui?.actions?.confirmUnitAbilityOrientation?.(abilityOrientation, direction);
+        await w.__ui?.actions?.confirmUnitAbilityOrientation?.(abilityOrientation, direction);
         return;
       }
       const pso = w.__interactions?.getPendingSpellOrientation?.();
@@ -98,7 +98,7 @@ export function attachUIEvents() {
         try { w.__ui.cancelButton.refreshCancelButton(); } catch {}
         return;
       }
-      w.__interactions.placeUnitWithDirection(direction);
+      await w.__interactions.placeUnitWithDirection(direction);
     });
   });
 }

--- a/src/ui/drawEvents.js
+++ b/src/ui/drawEvents.js
@@ -1,0 +1,46 @@
+// Утилиты для последовательного воспроизведения анимаций добора карт
+// Сосредоточены только на визуальной части, чтобы в будущем их можно было перенести в отдельный UI-слой
+export async function playDrawEvents(drawEvents, options = {}) {
+  const list = Array.isArray(drawEvents) ? drawEvents.filter(Boolean) : [];
+  if (!list.length) return;
+
+  const animateCard = typeof options.animateCard === 'function'
+    ? options.animateCard
+    : (typeof window !== 'undefined' ? window.animateDrawnCardToHand : null);
+  const updateHand = typeof options.updateHand === 'function'
+    ? options.updateHand
+    : (typeof window !== 'undefined' ? window.updateHand : null);
+  const logFn = typeof options.log === 'function'
+    ? options.log
+    : (typeof window !== 'undefined' ? window.addLog : null);
+  const stateRef = options.state ?? (typeof window !== 'undefined' ? window.gameState : undefined);
+  const defaultSource = options.sourceName || null;
+
+  for (const draw of list) {
+    const cards = Array.isArray(draw.cards) ? draw.cards.filter(Boolean) : [];
+    for (const cardTpl of cards) {
+      if (typeof animateCard !== 'function') break;
+      try {
+        await animateCard(cardTpl);
+      } catch (err) {
+        console.warn('[drawEvents] Ошибка анимации добора', err);
+      }
+    }
+    if (cards.length > 0 && typeof logFn === 'function') {
+      const label = draw.sourceName || defaultSource;
+      const amount = draw.amount ?? cards.length;
+      const message = label
+        ? `${label}: добор ${amount} карт(ы).`
+        : `Добор ${amount} карт(ы).`;
+      try { logFn(message); } catch (err) { console.warn('[drawEvents] Не удалось записать лог', err); }
+    }
+  }
+
+  if (typeof updateHand === 'function') {
+    try {
+      await updateHand(stateRef);
+    } catch (err) {
+      console.warn('[drawEvents] Не удалось обновить руку после добора', err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable ability handlers for summon draws, dodge bonuses and attack scheme selection
- integrate the new logic into ability resolution, rules, UI flow and exports
- define Cloud Runner, Don of Venoa, Latoo, Tritonan Harpoonsman and Aluhja Priestess with appropriate abilities and cover them with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd1118ad3483308eabc687e7b96869