### PR TITLE
Adjust water unit dodge logic and add board overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,6 +472,9 @@
        Split into logic (src/core/battle.js), FX (src/scene/battleFx.js)
        and net sync (src/net/battleSync.js). */
     async function performBattleSequence(r, c, markAttackTurn, opts = {}) {
+      const unitBefore = gameState.board?.[r]?.[c]?.unit;
+      const tplBefore = unitBefore ? CARDS[unitBefore.tplId] : null;
+      const attackerName = tplBefore?.name || 'Существо';
       const staged = stagedAttack(gameState, r, c, opts);
       if (!staged || staged.empty) return;
       // flashy заставка BATTLE (сокращённая)
@@ -613,6 +616,9 @@
           gameState = res.n1;
           const finalState = gameState;
           try { window.applyGameState(finalState); } catch {}
+          if (Array.isArray(res.dodgeUpdates) && res.dodgeUpdates.length) {
+            try { window.__interactions?.logDodgeUpdates?.(res.dodgeUpdates, finalState, attackerName); } catch {}
+          }
           try {
             if (typeof window.playDeltaAnimations === 'function') {
               window.playDeltaAnimations(stateBeforeFinish, finalState, { includeActive: true, skipDeathFx: true });
@@ -656,17 +662,17 @@
             }, 1400);
           } else {
             // Если смертей нет — подождём, пока анимация контратаки завершится, затем обновим визуально
-            setTimeout(() => {
-              updateUnits(finalState); updateUI(); for (const l of res.logLines.reverse()) addLog(l);
-              const pos2 = attackerPos;
-              if (markAttackTurn && gameState.board[pos2.r]?.[pos2.c]?.unit) {
-                gameState.board[pos2.r][pos2.c].unit.lastAttackTurn = gameState.turn;
-              }
-              try { schedulePush('battle-finish', { force: true }); } catch {}
-              if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
-                window.__interactions.interactionState.autoEndTurnAfterAttack = false;
-                try { endTurn(); } catch {}
-              }
+        setTimeout(() => {
+          updateUnits(finalState); updateUI(); for (const l of res.logLines.reverse()) addLog(l);
+          const pos2 = attackerPos;
+          if (markAttackTurn && gameState.board[pos2.r]?.[pos2.c]?.unit) {
+            gameState.board[pos2.r][pos2.c].unit.lastAttackTurn = gameState.turn;
+          }
+          try { schedulePush('battle-finish', { force: true }); } catch {}
+          if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
+            window.__interactions.interactionState.autoEndTurnAfterAttack = false;
+            try { endTurn(); } catch {}
+          }
             }, Math.max(0, animDelayMs));
             setTimeout(() => {
               try { updateUnits(finalState); } catch {}
@@ -726,6 +732,7 @@
       const tr = targetMesh.userData.row; const tc = targetMesh.userData.col;
       const attacker = gameState.board?.[from.r]?.[from.c]?.unit;
       if (!attacker || attacker.lastAttackTurn === gameState.turn) { showNotification('Incorrect target', 'error'); return; }
+      const attackerName = CARDS[attacker.tplId]?.name || 'Существо';
       const res = magicAttack(gameState, from.r, from.c, tr, tc);
       if (!res) { showNotification('Incorrect target', 'error'); return; }
       const attackerPosMagic = res.attackerPosUpdate || from;
@@ -766,6 +773,9 @@
         }
         gameState = res.n1;
         try { window.applyGameState(gameState); } catch {}
+        if (Array.isArray(res.dodgeUpdates) && res.dodgeUpdates.length) {
+          try { window.__interactions?.logDodgeUpdates?.(res.dodgeUpdates, gameState, attackerName); } catch {}
+        }
         const attackerCell = window.gameState?.board?.[attackerPosMagic.r]?.[attackerPosMagic.c];
         const attackerUnit = attackerCell?.unit;
         if (attackerUnit) attackerUnit.lastAttackTurn = window.gameState.turn;
@@ -780,6 +790,9 @@
       } else {
         // Если смертей нет — применяем состояние сразу
         gameState = res.n1; try { window.applyGameState(gameState); } catch {}
+        if (Array.isArray(res.dodgeUpdates) && res.dodgeUpdates.length) {
+          try { window.__interactions?.logDodgeUpdates?.(res.dodgeUpdates, gameState, attackerName); } catch {}
+        }
         updateUnits(); updateUI();
         const attackerCell2 = gameState.board?.[attackerPosMagic.r]?.[attackerPosMagic.c];
         const attackerUnit2 = attackerCell2?.unit;

--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -15,6 +15,7 @@ import {
   ensureDodgeState,
   attemptDodge as attemptDodgeInternal,
 } from './abilityHandlers/dodge.js';
+import { refreshBoardDodgeStates } from './abilityHandlers/dodgeEffects.js';
 import { computeTargetCostBonus as computeTargetCostBonusInternal } from './abilityHandlers/attackModifiers.js';
 import { collectRepositionOnDamage } from './abilityHandlers/reposition.js';
 import { extraActivationCostFromAuras } from './abilityHandlers/costModifiers.js';
@@ -22,6 +23,7 @@ import {
   applyElementalPossession,
   refreshContinuousPossessions as refreshContinuousPossessionsInternal,
 } from './abilityHandlers/possession.js';
+import { applySummonDraw } from './abilityHandlers/draw.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -64,6 +66,173 @@ function normalizeElements(value) {
     }
   }
   return set;
