### PR TITLE
Добавлены водные карты и обработчики атак

### DIFF
--- a/src/core/abilityHandlers/attackSchemes.js
+++ b/src/core/abilityHandlers/attackSchemes.js
@@ -1,0 +1,138 @@
+// Модуль для выбора схем атаки в зависимости от условий
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeElementSet(raw) {
+  const set = new Set();
+  for (const value of toArray(raw)) {
+    if (typeof value === 'string' && value) {
+      set.add(value.toUpperCase());
+    }
+  }
+  return set;
+}
+
+function cloneAttacks(list) {
+  if (!Array.isArray(list)) return [];
+  return list.map(item => (item ? { ...item } : item)).filter(Boolean);
+}
+
+function normalizeScheme(rawScheme, fallback = {}) {
+  if (!rawScheme) return null;
+  const key = rawScheme.key || fallback.key || null;
+  return {
+    key,
+    label: rawScheme.label || fallback.label || null,
+    attackType: rawScheme.attackType || fallback.attackType || null,
+    chooseDir: rawScheme.chooseDir != null ? !!rawScheme.chooseDir : (fallback.chooseDir ?? null),
+    attacks: cloneAttacks(rawScheme.attacks ?? fallback.attacks ?? []),
+    magicArea: rawScheme.magicArea || rawScheme.magicAttackArea || fallback.magicArea || null,
+  };
+}
+
+function collectSchemes(tpl) {
+  const base = {
+    key: null,
+    attackType: tpl?.attackType || 'STANDARD',
+    chooseDir: tpl?.chooseDir ?? false,
+    attacks: cloneAttacks(tpl?.attacks || []),
+    magicArea: tpl?.magicAttackArea || null,
+  };
+  const raw = Array.isArray(tpl?.attackSchemes) ? tpl.attackSchemes : [];
+  return raw.map((scheme, index) => normalizeScheme({ ...scheme, key: scheme.key || `SCHEME_${index}` }, base)).filter(Boolean);
+}
+
+function normalizeForceRules(value) {
+  const rules = [];
+  for (const raw of toArray(value)) {
+    if (!raw) continue;
+    if (typeof raw === 'string') {
+      const parts = raw.split(':');
+      if (parts.length >= 2) {
+        const el = parts[0]?.trim();
+        const scheme = parts[1]?.trim();
+        if (el && scheme) {
+          rules.push({ elements: normalizeElementSet(el.split(',')), scheme });
+        }
+      }
+      continue;
+    }
+    if (typeof raw === 'object') {
+      const scheme = raw.scheme || raw.key || raw.schemeKey;
+      if (!scheme) continue;
+      const elements = normalizeElementSet(raw.elements || raw.element || raw.field || raw.fields);
+      if (!elements.size) continue;
+      rules.push({ elements, scheme });
+    }
+  }
+  return rules;
+}
+
+function findSchemeByKey(tpl, key) {
+  if (!tpl || !key) return null;
+  const list = collectSchemes(tpl);
+  for (const scheme of list) {
+    if (scheme.key === key) return scheme;
+  }
+  return null;
+}
+
+function resolveForcedScheme(tpl, cellElement, context = {}) {
+  if (!tpl) return null;
+  if (context.forceSchemeKey) {
+    return findSchemeByKey(tpl, context.forceSchemeKey);
+  }
+  const rules = normalizeForceRules(tpl.forceSchemeOnElement);
+  if (!rules.length || !cellElement) return null;
+  const element = cellElement.toUpperCase();
+  for (const rule of rules) {
+    if (rule.elements.has(element)) {
+      const scheme = findSchemeByKey(tpl, rule.scheme);
+      if (scheme) return scheme;
+    }
+  }
+  return null;
+}
+
+export function resolveAttackProfile(state, tpl, context = {}) {
+  if (!tpl) {
+    return {
+      attackType: 'STANDARD',
+      chooseDir: false,
+      attacks: [],
+      schemeKey: null,
+      magicArea: null,
+    };
+  }
+
+  const cellElement = context.cellElement
+    || context.cell?.element
+    || ((typeof context.r === 'number' && typeof context.c === 'number')
+      ? state?.board?.[context.r]?.[context.c]?.element
+      : null);
+
+  const forced = resolveForcedScheme(tpl, cellElement, context);
+  if (forced) {
+    return {
+      attackType: forced.attackType || tpl.attackType || 'STANDARD',
+      chooseDir: forced.chooseDir != null ? forced.chooseDir : (tpl.chooseDir ?? false),
+      attacks: forced.attacks.length ? forced.attacks : cloneAttacks(tpl.attacks || []),
+      schemeKey: forced.key || null,
+      magicArea: forced.magicArea || tpl.magicAttackArea || null,
+    };
+  }
+
+  return {
+    attackType: tpl.attackType || 'STANDARD',
+    chooseDir: tpl.chooseDir ?? false,
+    attacks: cloneAttacks(tpl.attacks || []),
+    schemeKey: null,
+    magicArea: tpl.magicAttackArea || null,
+  };
+}
+
+export function getSchemeByKey(tpl, key) {
+  return findSchemeByKey(tpl, key);
+}