+}
+
+function cloneAttackEntry(entry = {}) {
+  const copy = { ...entry };
+  if (Array.isArray(entry.ranges)) copy.ranges = entry.ranges.slice();
+  return copy;
+}
+
+function buildSchemeMap(tpl) {
+  const list = Array.isArray(tpl?.attackSchemes) ? tpl.attackSchemes : [];
+  const map = new Map();
+  list.forEach((scheme, idx) => {
+    if (!scheme) return;
+    const key = scheme.key || scheme.id || scheme.code || `SCHEME_${idx}`;
+    map.set(key, {
+      key,
+      attackType: scheme.attackType || tpl.attackType,
+      attacks: Array.isArray(scheme.attacks) ? scheme.attacks.map(cloneAttackEntry) : [],
+      chooseDir: scheme.chooseDir != null ? !!scheme.chooseDir : undefined,
+      magicAttackArea: scheme.magicArea || scheme.magicAttackArea || tpl.magicAttackArea,
+    });
+  });
+  return map;
+}
+
+function normalizeSchemeRequirements(raw) {
+  if (!raw) return [];
+  const list = Array.isArray(raw) ? raw : [raw];
+  const result = [];
+  for (const item of list) {
+    if (!item) continue;
+    if (typeof item === 'string') {
+      result.push({ element: item.toUpperCase(), scheme: 'ALT' });
+      continue;
+    }
+    if (typeof item === 'object') {
+      const element = item.element || item.field || item.type;
+      const scheme = item.scheme || item.key || item.use;
+      if (!element) continue;
+      result.push({ element: String(element).toUpperCase(), scheme: scheme ? String(scheme) : 'ALT' });
+    }
+  }
+  return result;
+}
+
+function normalizeRangeList(raw) {
+  if (raw == null) return null;
+  const list = Array.isArray(raw) ? raw : [raw];
+  const result = [];
+  for (const item of list) {
+    const num = Number(item);
+    if (!Number.isFinite(num)) continue;
+    const val = Math.max(1, Math.floor(num));
+    if (!result.includes(val)) result.push(val);
+  }
+  return result.length ? result : null;
+}
+
+function normalizeRangeLimiter(raw) {
+  if (!raw) return null;
+  if (Array.isArray(raw)) {
+    return { element: null, ranges: normalizeRangeList(raw) };
+  }
+  if (typeof raw === 'object') {
+    const element = raw.element || raw.field || raw.type || null;
+    const ranges = normalizeRangeList(raw.ranges || raw.range);
+    const byDirRaw = raw.byDirection || raw.byDir;
+    let byDir = null;
+    if (byDirRaw && typeof byDirRaw === 'object') {
+      byDir = {};
+      for (const key of Object.keys(byDirRaw)) {
+        const dirKey = String(key).toUpperCase();
+        const values = normalizeRangeList(byDirRaw[key]);
+        if (values && values.length) {
+          byDir[dirKey] = values;
+        }
+      }
+      if (!Object.keys(byDir).length) byDir = null;
+    }
+    return {
+      element: element ? String(element).toUpperCase() : null,
+      ranges,
+      byDir,
+    };
+  }
+  return null;
+}
+
+export function resolveAttackProfile(state, r, c, tpl, opts = {}) {
+  if (!tpl) {
+    return {
+      attackType: 'STANDARD',
+      attacks: [],
+      chooseDir: false,
+      magicAttackArea: null,
+      schemeKey: null,
+    };
+  }
+  const cellElement = state?.board?.[r]?.[c]?.element || null;
+  const schemeMap = buildSchemeMap(tpl);
+  const defaultKey = tpl.defaultAttackScheme || 'BASE';
+  const defaultScheme = schemeMap.get(defaultKey) || (schemeMap.size ? schemeMap.values().next().value : null);
+
+  const requirements = normalizeSchemeRequirements(tpl.mustUseSchemeOnElement);
+  let active = null;
+  if (requirements.length && cellElement) {
+    for (const req of requirements) {
+      if (req.element === cellElement) {
+        if (req.scheme && schemeMap.has(req.scheme)) {
+          active = schemeMap.get(req.scheme);
+          break;
+        }
+      }
+    }
+  }
+  if (!active && tpl.mustUseMagicOnElement && cellElement === tpl.mustUseMagicOnElement) {
+    const scheme = tpl.forceMagicSchemeKey && schemeMap.get(tpl.forceMagicSchemeKey);
+    active = scheme || null;
+    if (!active) {
+      active = {
+        key: 'FORCED_MAGIC',
+        attackType: 'MAGIC',
+        attacks: [],
+        chooseDir: false,
+        magicAttackArea: tpl.magicAttackArea,
+      };
+    }
+  }
+  if (!active) {
+    active = defaultScheme || {
+      key: null,
+      attackType: tpl.attackType,
+      attacks: Array.isArray(tpl.attacks) ? tpl.attacks.map(cloneAttackEntry) : [],
+      chooseDir: tpl.chooseDir,
+      magicAttackArea: tpl.magicAttackArea,
+    };
+  }
+
+  const attackType = active.attackType || tpl.attackType || 'STANDARD';
+  const attacks = Array.isArray(active.attacks) && active.attacks.length
+    ? active.attacks.map(cloneAttackEntry)
+    : (Array.isArray(tpl.attacks) ? tpl.attacks.map(cloneAttackEntry) : []);
+  const chooseDir = active.chooseDir != null ? !!active.chooseDir : !!tpl.chooseDir;
+  const magicAttackArea = active.magicAttackArea != null ? active.magicAttackArea : tpl.magicAttackArea;
+
+  const limiter = normalizeRangeLimiter(
+    tpl.limitRangeOnElement || tpl.limitRangesOnElement || tpl.reduceRangeOnElement
+  );
+  if (limiter && limiter.element && limiter.element === cellElement) {
+    for (const attack of attacks) {
+      if (!attack || !Array.isArray(attack.ranges)) continue;
+      const dirKey = String(attack.dir || '').toUpperCase();
+      const override = limiter.byDir && limiter.byDir[dirKey];
+      const newRanges = override || limiter.ranges;
+      if (newRanges && newRanges.length) {
+        attack.ranges = newRanges.slice();
+      }
+    }
+  }
+
+  return {
+    attackType,
+    attacks,
+    chooseDir,
+    magicAttackArea,
+    schemeKey: active.key || null,
+  };
 }
 
 function collectInvisibilitySources(tpl) {
@@ -449,7 +618,15 @@ export function applySummonAbilities(state, r, c) {
   const tpl = getUnitTemplate(unit);
   if (!tpl) return events;
 
-  ensureDodgeState(unit, tpl);
+  const drawRes = applySummonDraw(state, r, c, unit, tpl);
+  if (drawRes.drawn > 0) {
+    events.draw = {
+      player: unit.owner,
+      count: drawRes.drawn,
+      cards: drawRes.cards,
+      element: cell.element || null,
+    };
+  }
 
   const possessionCfg = normalizeElementConfig(
     tpl.gainPossessionEnemiesOnElement,
@@ -471,6 +648,11 @@ export function applySummonAbilities(state, r, c) {
   }
   if (continuous.releases.length) {
     events.releases = [...(events.releases || []), ...continuous.releases];
+  }
+
+  const dodgeInfo = refreshBoardDodgeStates(state);
+  if (Array.isArray(dodgeInfo?.updated) && dodgeInfo.updated.length) {
+    events.dodgeUpdates = dodgeInfo.updated;
   }
 
   return events;
@@ -511,9 +693,10 @@ export function shouldUseMagicAttack(state, r, c, tplOverride = null) {
   const unit = cell?.unit;
   const tpl = tplOverride || getUnitTemplate(unit);
   if (!cell || !unit || !tpl) return false;
-  const requiredElement = tpl.mustUseMagicOnElement;
-  if (!requiredElement) return false;
-  return cell.element === requiredElement;
+  const profile = resolveAttackProfile(state, r, c, tpl, { unit, cell });
+  if (!profile) return false;
+  const baseType = tpl.attackType || 'STANDARD';
+  return profile.attackType === 'MAGIC' && baseType !== 'MAGIC';
 }
 
 export function computeMagicAreaCells(tpl, tr, tc) {
@@ -584,6 +767,7 @@ export const applyIncarnationSummon = applyIncarnationSummonInternal;
 export const ensureUnitDodgeState = ensureDodgeState;
 export const attemptUnitDodge = attemptDodgeInternal;
 export const refreshContinuousPossessions = refreshContinuousPossessionsInternal;
+export { refreshBoardDodgeStates };
 
 export function collectUnitActions(state, r, c) {
   const actions = [];

--- a/src/core/abilityHandlers/dodgeEffects.js
+++ b/src/core/abilityHandlers/dodgeEffects.js
@@ -1,0 +1,216 @@
+// Модуль для вычисления дополнительных источников способности dodge
+// Позволяет повторно использовать логику как в браузере, так и при переносе в другие движки
+import { CARDS } from '../cards.js';
+import { getDodgeConfig, ensureDodgeState } from './dodge.js';
+
+const DIRS = [
+  { dr: -1, dc: 0 },
+  { dr: 1, dc: 0 },
+  { dr: 0, dc: -1 },
+  { dr: 0, dc: 1 },
+];
+
+function inBounds(r, c) {
+  return r >= 0 && r < 3 && c >= 0 && c < 3;
+}
+
+function normalizeAttempts(value) {
+  if (value == null) return 1;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 1;
+  return Math.max(0, Math.floor(num));
+}
+
+function normalizeDodgeGain(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    return { element: raw.toUpperCase(), attempts: 1 };
+  }
+  if (typeof raw === 'object') {
+    const element = raw.element || raw.field || raw.type;
+    const attempts = normalizeAttempts(raw.attempts || raw.limit || raw.count);
+    const chance = (typeof raw.chance === 'number') ? raw.chance : null;
+    const includeSelf = raw.includeSelf !== false;
+    return {
+      element: element ? String(element).toUpperCase() : null,
+      attempts,
+      chance,
+      includeSelf,
+    };
+  }
+  return null;
+}
+
+function normalizeAdjacentGrant(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'number') {
+    return { attempts: normalizeAttempts(raw) };
+  }
+  if (typeof raw === 'object') {
+    return {
+      attempts: normalizeAttempts(raw.attempts || raw.count),
+      chance: (typeof raw.chance === 'number') ? raw.chance : null,
+    };
+  }
+  return { attempts: 1 };
+}
+
+function normalizeEnemyGain(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'number') {
+    return { attemptsPerEnemy: Math.max(0, Math.floor(raw)) };
+  }
+  if (typeof raw === 'object') {
+    const attempts = raw.attemptsPerEnemy || raw.perEnemy || raw.amount || 1;
+    return { attemptsPerEnemy: Math.max(0, Math.floor(attempts)) };
+  }
+  return { attemptsPerEnemy: 1 };
+}
+
+function addContribution(map, r, c, payload) {
+  const key = `${r},${c}`;
+  if (!map.has(key)) {
+    map.set(key, []);
+  }
+  map.get(key).push(payload);
+}
+
+export function refreshBoardDodgeStates(state) {
+  if (!state?.board) return { updated: [] };
+  const contributions = new Map();
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const cell = state.board[r][c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+
+      const selfGain = normalizeDodgeGain(tpl.gainDodgeOnElement || tpl.gainDodgeAttemptOnElement);
+      if (selfGain && selfGain.element) {
+        if (cell.element === selfGain.element) {
+          addContribution(contributions, r, c, {
+            attempts: selfGain.attempts,
+            chance: selfGain.chance,
+          });
+        }
+      }
+
+      const auraCfg = normalizeDodgeGain(tpl.auraGrantDodgeOnElement);
+      if (auraCfg && auraCfg.element) {
+        for (let rr = 0; rr < 3; rr++) {
+          for (let cc = 0; cc < 3; cc++) {
+            if (!auraCfg.includeSelf && rr === r && cc === c) continue;
+            const target = state.board?.[rr]?.[cc]?.unit;
+            if (!target) continue;
+            if (target.owner !== unit.owner) continue;
+            if (state.board[rr][cc]?.element === auraCfg.element) {
+              addContribution(contributions, rr, cc, {
+                attempts: auraCfg.attempts,
+                chance: auraCfg.chance,
+              });
+            }
+          }
+        }
+      }
+
+      const adjGrant = normalizeAdjacentGrant(tpl.grantDodgeAdjacentAllies);
+      if (adjGrant && adjGrant.attempts > 0) {
+        for (const dir of DIRS) {
+          const rr = r + dir.dr;
+          const cc = c + dir.dc;
+          if (!inBounds(rr, cc)) continue;
+          const target = state.board?.[rr]?.[cc]?.unit;
+          if (!target) continue;
+          if (target.owner !== unit.owner) continue;
+          addContribution(contributions, rr, cc, {
+            attempts: adjGrant.attempts,
+            chance: adjGrant.chance,
+          });
+        }
+      }
+
+      const enemyGain = normalizeEnemyGain(tpl.gainDodgeFromAdjacentEnemies);
+      if (enemyGain && enemyGain.attemptsPerEnemy > 0) {
+        let enemies = 0;
+        for (const dir of DIRS) {
+          const rr = r + dir.dr;
+          const cc = c + dir.dc;
+          if (!inBounds(rr, cc)) continue;
+          const target = state.board?.[rr]?.[cc]?.unit;
+          if (!target) continue;
+          if (target.owner === unit.owner) continue;
+          enemies += 1;
+        }
+        if (enemies > 0) {
+          addContribution(contributions, r, c, {
+            attempts: enemyGain.attemptsPerEnemy * enemies,
+          });
+        }
+      }
+    }
+  }
+
+  const updated = [];
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const cell = state.board[r][c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) {
+        if (unit.dodgeState) delete unit.dodgeState;
+        continue;
+      }
+      const base = getDodgeConfig(tpl);
+      const contrib = contributions.get(`${r},${c}`) || [];
+      let totalAttempts = 0;
+      let overrideChance = null;
+      for (const item of contrib) {
+        totalAttempts += normalizeAttempts(item?.attempts || 0);
+        if (item?.chance != null && Number.isFinite(item.chance)) {
+          overrideChance = item.chance;
+        }
+      }
+      if (!base && totalAttempts <= 0) {
+        if (unit.dodgeState) {
+          delete unit.dodgeState;
+          updated.push({ r, c, removed: true });
+        }
+        continue;
+      }
+      if (!base && totalAttempts > 0) {
+        const cfg = {
+          chance: overrideChance != null ? overrideChance : 0.5,
+          successes: totalAttempts,
+          keyword: totalAttempts === 1 ? 'DODGE_ATTEMPT' : 'DODGE_ATTEMPT',
+        };
+        ensureDodgeState(unit, tpl, cfg);
+        updated.push({ r, c, attempts: cfg.successes, chance: cfg.chance });
+        continue;
+      }
+      if (base) {
+        if (base.successes == null) {
+          const cfg = {
+            chance: overrideChance != null ? overrideChance : base.chance,
+            successes: null,
+            keyword: base.keyword,
+          };
+          ensureDodgeState(unit, tpl, cfg);
+          if (overrideChance != null) {
+            updated.push({ r, c, unlimited: true, chance: cfg.chance });
+          }
+          continue;
+        }
+        const cfg = {
+          chance: overrideChance != null ? overrideChance : base.chance,
+          successes: base.successes + totalAttempts,
+          keyword: base.keyword,
+        };
+        ensureDodgeState(unit, tpl, cfg);
+        updated.push({ r, c, attempts: cfg.successes, chance: cfg.chance });
+      }
+    }
+  }
+  return { updated };
+}