--- a/src/core/abilityHandlers/dodgeAuras.js
+++ b/src/core/abilityHandlers/dodgeAuras.js
@@ -1,0 +1,172 @@
+// Модуль пересчёта попыток Dodge с учётом аур и условий на поле
+import { CARDS } from '../cards.js';
+import { inBounds } from '../constants.js';
+import { ensureDodgeState, getDodgeConfig } from './dodge.js';
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeElementSet(raw) {
+  const set = new Set();
+  for (const value of toArray(raw)) {
+    if (typeof value === 'string' && value) {
+      set.add(value.toUpperCase());
+    }
+  }
+  return set;
+}
+
+function matchesElement(element, ruleSet) {
+  if (!element || !(ruleSet instanceof Set)) return false;
+  return ruleSet.has(element.toUpperCase());
+}
+
+function addContribution(map, r, c, amount) {
+  if (!Number.isFinite(amount) || amount <= 0) return;
+  const key = `${r},${c}`;
+  map.set(key, (map.get(key) || 0) + amount);
+}
+
+function applySelfElementBonus(state, contributions, r, c, tpl, cellElement) {
+  const raw = tpl?.gainDodgeOnElement;
+  if (!raw) return;
+  const rules = Array.isArray(raw) ? raw : [raw];
+  for (const entry of rules) {
+    if (!entry) continue;
+    let elements = null;
+    let amount = 1;
+    if (typeof entry === 'string') {
+      elements = normalizeElementSet(entry);
+    } else if (typeof entry === 'object') {
+      elements = normalizeElementSet(entry.elements || entry.element || entry.field);
+      amount = Number(entry.amount ?? entry.attempts ?? entry.bonus ?? 1);
+    }
+    if (!elements || !elements.size) continue;
+    if (!matchesElement(cellElement, elements)) continue;
+    addContribution(contributions, r, c, amount);
+  }
+}
+
+function applyAdjacentEnemyBonus(state, contributions, r, c, unit, tpl) {
+  const raw = tpl?.dodgePerAdjacentEnemies || tpl?.dodgeByAdjacentEnemies;
+  if (!raw) return;
+  const amountPerEnemy = Number(raw.amount ?? raw.perEnemy ?? raw.value ?? raw) || 1;
+  let count = 0;
+  for (const [dr, dc] of Object.values({ N: [-1,0], S: [1,0], E: [0,1], W: [0,-1] })) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) continue;
+    const other = state.board?.[nr]?.[nc]?.unit;
+    if (other && other.owner !== unit.owner) count += 1;
+  }
+  if (count > 0) {
+    addContribution(contributions, r, c, count * amountPerEnemy);
+  }
+}
+
+function applyAdjacentAllyAura(state, contributions, r, c, unit, tpl) {
+  const raw = tpl?.grantDodgeToAdjacentAllies;
+  if (!raw) return;
+  const amount = Number(raw.amount ?? raw.value ?? 1);
+  if (amount <= 0) return;
+  for (const [dr, dc] of Object.values({ N: [-1,0], S: [1,0], E: [0,1], W: [0,-1] })) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) continue;
+    const ally = state.board?.[nr]?.[nc]?.unit;
+    if (!ally || ally.owner !== unit.owner) continue;
+    addContribution(contributions, nr, nc, amount);
+  }
+}
+
+function applyAlliedFieldAura(state, contributions, r, c, unit, tpl) {
+  const raw = tpl?.grantDodgeToAlliesOnElement;
+  if (!raw) return;
+  const elements = normalizeElementSet(raw.elements || raw.element || raw.field);
+  if (!elements.size) return;
+  const amount = Number(raw.amount ?? raw.value ?? raw.attempts ?? 1);
+  if (amount <= 0) return;
+  const includeSelf = !!raw.includeSelf || raw.self === true;
+  for (let rr = 0; rr < 3; rr++) {
+    for (let cc = 0; cc < 3; cc++) {
+      const target = state.board?.[rr]?.[cc]?.unit;
+      if (!target || target.owner !== unit.owner) continue;
+      if (!includeSelf && rr === r && cc === c) continue;
+      const cellElement = state.board?.[rr]?.[cc]?.element;
+      if (!matchesElement(cellElement, elements)) continue;
+      addContribution(contributions, rr, cc, amount);
+    }
+  }
+}
+
+function buildFinalConfig(baseCfg, extra) {
+  const bonus = Math.max(0, extra || 0);
+
+  if (baseCfg) {
+    if (baseCfg.successes != null) {
+      const baseAttempts = Math.max(0, baseCfg.successes || 0);
+      const total = baseAttempts + bonus;
+      if (total <= 0) {
+        // Базовую конфигурацию без попыток возвращаем только если там явно указано ограничение
+        return baseAttempts > 0
+          ? { chance: baseCfg.chance, successes: baseAttempts, keyword: baseCfg.keyword }
+          : null;
+      }
+      return { chance: baseCfg.chance, successes: total, keyword: baseCfg.keyword };
+    }
+    // Неограниченный Dodge остаётся как есть, добавочные попытки не требуются
+    return { chance: baseCfg.chance, successes: null, keyword: baseCfg.keyword };
+  }
+
+  if (bonus > 0) {
+    return { chance: 0.5, successes: bonus, keyword: 'DODGE_ATTEMPT' };
+  }
+
+  return null;
+}
+
+export function rebuildDodgeStates(state) {
+  if (!state?.board) return { updated: false };
+  const contributions = new Map();
+
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const cell = state.board?.[r]?.[c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      const cellElement = cell.element;
+      applySelfElementBonus(state, contributions, r, c, tpl, cellElement);
+      applyAdjacentEnemyBonus(state, contributions, r, c, unit, tpl);
+      applyAdjacentAllyAura(state, contributions, r, c, unit, tpl);
+      applyAlliedFieldAura(state, contributions, r, c, unit, tpl);
+    }
+  }
+
+  let updated = false;
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const cell = state.board?.[r]?.[c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      const baseCfg = getDodgeConfig(tpl);
+      const extra = contributions.get(`${r},${c}`) || 0;
+      const finalCfg = buildFinalConfig(baseCfg, extra);
+      if (finalCfg) {
+        const prev = unit.dodgeState;
+        const stateObj = ensureDodgeState(unit, tpl, finalCfg);
+        if (prev !== stateObj) updated = true;
+      } else if (unit.dodgeState) {
+        delete unit.dodgeState;
+        updated = true;
+      }
+    }
+  }
+
+  return { updated };
+}