--- a/src/core/abilityHandlers/draw.js
+++ b/src/core/abilityHandlers/draw.js
@@ -1,0 +1,69 @@
+// Модуль обработки эффектов добора карт при призыве существ
+// Вся логика изолирована от визуального слоя, чтобы облегчить перенос на другие движки
+import { drawOneNoAdd } from '../board.js';
+
+function normalizeConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    return { element: raw.toUpperCase() };
+  }
+  if (typeof raw === 'object') {
+    const element = raw.element || raw.field || raw.elementType;
+    const limit = raw.limit || raw.max || null;
+    const includeSelf = raw.includeSelf !== false;
+    const includeCenter = raw.includeCenter !== false;
+    const min = raw.min || raw.minimum || 0;
+    return {
+      element: element ? String(element).toUpperCase() : null,
+      limit: typeof limit === 'number' && Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : null,
+      includeSelf,
+      includeCenter,
+      min: typeof min === 'number' && Number.isFinite(min) ? Math.max(0, Math.floor(min)) : 0,
+    };
+  }
+  return null;
+}
+
+function countMatchingFields(state, cfg) {
+  if (!state?.board) return 0;
+  const element = cfg?.element || null;
+  let count = 0;
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      if (!cfg.includeCenter && r === 1 && c === 1) continue;
+      if (!cfg.includeSelf && r === cfg?.self?.r && c === cfg?.self?.c) continue;
+      const cellEl = state.board?.[r]?.[c]?.element || null;
+      if (element && cellEl !== element) continue;
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function computeSummonDraw(state, r, c, tpl) {
+  if (!tpl) return null;
+  const cfgRaw = tpl.drawOnSummonByElementFields || tpl.drawCardsOnSummon;
+  const cfg = normalizeConfig(cfgRaw);
+  if (!cfg || !cfg.element) return null;
+  const count = countMatchingFields(state, { ...cfg, self: { r, c } });
+  const limited = cfg.limit != null ? Math.min(cfg.limit, count) : count;
+  const amount = Math.max(cfg.min || 0, limited);
+  if (amount <= 0) return null;
+  return { element: cfg.element, amount };
+}
+
+export function applySummonDraw(state, r, c, unit, tpl) {
+  const info = computeSummonDraw(state, r, c, tpl);
+  if (!info || !unit) return { drawn: 0, cards: [] };
+  const owner = unit.owner;
+  if (owner == null || !state?.players?.[owner]) return { drawn: 0, cards: [] };
+  const player = state.players[owner];
+  const drawn = [];
+  for (let i = 0; i < info.amount; i++) {
+    const card = drawOneNoAdd(state, owner);
+    if (!card) break;
+    player.hand.push(card);
+    drawn.push(card);
+  }
+  return { drawn: drawn.length, cards: drawn };
+}

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -27,7 +27,7 @@ export const CARDS = {
   FIRE_FREEDONIAN_WANDERER: {
     id: 'FIRE_FREEDONIAN_WANDERER', name: 'Freedonian Wanderer', type: 'UNIT', cost: 2, activation: 1,
     element: 'FIRE', atk: 1, hp: 2,
-    attackType: 'STANDARD',
+    attackType: 'STANDARD', pierce: true,
     attacks: [ { dir: 'N', ranges: [1] } ],
     blindspots: ['S'], auraGainManaOnSummon: true,
     desc: 'While Freedonian Wanderer is on a non‑Fire field, you gain 1 mana each time you summon an allied creature.'
@@ -43,7 +43,7 @@ export const CARDS = {
   FIRE_GREAT_MINOS: {
     id: 'FIRE_GREAT_MINOS', name: 'Great Minos of Sciondar', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 2, hp: 1,
-    attackType: 'STANDARD',
+    attackType: 'STANDARD', pierce: true,
     // бьёт сразу по двум клеткам впереди, игнорируя преграды и задевая союзников
     attacks: [ { dir: 'N', ranges: [1, 2] } ],
     blindspots: ['S'], perfectDodge: true, activationReduction: 1, diesOffElement: 'FIRE',
@@ -190,6 +190,83 @@ export const CARDS = {
     targetAllNonElement: 'WATER',
     diesOnElement: 'BIOLITH',
     desc: 'Incarnation. Goddess Tritona’s Magic Attack targets all enemies on non-Water fields. Destroy Goddess Tritona if she is on a Biolith field.'
+  },
+
+  WATER_CLOUD_RUNNER: {
+    id: 'WATER_CLOUD_RUNNER', name: 'Cloud Runner', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 1, hp: 2,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'E', ranges: [1, 2], mode: 'ANY' },
+      { dir: 'W', ranges: [1, 2], mode: 'ANY' },
+    ],
+    dodge: { chance: 0.5, attempts: 1 },
+    drawOnSummonByElementFields: { element: 'WATER', includeSelf: true, includeCenter: true },
+    desc: 'Dodge attempt. When Cloud Runner is summoned, draw cards equal to the number of Water fields.'
+  },
+
+  WATER_DON_OF_VENOA: {
+    id: 'WATER_DON_OF_VENOA', name: 'Don of Venoa', type: 'UNIT', cost: 5, activation: 3,
+    element: 'WATER', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attackSchemes: [
+      {
+        key: 'BASE',
+        label: 'Cleave',
+        attacks: [
+          { dir: 'N', ranges: [1], group: 'FRONT_BACK' },
+          { dir: 'S', ranges: [1], group: 'FRONT_BACK' },
+        ],
+      },
+      {
+        key: 'WATER_SWIRL',
+        label: 'Whirlpool',
+        attacks: [
+          { dir: 'N', ranges: [1], group: 'SWIRL' },
+          { dir: 'S', ranges: [1], group: 'SWIRL' },
+          { dir: 'E', ranges: [1], group: 'SWIRL' },
+          { dir: 'W', ranges: [1], group: 'SWIRL' },
+        ],
+      },
+    ],
+    defaultAttackScheme: 'BASE',
+    mustUseSchemeOnElement: [ { element: 'WATER', scheme: 'WATER_SWIRL' } ],
+    dodge: { chance: 0.5, attempts: 1 },
+    gainDodgeFromAdjacentEnemies: { attemptsPerEnemy: 1 },
+    grantDodgeAdjacentAllies: 1,
+    desc: 'Dodge attempt. Gains one Dodge attempt for each adjacent enemy. Adjacent allied creatures gain one Dodge attempt. While on a Water field he strikes all adjacent cells.'
+  },
+
+  WATER_MERCENARY_SAVIOR_LATOO: {
+    id: 'WATER_MERCENARY_SAVIOR_LATOO', name: 'Mercenary Savior Latoo', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 2, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], group: 'LINE' } ],
+    limitRangeOnElement: { element: 'EARTH', ranges: [1] },
+    plusAtkIfTargetOnElement: { element: 'WATER', amount: 1 },
+    auraGrantDodgeOnElement: { element: 'WATER', attempts: 1, includeSelf: false },
+    desc: 'Adds 1 to his Attack if at least one target is on a Water field. While Latoo is on the board, allied creatures on Water fields gain one Dodge attempt. While on an Earth field he strikes only the adjacent cell.'
+  },
+
+  WATER_TRITONAN_HARPOONSMAN: {
+    id: 'WATER_TRITONAN_HARPOONSMAN', name: 'Tritonan Harpoonsman', type: 'UNIT', cost: 2, activation: 1,
+    element: 'WATER', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], group: 'LINE' } ],
+    limitRangeOnElement: { element: 'EARTH', ranges: [1] },
+    gainDodgeOnElement: { element: 'WATER', attempts: 1 },
+    desc: 'While on a Water field Tritonan Harpoonsman gains one Dodge attempt. While on an Earth field his attack reaches only the adjacent cell.'
+  },
+
+  WATER_ALUHJA_PRIESTESS: {
+    id: 'WATER_ALUHJA_PRIESTESS', name: 'Aluhja Priestess', type: 'UNIT', cost: 2, activation: 1,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'MAGIC',
+    attacks: [ { dir: 'N', ranges: [1, 2, 3], mode: 'ANY' } ],
+    blindspots: ['N', 'E', 'S', 'W'],
+    magicAttackArea: 'CROSS',
+    gainDodgeOnElement: { element: 'WATER', attempts: 1 },
+    desc: 'Magic Attack. While on a Water field, Aluhja Priestess gains one Dodge attempt.'
   },
 
   EARTH_NOVOGUS_GRAVEKEEPER: {

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -16,6 +16,8 @@ import {
   attemptUnitDodge,
   collectDamageInteractions,
   applyDamageInteractionResults,
+  resolveAttackProfile,
+  refreshBoardDodgeStates,
 } from './abilities.js';
 import { countUnits } from './board.js';
 import { computeCellBuff } from './fieldEffects.js';
@@ -44,13 +46,16 @@ function rotateDir(facing, dir) {
 }
 
 // Возвращает все потенциальные клетки атаки без учёта препятствий
-function attackCellsForTpl(tpl, facing, opts = {}) {
+function attackCellsFromProfile(profile, tpl, facing, opts = {}) {
   const res = [];
-  const attacks = tpl.attacks || [];
+  const attacks = (Array.isArray(profile?.attacks) && profile.attacks.length)
+    ? profile.attacks
+    : (tpl.attacks || []);
   const { chosenDir, rangeChoices, union } = opts;
+  const chooseDir = profile?.chooseDir ?? !!tpl?.chooseDir;
   let seq = 0;
   for (const a of attacks) {
-    if (!union && tpl.chooseDir) {
+    if (!union && chooseDir) {
       if (!chosenDir) continue; // направление нужно выбрать явно
       if (a.dir !== chosenDir) continue;
     }
@@ -84,13 +89,25 @@ export function effectiveStats(cell, unit) {
 }
 
 export function computeHits(state, r, c, opts = {}) {
-  const attacker = state.board?.[r]?.[c]?.unit;
-  if (!attacker) return [];
+  const cell = state.board?.[r]?.[c];
+  const attacker = cell?.unit;
+  if (!attacker) {
+    const empty = [];
+    empty.profile = null;
+    empty.schemeKey = null;
+    empty.attackType = null;
+    return empty;
+  }
   const tplA = CARDS[attacker.tplId];
+  const profile = opts.profile || resolveAttackProfile(state, r, c, tplA, { unit: attacker, cell });
+  const attackType = profile?.attackType || tplA?.attackType || 'STANDARD';
   // tplA.friendlyFire — может ли атака задевать союзников
-  const cells = attackCellsForTpl(tplA, attacker.facing, opts);
-  const { atk } = effectiveStats(state.board[r][c], attacker);
+  const cells = attackCellsFromProfile(profile, tplA, attacker.facing, opts);
+  const { atk } = effectiveStats(cell, attacker);
   const hits = [];
+  hits.profile = profile;
+  hits.schemeKey = profile?.schemeKey || null;
+  hits.attackType = attackType;
   const aFlying = (tplA.keywords || []).includes('FLYING');
   const basePierce = !!tplA.pierce;
   const allowFriendly = !!tplA.friendlyFire; // может ли существо задевать союзников
@@ -216,14 +233,19 @@ export function computeHits(state, r, c, opts = {}) {
 // Постановочный (staged) бой с поддержкой выбора направления/дистанции
 export function stagedAttack(state, r, c, opts = {}) {
   const base = JSON.parse(JSON.stringify(state));
-  const attacker = base.board?.[r]?.[c]?.unit;
+  const cellOrigin = base.board?.[r]?.[c];
+  const attacker = cellOrigin?.unit;
   if (!attacker) return null;
   // не позволяем атаковать более одного раза за ход
   if (attacker.lastAttackTurn === base.turn) return null;
   const tplA = CARDS[attacker.tplId];
   if (!canAttack(tplA)) return null;
 
-  const startElement = base.board?.[r]?.[c]?.element;
+  const profile = resolveAttackProfile(base, r, c, tplA, { unit: attacker, cell: cellOrigin });
+  const attackType = profile?.attackType || tplA.attackType || 'STANDARD';
+  const schemeKey = profile?.schemeKey || null;
+
+  const startElement = cellOrigin?.element;
   const attackCostValue = attackCost(tplA, startElement, {
     state: base,
     r,
@@ -232,13 +254,14 @@ export function stagedAttack(state, r, c, opts = {}) {
     owner: attacker?.owner,
   });
 
-  const baseStats = effectiveStats(base.board[r][c], attacker);
+  const baseStats = effectiveStats(cellOrigin, attacker);
   let atk = baseStats.atk;
   let logLines = [];
   const damageEffects = { preventRetaliation: new Set(), events: [] };
   const randomFn = typeof opts?.rng === 'function' ? opts.rng : Math.random;
+  const dodgeUpdates = [];
 
-  const hitsRaw = computeHits(base, r, c, opts);
+  const hitsRaw = computeHits(base, r, c, { ...opts, profile });
   if (!hitsRaw.length) return { empty: true };
 
   if (tplA.dynamicAtk === 'OTHERS_ON_BOARD') {
@@ -319,7 +342,7 @@ export function stagedAttack(state, r, c, opts = {}) {
     const B = cell?.unit;
     if (!B) return { ...h, dealt: 0 };
     const sameOwner = B.owner === attacker.owner;
-    const isMagic = tplA.attackType === 'MAGIC';
+    const isMagic = attackType === 'MAGIC';
     const tplB = CARDS[B.tplId];
     if (sameOwner) {
       // Союзники не уклоняются от массового удара, поэтому просто получаем урон
@@ -409,6 +432,10 @@ export function stagedAttack(state, r, c, opts = {}) {
         }
       }
     }
+    const dodgeStep = refreshBoardDodgeStates(n1);
+    if (Array.isArray(dodgeStep?.updated) && dodgeStep.updated.length) {
+      dodgeUpdates.push(...dodgeStep.updated);
+    }
     step1Done = true;
   }
 
@@ -437,7 +464,7 @@ export function stagedAttack(state, r, c, opts = {}) {
         retaliators.push({ r: h.r, c: h.c });
       }
     }
-    const preventRetaliation = tplA.attackType === 'MAGIC' || (tplA.avoidRetaliation50 && Math.random() < 0.5);
+    const preventRetaliation = attackType === 'MAGIC' || (tplA.avoidRetaliation50 && Math.random() < 0.5);
     const total = preventRetaliation ? 0 : totalRetaliation;
     return { total, retaliators };
   }
@@ -538,6 +565,10 @@ export function stagedAttack(state, r, c, opts = {}) {
 
     const targets = step1Damages.map(h => ({ r: h.r, c: h.c, dmg: h.dealt || 0 }));
     const combinedReleases = [...releaseEvents.releases, ...continuous.releases];
+    const dodgeFinal = refreshBoardDodgeStates(nFinal);
+    if (Array.isArray(dodgeFinal?.updated) && dodgeFinal.updated.length) {
+      dodgeUpdates.push(...dodgeFinal.updated);
+    }
     return {
       n1: nFinal,
       logLines,
@@ -547,6 +578,10 @@ export function stagedAttack(state, r, c, opts = {}) {
       releases: combinedReleases,
       possessions: continuous.possessions,
       attackerPosUpdate,
+      dodgeUpdates,
+      attackType,
+      schemeKey,
+      attackProfile: profile,
     };
   }
 
@@ -558,22 +593,32 @@ export function stagedAttack(state, r, c, opts = {}) {
     quickRetaliation,
     quickRetaliators,
     attackerQuick,
+    attackType,
+    schemeKey,
+    attackProfile: profile,
     get nQuick() { stepQuick(); return n1; },
     get n1() { ensureStep1(); return n1; },
     get targetsPreview() { return step1Damages.map(h => ({ r: h.r, c: h.c, dmg: h.dealt || 0 })); },
+    get dodgeSnapshots() { ensureStep1(); return dodgeUpdates.slice(); },
   };
 }
 
 export function magicAttack(state, fr, fc, tr, tc) {
   const n1 = JSON.parse(JSON.stringify(state));
-  const attacker = n1.board?.[fr]?.[fc]?.unit;
+  const originCell = n1.board?.[fr]?.[fc];
+  const attacker = originCell?.unit;
   if (!attacker) return null;
   // не позволяем магам бить дважды в одном ходу
   if (attacker.lastAttackTurn === n1.turn) return null;
   const tplA = CARDS[attacker.tplId];
   if (!canAttack(tplA)) return null;
 
-  const startElement = n1.board?.[fr]?.[fc]?.element;
+  const profile = resolveAttackProfile(n1, fr, fc, tplA, { unit: attacker, cell: originCell });
+  const attackType = profile?.attackType || tplA.attackType || 'STANDARD';
+  const schemeKey = profile?.schemeKey || null;
+  if (attackType !== 'MAGIC') return null;
+
+  const startElement = originCell?.element;
   const attackCostValue = attackCost(tplA, startElement, {
     state: n1,
     r: fr,
@@ -582,12 +627,16 @@ export function magicAttack(state, fr, fc, tr, tc) {
     owner: attacker?.owner,
   });
   const allowFriendly = !!tplA.friendlyFire;
+  const tplForMagic = (profile?.magicAttackArea != null)
+    ? { ...tplA, magicAttackArea: profile.magicAttackArea }
+    : tplA;
   const mainTarget = n1.board?.[tr]?.[tc]?.unit;
   if (!allowFriendly && (!mainTarget || mainTarget.owner === attacker.owner)) return null;
 
   const logLines = [];
   const targets = [];
   const damageEffects = { preventRetaliation: new Set(), events: [] };
+  const dodgeUpdates = [];
   const hitsSummary = new Map();
   const addSummary = (r, c, dealt, extra = {}) => {
     const key = `${r},${c}`;
@@ -597,7 +646,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
     hitsSummary.set(key, entry);
   };
 
-  const atkStats = effectiveStats(n1.board[fr][fc], attacker);
+  const atkStats = effectiveStats(originCell, attacker);
   let atk = atkStats.atk || 0;
   const dynMagic = computeDynamicMagicAttack(n1, tplA);
   if (dynMagic) {
@@ -632,7 +681,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
   const primaryTarget = (typeof tr === 'number' && typeof tc === 'number')
     ? { r: tr, c: tc }
     : null;
-  const baseCells = collectMagicTargetCells(n1, tplA, { r: fr, c: fc }, primaryTarget) || [];
+  const baseCells = collectMagicTargetCells(n1, tplForMagic, { r: fr, c: fc }, primaryTarget) || [];
   for (const cell of baseCells) { addCell(cell.r, cell.c); }
 
   const splash = tplA.splash || 0;
@@ -773,8 +822,26 @@ export function magicAttack(state, fr, fc, tr, tc) {
   }
   attacker.lastAttackTurn = n1.turn;
   attacker.apSpent = (attacker.apSpent || 0) + attackCostValue;
+  const dodgeFinal = refreshBoardDodgeStates(n1);
+  if (Array.isArray(dodgeFinal?.updated) && dodgeFinal.updated.length) {
+    dodgeUpdates.push(...dodgeFinal.updated);
+  }
   const combinedReleases = [...releaseEvents.releases, ...continuous.releases];
-  return { n1, logLines, targets, deaths, releases: combinedReleases, possessions: continuous.possessions, attackerPosUpdate };
+  return {
+    n1,
+    logLines,
+    targets,
+    deaths,
+    releases: combinedReleases,
+    possessions: continuous.possessions,
+    attackerPosUpdate,
+    dodgeUpdates,
+    attackType,
+    schemeKey,
+    attackProfile: profile,
+    dmg,
+  };
 }
 
 export { computeCellBuff };
+export { resolveAttackProfile, refreshBoardDodgeStates } from './abilities.js';

--- a/src/main.js
+++ b/src/main.js
@@ -71,6 +71,8 @@ try {
   window.computeHits = Rules.computeHits;
   window.stagedAttack = Rules.stagedAttack;
   window.magicAttack = Rules.magicAttack;
+  window.resolveAttackProfile = Rules.resolveAttackProfile;
+  window.refreshBoardDodgeStates = Rules.refreshBoardDodgeStates;
 
   window.shuffle = shuffle;
   window.drawOne = drawOne;

--- a/src/scene/board.js
+++ b/src/scene/board.js
@@ -1,5 +1,6 @@
 // Board construction and materials
 import { getCtx } from './context.js';
+import { clearDodgeOverlays } from './dodgeOverlay.js';
 
 const BASE_MAP = {
   FIRE: './textures/tile_fire.png',
@@ -125,6 +126,7 @@ export function createBoard(gameState) {
   // Cleanup previous
   (ctx.tileMeshes || []).forEach(row => row && row.forEach(tile => { try { boardGroup.remove(tile); } catch {} }));
   (ctx.tileFrames || []).forEach(row => row && row.forEach(f => { try { boardGroup.remove(f); } catch {} }));
+  try { clearDodgeOverlays(); } catch {}
   ctx.tileMeshes = []; ctx.tileFrames = [];
 
   const tileSize = 6.2;

--- a/src/scene/dodgeOverlay.js
+++ b/src/scene/dodgeOverlay.js
@@ -1,0 +1,170 @@
+// Визуальные оверлеи для отображения текущего числа попыток Dodge на клетках
+// Логика изолирована, чтобы можно было переиспользовать подсказки при миграции
+// на другие движки (например, Unity)
+
+import { getCtx } from './context.js';
+
+function ensureStore() {
+  const ctx = getCtx();
+  if (!Array.isArray(ctx.dodgeOverlays)) {
+    ctx.dodgeOverlays = Array.from({ length: 3 }, () => Array(3).fill(null));
+  }
+  return ctx.dodgeOverlays;
+}
+
+function disposeOverlay(sprite) {
+  if (!sprite) return;
+  try {
+    if (sprite.parent) {
+      sprite.parent.remove(sprite);
+    }
+  } catch {}
+  try {
+    sprite.material?.map?.dispose?.();
+  } catch {}
+  try {
+    sprite.material?.dispose?.();
+  } catch {}
+}
+
+function formatAttempts(unit) {
+  const state = unit?.dodgeState;
+  if (!state) {
+    return '0';
+  }
+  if (!state.limited) {
+    return '∞';
+  }
+  const remaining = (typeof state.remaining === 'number')
+    ? state.remaining
+    : (typeof state.max === 'number' ? state.max : (typeof state.successes === 'number' ? state.successes : 0));
+  return String(Math.max(0, remaining));
+}
+
+function createTexture(text, THREE) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 256;
+  canvas.height = 128;
+  const ctx2d = canvas.getContext('2d');
+  if (!ctx2d) return null;
+  ctx2d.clearRect(0, 0, canvas.width, canvas.height);
+  ctx2d.fillStyle = 'rgba(15, 23, 42, 0.78)';
+  ctx2d.strokeStyle = 'rgba(59, 130, 246, 0.85)';
+  ctx2d.lineWidth = 6;
+  const radius = 28;
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx2d.beginPath();
+  ctx2d.moveTo(radius, 0);
+  ctx2d.lineTo(w - radius, 0);
+  ctx2d.quadraticCurveTo(w, 0, w, radius);
+  ctx2d.lineTo(w, h - radius);
+  ctx2d.quadraticCurveTo(w, h, w - radius, h);
+  ctx2d.lineTo(radius, h);
+  ctx2d.quadraticCurveTo(0, h, 0, h - radius);
+  ctx2d.lineTo(0, radius);
+  ctx2d.quadraticCurveTo(0, 0, radius, 0);
+  ctx2d.closePath();
+  ctx2d.fill();
+  ctx2d.stroke();
+
+  ctx2d.font = 'bold 44px "Inter", "Arial", sans-serif';
+  ctx2d.fillStyle = '#f8fafc';
+  ctx2d.textAlign = 'center';
+  ctx2d.textBaseline = 'middle';
+  ctx2d.fillText(text, w / 2, h / 2);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  return texture;
+}
+
+function createSprite(text, THREE) {
+  const texture = createTexture(text, THREE);
+  if (!texture) return null;
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false, depthTest: false });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(2.6, 1.1, 1);
+  sprite.center.set(1, 1);
+  sprite.renderOrder = 2500;
+  sprite.userData = { kind: 'dodgeOverlay', text };
+  return sprite;
+}
+
+function updateSpriteText(sprite, text, THREE) {
+  if (!sprite || sprite.userData?.text === text) return;
+  const oldTex = sprite.material?.map || null;
+  const texture = createTexture(text, THREE);
+  if (texture) {
+    sprite.material.map = texture;
+    sprite.material.needsUpdate = true;
+    sprite.userData.text = text;
+  }
+  if (oldTex) {
+    try { oldTex.dispose(); } catch {}
+  }
+}
+
+function positionSprite(sprite, tile) {
+  if (!sprite || !tile) return;
+  const width = tile.geometry?.parameters?.width ?? 6.2;
+  const height = tile.geometry?.parameters?.height ?? 0.35;
+  const depth = tile.geometry?.parameters?.depth ?? width;
+  const marginX = 0.7;
+  const marginZ = 0.7;
+  const yOffset = height / 2 + 0.9;
+  sprite.position.set(width / 2 - marginX, yOffset, -depth / 2 + marginZ);
+}
+
+export function updateDodgeOverlays(gameState) {
+  const ctx = getCtx();
+  const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
+  if (!THREE) return;
+  const tiles = ctx.tileMeshes || [];
+  if (!tiles.length) return;
+  const store = ensureStore();
+
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 3; c++) {
+      const tile = tiles?.[r]?.[c] || null;
+      const sprite = store[r][c];
+      const cell = gameState?.board?.[r]?.[c];
+      const unit = cell?.unit;
+      if (!tile || !unit) {
+        if (sprite) {
+          disposeOverlay(sprite);
+          store[r][c] = null;
+        }
+        continue;
+      }
+      const attemptsText = `Dodge: ${formatAttempts(unit)} attempts`;
+      if (!sprite) {
+        const created = createSprite(attemptsText, THREE);
+        if (!created) continue;
+        positionSprite(created, tile);
+        tile.add(created);
+        store[r][c] = created;
+      } else {
+        updateSpriteText(sprite, attemptsText, THREE);
+        if (sprite.parent !== tile) {
+          try { sprite.parent?.remove(sprite); } catch {}
+          tile.add(sprite);
+        }
+        positionSprite(sprite, tile);
+      }
+    }
+  }
+}
+
+export function clearDodgeOverlays() {
+  const ctx = getCtx();
+  if (!Array.isArray(ctx.dodgeOverlays)) return;
+  for (let r = 0; r < ctx.dodgeOverlays.length; r++) {
+    const row = ctx.dodgeOverlays[r] || [];
+    for (let c = 0; c < row.length; c++) {
+      disposeOverlay(row[c]);
+      row[c] = null;
+    }
+  }
+  ctx.dodgeOverlays = Array.from({ length: 3 }, () => Array(3).fill(null));
+}

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -5,7 +5,6 @@ import { highlightTiles, clearHighlights } from './highlight.js';
 import {
   applyFreedonianAura,
   applySummonAbilities,
-  shouldUseMagicAttack,
   evaluateIncarnationSummon,
   applyIncarnationSummon,
   isIncarnationCard,
@@ -34,6 +33,28 @@ export const interactionState = {
   // флаг для автоматического завершения хода после атаки
   autoEndTurnAfterAttack: false,
 };
+
+export function logDodgeUpdates(updates, state, sourceName = null) {
+  if (!Array.isArray(updates) || !updates.length) return;
+  const cardsRef = window.CARDS || {};
+  for (const upd of updates) {
+    const targetUnit = state?.board?.[upd.r]?.[upd.c]?.unit;
+    if (!targetUnit) continue;
+    const tplTarget = cardsRef[targetUnit.tplId];
+    const name = tplTarget?.name || 'Существо';
+    const prefix = sourceName ? `${sourceName}: ` : '';
+    if (upd.removed) {
+      window.__ui?.log?.add?.(`${prefix}${name}: способность Dodge отключена.`);
+      continue;
+    }
+    const chance = (typeof upd.chance === 'number') ? Math.round(upd.chance * 100) : 50;
+    if (upd.unlimited) {
+      window.__ui?.log?.add?.(`${prefix}${name}: шанс Dodge ${chance}%.`);
+    } else if (typeof upd.attempts === 'number') {
+      window.__ui?.log?.add?.(`${prefix}${name}: ${upd.attempts} попытк(и) Dodge (${chance}%).`);
+    }
+  }
+}
 
 function isInputLocked() {
   if (typeof window !== 'undefined' && typeof window.isInputLocked === 'function') {
@@ -503,7 +524,16 @@ function performChosenAttack(from, targetMesh) {
   const ORDER = ['N', 'E', 'S', 'W'];
   const relDir = ORDER[(ORDER.indexOf(absDir) - ORDER.indexOf(attacker.facing) + 4) % 4];
   const dist = Math.max(Math.abs(dr), Math.abs(dc));
-  const opts = { chosenDir: relDir, rangeChoices: { [relDir]: dist } };
+  const tpl = window.CARDS?.[attacker.tplId];
+  const profile = window.resolveAttackProfile
+    ? window.resolveAttackProfile(gameState, from.r, from.c, tpl)
+    : { attacks: tpl?.attacks || [], chooseDir: tpl?.chooseDir };
+  const attacks = Array.isArray(profile?.attacks) ? profile.attacks : [];
+  const needsRangeChoice = attacks.some(a => a?.mode === 'ANY');
+  const opts = { chosenDir: relDir, profile };
+  if (needsRangeChoice) {
+    opts.rangeChoices = { [relDir]: dist };
+  }
   const hits = window.computeHits(gameState, from.r, from.c, opts);
   if (!hits.length) { showNotification('Incorrect target', 'error'); return false; }
   window.performBattleSequence(from.r, from.c, true, opts);
@@ -584,6 +614,7 @@ export function placeUnitWithDirection(direction) {
     }
     incarnationResult = applied;
   }
+  try { if (card.userData) card.userData.isInHand = false; } catch {}
   const unit = {
     uid: window.uid(),
     owner: gameState.active,
@@ -670,6 +701,25 @@ export function placeUnitWithDirection(direction) {
   }
   if (gameState.board[row][col].unit) {
     const summonEvents = applySummonAbilities(gameState, row, col);
+    if (summonEvents?.draw?.count > 0) {
+      const drawInfo = summonEvents.draw;
+      const ownerIdx = typeof drawInfo.player === 'number' ? drawInfo.player : gameState.active;
+      const cards = Array.isArray(drawInfo.cards) ? drawInfo.cards : [];
+      const name = cardData?.name || 'Существо';
+      window.__ui?.log?.add?.(`${name}: игрок ${ownerIdx + 1} добирает ${drawInfo.count} карт(ы).`);
+      (async () => {
+        const animate = window.animateDrawnCardToHand;
+        if (typeof animate === 'function') {
+          for (const tplDrawn of cards) {
+            try { await animate(tplDrawn); } catch (err) { console.warn('[summonDraw] animation failed', err); }
+          }
+        }
+        window.updateHand?.(gameState);
+      })();
+    }
+    if (Array.isArray(summonEvents?.dodgeUpdates) && summonEvents.dodgeUpdates.length) {
+      logDodgeUpdates(summonEvents.dodgeUpdates, gameState, cardData?.name || null);
+    }
     if (summonEvents?.possessions?.length) {
       try {
         const cards = window.CARDS || {};
@@ -721,13 +771,16 @@ export function placeUnitWithDirection(direction) {
       window.updateUnits();
       window.updateUI();
       const tpl = window.CARDS?.[cardData.id];
-      const forcedMagic = shouldUseMagicAttack(gameState, row, col, tpl);
+      const profile = window.resolveAttackProfile
+        ? window.resolveAttackProfile(gameState, row, col, tpl)
+        : { attacks: tpl?.attacks || [], chooseDir: tpl?.chooseDir, attackType: tpl?.attackType };
+      const usesMagic = profile?.attackType === 'MAGIC';
       if (wasIncarnation) {
         interactionState.autoEndTurnAfterAttack = false;
         if (unlockTriggered) { setTimeout(() => { try { window.__ui?.summonLock?.playUnlockAnimation(); } catch {} }, 0); }
         return;
       }
-      if (tpl?.attackType === 'MAGIC' || forcedMagic) {
+      if (usesMagic) {
         const allowFriendly = !!tpl.friendlyFire;
         const cells = [];
         let hasEnemy = false;
@@ -755,18 +808,18 @@ export function placeUnitWithDirection(direction) {
           try { window.endTurn && window.endTurn(); } catch {}
         }
       } else {
-        const attacks = tpl?.attacks || [];
-        const needsChoice = tpl?.chooseDir || attacks.some(a => a.mode === 'ANY');
+        const attacks = Array.isArray(profile?.attacks) ? profile.attacks : (tpl?.attacks || []);
+        const needsChoice = !!profile?.chooseDir || attacks.some(a => a.mode === 'ANY');
         // если в шаблоне несколько дистанций без выбора, подсвечиваем и пустые клетки
         const includeEmpty = attacks.some(a => Array.isArray(a.ranges) && a.ranges.length > 1 && !a.mode);
-        const hitsAll = window.computeHits(gameState, row, col, { union: true, includeEmpty });
+        const hitsAll = window.computeHits(gameState, row, col, { union: true, includeEmpty, profile });
         const hasEnemy = hitsAll.some(h => {
           const u2 = gameState.board?.[h.r]?.[h.c]?.unit;
           return u2 && u2.owner !== unit.owner;
         });
         if (hitsAll.length && hasEnemy) {
           if (needsChoice && hitsAll.length > 1) {
-            interactionState.pendingAttack = { r: row, c: col, cancelMode: 'summon', owner: unit.owner };
+            interactionState.pendingAttack = { r: row, c: col, cancelMode: 'summon', owner: unit.owner, profile };
             interactionState.autoEndTurnAfterAttack = true;
             highlightTiles(hitsAll);
             window.__ui?.log?.add?.(`${tpl.name}: choose a target for the attack.`);
@@ -780,7 +833,10 @@ export function placeUnitWithDirection(direction) {
               const ORDER = ['N', 'E', 'S', 'W'];
               const relDir = ORDER[(ORDER.indexOf(absDir) - ORDER.indexOf(unit.facing) + 4) % 4];
               const dist = Math.max(Math.abs(dr), Math.abs(dc));
-              opts = { chosenDir: relDir, rangeChoices: { [relDir]: dist } };
+              opts = { chosenDir: relDir, profile };
+              if (attacks.some(a => a.mode === 'ANY')) {
+                opts.rangeChoices = { [relDir]: dist };
+              }
             }
             interactionState.autoEndTurnAfterAttack = true;
             window.performBattleSequence(row, col, true, opts);

--- a/src/scene/units.js
+++ b/src/scene/units.js
@@ -5,6 +5,7 @@ import { renderFieldLocks } from './fieldlocks.js';
 import { isUnitPossessed, hasInvisibility } from '../core/abilities.js';
 import { attachPossessionOverlay, disposePossessionOverlay } from './possessionOverlay.js';
 import { setInvisibilityFx } from './unitFx.js';
+import { updateDodgeOverlays } from './dodgeOverlay.js';
 
 function getTHREE() {
   const ctx = getCtx();
@@ -245,6 +246,7 @@ export function updateUnits(gameState) {
   try { if (typeof window !== 'undefined') window.unitMeshes = ctx.unitMeshes; } catch {}
 
   try { renderFieldLocks(gameState); } catch {}
+  try { updateDodgeOverlays(gameState); } catch {}
 }
 
 try { if (typeof window !== 'undefined') window.__units = { updateUnits }; } catch {}

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { computeCellBuff, effectiveStats, hasAdjacentGuard, computeHits, magicAttack, stagedAttack } from '../src/core/rules.js';
+import {
+  computeCellBuff,
+  effectiveStats,
+  hasAdjacentGuard,
+  computeHits,
+  magicAttack,
+  stagedAttack,
+  resolveAttackProfile,
+  refreshBoardDodgeStates,
+} from '../src/core/rules.js';
 import { computeFieldquakeLockedCells } from '../src/core/fieldLocks.js';
 import { hasFirstStrike, applySummonAbilities, shouldUseMagicAttack, refreshContinuousPossessions } from '../src/core/abilities.js';
 import { CARDS } from '../src/core/cards.js';
@@ -8,6 +17,10 @@ function makeBoard() {
   const b = Array.from({ length: 3 }, () => Array.from({ length: 3 }, () => ({ element: 'FIRE', unit: null })));
   b[1][1].element = 'BIOLITH';
   return b;
+}
+
+function cloneCard(id) {
+  return JSON.parse(JSON.stringify(CARDS[id]));
 }
 
 
@@ -72,7 +85,7 @@ describe('guards and hits', () => {
     state.board[0][1].unit = { owner: 1, tplId: 'FIRE_PARTMOLE_FLAME_LIZARD', facing: 'S' };
     state.board[1][2].unit = { owner: 1, tplId: 'FIRE_PARTMOLE_FLAME_LIZARD', facing: 'W' };
     // без выбранного направления ничего не происходит
-    expect(computeHits(state, 1, 1)).toEqual([]);
+    expect(computeHits(state, 1, 1)).toHaveLength(0);
     // union=true возвращает все возможные цели
     const allHits = computeHits(state, 1, 1, { union: true });
     expect(allHits.length).toBe(2);
@@ -212,7 +225,7 @@ describe('guards and hits', () => {
       currentHP: CARDS.FIRE_PARTMOLE_FLAME_LIZARD.hp,
     };
     const hits = computeHits(state, 2, 1);
-    expect(hits).toEqual([]);
+    expect(hits).toHaveLength(0);
   });
 });
 
@@ -797,6 +810,110 @@ describe('новые механики', () => {
     state.board[1][1].unit = { owner:0, tplId:'FIRE_DIDI_THE_ENLIGHTENED', facing:'N' };
     const cells = computeFieldquakeLockedCells(state);
     expect(cells.length).toBe(8);
+  });
+});
+
+describe('Water cards — добор и уклонения', () => {
+  function prepareStateForSummon() {
+    const board = makeBoard();
+    const waterTiles = [ [0, 0], [0, 1], [1, 0], [1, 1], [2, 2] ];
+    for (const [r, c] of waterTiles) {
+      board[r][c].element = 'WATER';
+    }
+    const deckIds = [
+      'FIRE_FLAME_MAGUS',
+      'FIRE_HELLFIRE_SPITTER',
+      'FIRE_RED_CUBIC',
+      'FIRE_PARTMOLE_FLAME_LIZARD',
+      'FIRE_GREAT_MINOS',
+    ];
+    return {
+      state: {
+        board,
+        players: [
+          { deck: deckIds.map(cloneCard), hand: [], discard: [], graveyard: [], mana: 0 },
+          { deck: [], hand: [], discard: [], graveyard: [], mana: 0 },
+        ],
+        active: 0,
+        turn: 1,
+      },
+      waterTiles,
+    };
+  }
+
+  it('Cloud Runner добирает карты по числу водных полей и получает dodge', () => {
+    const { state, waterTiles } = prepareStateForSummon();
+    const r = 0; const c = 1;
+    state.board[r][c].unit = {
+      tplId: 'WATER_CLOUD_RUNNER',
+      owner: 0,
+      facing: 'N',
+      currentHP: CARDS.WATER_CLOUD_RUNNER.hp,
+    };
+
+    const events = applySummonAbilities(state, r, c);
+    expect(events.draw).toBeTruthy();
+    expect(events.draw.count).toBe(waterTiles.length);
+    expect(events.draw.player).toBe(0);
+    expect(events.draw.element).toBe('WATER');
+    expect(state.players[0].hand).toHaveLength(waterTiles.length);
+    const drawnIds = events.draw.cards.map(card => card.id);
+    expect(drawnIds).toEqual(state.players[0].hand.map(card => card.id));
+    expect(events.dodgeUpdates.some(u => u.r === r && u.c === c && (u.attempts ?? 0) >= 1)).toBe(true);
+  });
+
+  it('refreshBoardDodgeStates суммирует ауру Лату и бонусы Дона', () => {
+    const board = makeBoard();
+    board[1][1].element = 'WATER';
+    board[1][0].element = 'EARTH';
+    board[0][1].element = 'WATER';
+    board[1][2].element = 'WATER';
+
+    const state = { board };
+    state.board[1][1].unit = { tplId: 'WATER_DON_OF_VENOA', owner: 0, facing: 'N' };
+    state.board[1][0].unit = { tplId: 'FIRE_FLAME_MAGUS', owner: 1, facing: 'E' };
+    state.board[0][1].unit = { tplId: 'WATER_MERCENARY_SAVIOR_LATOO', owner: 0, facing: 'S' };
+    state.board[1][2].unit = { tplId: 'WATER_CLOUD_RUNNER', owner: 0, facing: 'W' };
+
+    const { updated } = refreshBoardDodgeStates(state);
+    expect(updated).toBeTruthy();
+    const find = (r, c) => updated.find(u => u.r === r && u.c === c);
+    const don = find(1, 1);
+    const latoo = find(0, 1);
+    const runner = find(1, 2);
+    expect(don?.attempts).toBe(3);
+    expect(latoo?.attempts).toBe(1);
+    expect(runner?.attempts).toBe(3);
+  });
+
+  it('resolveAttackProfile переключает схемы атаки Дона на воде', () => {
+    const board = makeBoard();
+    const state = { board };
+    state.board[1][1].unit = { tplId: 'WATER_DON_OF_VENOA', owner: 0, facing: 'N' };
+
+    board[1][1].element = 'EARTH';
+    let profile = resolveAttackProfile(state, 1, 1, CARDS.WATER_DON_OF_VENOA);
+    expect(profile.schemeKey).toBe('BASE');
+    expect(profile.attacks.map(a => a.dir).sort()).toEqual(['N', 'S']);
+
+    board[1][1].element = 'WATER';
+    profile = resolveAttackProfile(state, 1, 1, CARDS.WATER_DON_OF_VENOA);
+    expect(profile.schemeKey).toBe('WATER_SWIRL');
+    expect(profile.attacks.map(a => a.dir).sort()).toEqual(['E', 'N', 'S', 'W']);
+  });
+
+  it('Harpoonsman сокращает дальность на земном поле', () => {
+    const board = makeBoard();
+    const state = { board };
+    state.board[0][1].unit = { tplId: 'WATER_TRITONAN_HARPOONSMAN', owner: 0, facing: 'N' };
+
+    board[0][1].element = 'WATER';
+    let profile = resolveAttackProfile(state, 0, 1, CARDS.WATER_TRITONAN_HARPOONSMAN);
+    expect(profile.attacks[0].ranges).toContain(2);
+
+    board[0][1].element = 'EARTH';
+    profile = resolveAttackProfile(state, 0, 1, CARDS.WATER_TRITONAN_HARPOONSMAN);
+    expect(profile.attacks[0].ranges).toEqual([1]);
   });
 });
 


### PR DESCRIPTION
## Summary
- скорректировал атаки новых водных юнитов: Cloud Runner бьёт только по горизонтали, а Latoo и Harpoonsman используют ограничение дальности без альтернативных схем, тексты карт совпадают со скриншотами
- вынес визуализацию оставшихся попыток Dodge в отдельный модуль dodgeOverlay и обновил его очистку при пересборке доски
- устранил избыточные попытки Dodge, обновил тесты и починил анимацию добора после призыва, чтобы карта не возвращалась в руку

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd1118ad3483308eabc687e7b96869