--- a/src/core/abilityHandlers/draw.js
+++ b/src/core/abilityHandlers/draw.js
@@ -1,0 +1,72 @@
+// Модуль для добора карт по различным условиям
+import { drawOneNoAdd } from '../board.js';
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeElement(value) {
+  if (typeof value === 'string' && value) return value.toUpperCase();
+  return null;
+}
+
+function normalizeFieldDrawConfig(raw) {
+  if (!raw) return null;
+  const [entry] = toArray(raw);
+  if (!entry) return null;
+  if (typeof entry === 'string') {
+    const el = normalizeElement(entry);
+    if (!el) return null;
+    return { element: el, multiplier: 1 };
+  }
+  if (typeof entry === 'object') {
+    const element = normalizeElement(entry.element || entry.field || (entry.elements ? entry.elements[0] : null));
+    if (!element) return null;
+    const multiplier = Number(entry.multiplier ?? entry.scale ?? 1) || 1;
+    const min = Number.isFinite(entry.min) ? entry.min : null;
+    const max = Number.isFinite(entry.max) ? entry.max : null;
+    return { element, multiplier, min, max };
+  }
+  return null;
+}
+
+function countFieldsWithElement(state, element) {
+  if (!state?.board || !element) return 0;
+  let total = 0;
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      if (state.board?.[r]?.[c]?.element === element) total += 1;
+    }
+  }
+  return total;
+}
+
+export function applyDrawOnSummon(state, context = {}) {
+  const { tpl, owner } = context;
+  if (!state || typeof owner !== 'number' || !tpl) return { draws: [] };
+  const player = state.players?.[owner];
+  if (!player) return { draws: [] };
+
+  const results = [];
+  const cfg = normalizeFieldDrawConfig(tpl.drawCardsOnSummonByFieldCount);
+  if (cfg) {
+    let count = countFieldsWithElement(state, cfg.element) * cfg.multiplier;
+    if (cfg.min != null) count = Math.max(count, cfg.min);
+    if (cfg.max != null) count = Math.min(count, cfg.max);
+    const total = Math.max(0, Math.floor(count));
+    const cards = [];
+    for (let i = 0; i < total; i++) {
+      const drawn = drawOneNoAdd(state, owner);
+      if (!drawn) break;
+      player.hand = Array.isArray(player.hand) ? player.hand : [];
+      player.hand.push(drawn);
+      cards.push(drawn);
+    }
+    if (cards.length) {
+      results.push({ owner, cards, count: cards.length, element: cfg.element, reason: 'FIELD_COUNT' });
+    }
+  }
+
+  return { draws: results };
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -320,6 +320,122 @@ export const CARDS = {
     ],
     desc: 'Magic Attack. While on a Water field, Imposter Queen Anfisa gains Possession of all enemies on adjacent fields.'
   },
+  WATER_CLOUD_RUNNER: {
+    id: 'WATER_CLOUD_RUNNER', name: 'Cloud Runner', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 2, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY' } ],
+    blindspots: ['S'],
+    keywords: ['DODGE_ATTEMPT'],
+    dodge: { chance: 0.5, attempts: 1 },
+    drawCardsOnSummonByFieldCount: { element: 'WATER' },
+    desc: 'Chooses a target up to 2 cells ahead. When Cloud Runner is summoned, draw cards equal to the number of Water fields. Dodge attempt.'
+  },
+  WATER_DON_OF_VENOA: {
+    id: 'WATER_DON_OF_VENOA', name: 'Don of Venoa', type: 'UNIT', cost: 5, activation: 3,
+    element: 'WATER', atk: 3, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1], group: 'FRONT_BACK' },
+      { dir: 'S', ranges: [1], group: 'FRONT_BACK' },
+    ],
+    attackSchemes: [
+      {
+        key: 'BASE',
+        label: 'Base',
+        attacks: [
+          { dir: 'N', ranges: [1], group: 'FRONT_BACK' },
+          { dir: 'S', ranges: [1], group: 'FRONT_BACK' },
+        ],
+      },
+      {
+        key: 'WATER_SWEEP',
+        label: 'Water',
+        attacks: [
+          { dir: 'N', ranges: [1], group: 'WATER_SWEEP' },
+          { dir: 'E', ranges: [1], group: 'WATER_SWEEP' },
+          { dir: 'S', ranges: [1], group: 'WATER_SWEEP' },
+          { dir: 'W', ranges: [1], group: 'WATER_SWEEP' },
+        ],
+      },
+    ],
+    forceSchemeOnElement: { element: 'WATER', scheme: 'WATER_SWEEP' },
+    blindspots: [],
+    keywords: ['DODGE_ATTEMPT'],
+    dodgePerAdjacentEnemies: { amount: 1 },
+    grantDodgeToAdjacentAllies: { amount: 1 },
+    desc: 'Attacks both the front and rear spaces, or all adjacent spaces while on a Water field. Gains one Dodge attempt for each adjacent enemy and grants adjacent allies one Dodge attempt.'
+  },
+  WATER_MERCENARY_SAVIOR_LATOO: {
+    id: 'WATER_MERCENARY_SAVIOR_LATOO', name: 'Mercenary Savior Latoo', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1], group: 'DOUBLE_FRONT' },
+      { dir: 'N', ranges: [2], group: 'DOUBLE_FRONT' },
+    ],
+    attackSchemes: [
+      {
+        key: 'BASE',
+        label: 'Base',
+        attacks: [
+          { dir: 'N', ranges: [1], group: 'DOUBLE_FRONT' },
+          { dir: 'N', ranges: [2], group: 'DOUBLE_FRONT' },
+        ],
+      },
+      {
+        key: 'EARTH_ONLY',
+        label: 'Earth',
+        attacks: [ { dir: 'N', ranges: [1] } ],
+      },
+    ],
+    forceSchemeOnElement: { element: 'EARTH', scheme: 'EARTH_ONLY' },
+    blindspots: ['S'],
+    keywords: ['DODGE_ATTEMPT'],
+    dodge: { chance: 0.5, attempts: 1 },
+    plusAtkIfTargetOnElement: { element: 'WATER', amount: 1 },
+    grantDodgeToAlliesOnElement: { element: 'WATER', amount: 1, includeSelf: false },
+    desc: 'Attacks both spaces in front (range 1-2), or only the first space when on an Earth field. Adds 1 to his Attack if at least one target is on a Water field. Dodge attempt. Other allied creatures on Water fields gain one Dodge attempt while Latoo remains on the board.'
+  },
+  WATER_TRITONAN_HARPOONSMAN: {
+    id: 'WATER_TRITONAN_HARPOONSMAN', name: 'Tritonan Harpoonsman', type: 'UNIT', cost: 2, activation: 1,
+    element: 'WATER', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'N', ranges: [1], group: 'DOUBLE_FRONT' },
+      { dir: 'N', ranges: [2], group: 'DOUBLE_FRONT' },
+    ],
+    attackSchemes: [
+      {
+        key: 'BASE',
+        label: 'Base',
+        attacks: [
+          { dir: 'N', ranges: [1], group: 'DOUBLE_FRONT' },
+          { dir: 'N', ranges: [2], group: 'DOUBLE_FRONT' },
+        ],
+      },
+      {
+        key: 'EARTH_ONLY',
+        label: 'Earth',
+        attacks: [ { dir: 'N', ranges: [1] } ],
+      },
+    ],
+    forceSchemeOnElement: { element: 'EARTH', scheme: 'EARTH_ONLY' },
+    blindspots: ['S'],
+    keywords: ['DODGE_ATTEMPT'],
+    gainDodgeOnElement: { element: 'WATER', amount: 1 },
+    desc: 'Attacks the first two spaces ahead, or only the adjacent space while on an Earth field. While on a Water field, Tritonan Harpoonsman gains one Dodge attempt.'
+  },
+  WATER_ALUHJA_PRIESTESS: {
+    id: 'WATER_ALUHJA_PRIESTESS', name: 'Aluhja Priestess', type: 'UNIT', cost: 2, activation: 1,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['N','E','S','W'],
+    keywords: ['DODGE_ATTEMPT'],
+    gainDodgeOnElement: { element: 'WATER', amount: 1 },
+    desc: 'Magic Attack. While on a Water field, Aluhja Priestess gains one Dodge attempt.'
+  },
   FOREST_SWALLOW_NINJA: {
     id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 1, hp: 3,

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -8,6 +8,7 @@ import {
   shouldUseMagicAttack,
   collectUnitActions,
   executeUnitAction,
+  resolveUnitAttackProfile,
 } from '../core/abilities.js';
 import {
   interactionState,
@@ -82,8 +83,10 @@ export function performUnitAttack(unitMesh) {
       ? window.attackCost(tpl, fieldElement, { state: gameState, r, c, unit, owner: unit.owner })
       : 0;
     const iState = window.__interactions?.interactionState;
+    const attackProfile = resolveUnitAttackProfile(gameState, r, c, tpl);
+    const attackType = attackProfile.attackType || tpl?.attackType;
     const mustUseMagic = shouldUseMagicAttack(gameState, r, c, tpl);
-    if (tpl?.attackType === 'MAGIC' || mustUseMagic) {
+    if ((attackType === 'MAGIC') || mustUseMagic) {
       const allowFriendly = !!tpl.friendlyFire;
       const cells = [];
       let hasEnemy = false;
@@ -117,8 +120,11 @@ export function performUnitAttack(unitMesh) {
       return;
     }
     const computeHits = window.computeHits;
-    const attacks = tpl?.attacks || [];
-    const needsChoice = tpl?.chooseDir || attacks.some(a => a.mode === 'ANY');
+    const attacks = (attackProfile.attacks && attackProfile.attacks.length)
+      ? attackProfile.attacks
+      : (tpl?.attacks || []);
+    const chooseDir = attackProfile.chooseDir != null ? attackProfile.chooseDir : tpl?.chooseDir;
+    const needsChoice = chooseDir || attacks.some(a => a.mode === 'ANY');
     const includeEmpty = attacks.some(a => Array.isArray(a.ranges) && a.ranges.length > 1 && !a.mode);
     const hitsAll = typeof computeHits === 'function' ? computeHits(gameState, r, c, { union: true, includeEmpty }) : [];
     const allowFriendly = !!tpl?.friendlyFire;


### PR DESCRIPTION
## Summary
- вынес обработчики схем атак, аур Dodge и добора карт в отдельные модули и подключил их в подсистеме способностей
- обновил расчёт атак/контратак, чтобы динамически определять схемы ударов и пересчитывать Dodge-ауры после боя
- добавил новые водные карты с уникальными атаками, добором и аурами Dodge, а также соответствующие UI-обновления и тесты

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68cd1118ad3483308eabc687e7b96869