### PR TITLE
Fix Juno heal bonus and adjust debug mana control

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,11 @@
       <button id="cancel-play-btn" class="overlay-panel px-4 py-2 bg-red-600 hover:bg-red-700 hidden">Отмена</button>
     </div>
 
+    <!-- Левый нижний угол: отладочные действия -->
+    <div id="corner-left" class="ui-panel fixed left-4 bottom-24 z-30 flex flex-col space-y-2">
+      <button id="debug-mana-btn" class="overlay-panel px-3 py-1.5 text-xs bg-emerald-700 hover:bg-emerald-600 transition-colors">+10 маны всем</button>
+    </div>
+
     <!-- Правый нижний угол: сервисные кнопки -->
     <div id="corner-right" class="ui-panel fixed right-4 bottom-4 z-20">
       <div class="flex gap-2 opacity-90">

--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -30,6 +30,10 @@ import {
   computeAuraAttackBonus as computeAuraAttackBonusInternal,
   computeAuraActivationDelta as computeAuraActivationDeltaInternal,
 } from './abilityHandlers/auraModifiers.js';
+import { hasAuraInvisibility } from './abilityHandlers/invisibilityAura.js';
+import { applyEnemySummonReactions } from './abilityHandlers/summonReactions.js';
+import { applyTurnStartManaEffects as applyTurnStartManaEffectsInternal } from './abilityHandlers/startPhase.js';
+import { normalizeElementName } from './utils/elements.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -67,9 +71,8 @@ function normalizeTplIdList(value) {
 function normalizeElements(value) {
   const set = new Set();
   for (const raw of toArray(value)) {
-    if (typeof raw === 'string' && raw) {
-      set.add(raw.toUpperCase());
-    }
+    const el = normalizeElementName(raw);
+    if (el) set.add(el);
   }
   return set;
 }
@@ -214,6 +217,9 @@ export function hasInvisibility(state, r, c, opts = {}) {
   if (tpl.invisibility) return true;
   const byElement = normalizeElements(tpl.invisibilityOnElement);
   if (byElement.size && cell?.element && byElement.has(cell.element)) {
+    return true;
+  }
+  if (hasAuraInvisibility(state, r, c, { unit, tpl })) {
     return true;
   }
   const sources = collectInvisibilitySources(tpl);
@@ -452,10 +458,19 @@ export function applyDamageInteractionResults(state, effects = {}) {
 function normalizeElementConfig(value, defaults = {}) {
   if (!value) return null;
   if (typeof value === 'string') {
-    return { ...defaults, element: value };
+    const element = normalizeElementName(value);
+    if (!element) return null;
+    return { ...defaults, element };
   }
   if (typeof value === 'object') {
-    return { ...defaults, ...value };
+    const result = { ...defaults, ...value };
+    if (value.element != null) {
+      const element = normalizeElementName(value.element);
+      if (element) {
+        result.element = element;
+      }
+    }
+    return result;
   }
   return null;
 }
@@ -627,6 +642,11 @@ export function applySummonAbilities(state, r, c) {
     events.dodgeUpdates = dodgeInfo.updated;
   }
 
+  const reactions = applyEnemySummonReactions(state, { r, c, unit, tpl });
+  if (Array.isArray(reactions?.heals) && reactions.heals.length) {
+    events.heals = [...(events.heals || []), ...reactions.heals];
+  }
+
   return events;
 }
 
@@ -748,6 +768,7 @@ export const ensureUnitDodgeState = ensureDodgeState;
 export const attemptUnitDodge = attemptDodgeInternal;
 export const refreshContinuousPossessions = refreshContinuousPossessionsInternal;
 export { refreshBoardDodgeStates };
+export const applyTurnStartManaEffects = applyTurnStartManaEffectsInternal;
 
 export function collectUnitActions(state, r, c) {
   const actions = [];

--- a/src/core/abilityHandlers/invisibilityAura.js
+++ b/src/core/abilityHandlers/invisibilityAura.js
@@ -1,0 +1,106 @@
+// Поддержка аур невидимости (логика отдельно от визуала)
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+function getTemplate(unit) {
+  if (!unit) return null;
+  return CARDS[unit.tplId] || null;
+}
+
+const normalizeElement = (value) => normalizeElementName(value);
+
+function collectGrantElements(raw, fallbackElement = null) {
+  const set = new Set();
+  const fallback = normalizeElement(fallbackElement);
+  const add = (value) => {
+    const el = normalizeElement(value);
+    if (el) set.add(el);
+  };
+
+  if (raw == null) {
+    return set;
+  }
+  if (raw === true && fallback) {
+    set.add(fallback);
+    return set;
+  }
+  if (typeof raw === 'string') {
+    add(raw);
+    return set;
+  }
+  if (Array.isArray(raw)) {
+    raw.forEach(add);
+    return set;
+  }
+  if (typeof raw === 'object') {
+    if (raw.element) add(raw.element);
+    if (raw.elements) {
+      const list = Array.isArray(raw.elements) ? raw.elements : [raw.elements];
+      list.forEach(add);
+    }
+    if (raw.field) add(raw.field);
+    if (!raw.element && !raw.elements && !raw.field && fallback) {
+      set.add(fallback);
+    }
+    return set;
+  }
+  return set;
+}
+
+function isUnitAlive(unit, tpl) {
+  const current = typeof unit?.currentHP === 'number' ? unit.currentHP : null;
+  if (current != null) return current > 0;
+  if (typeof tpl?.hp === 'number') return tpl.hp > 0;
+  return true;
+}
+
+export function hasAuraInvisibility(state, r, c, opts = {}) {
+  if (!state?.board) return false;
+  const unit = opts.unit || state.board?.[r]?.[c]?.unit;
+  if (!unit) return false;
+  const tpl = opts.tpl || getTemplate(unit);
+  if (!tpl) return false;
+  const owner = unit.owner;
+  if (owner == null) return false;
+  const cellElement = normalizeElement(state.board?.[r]?.[c]?.element);
+
+  for (let rr = 0; rr < state.board.length; rr += 1) {
+    const row = state.board[rr];
+    if (!Array.isArray(row)) continue;
+    for (let cc = 0; cc < row.length; cc += 1) {
+      const auraUnit = row[cc]?.unit;
+      if (!auraUnit || auraUnit.owner !== owner) continue;
+      const auraTpl = getTemplate(auraUnit);
+      if (!auraTpl) continue;
+      if (!isUnitAlive(auraUnit, auraTpl)) continue;
+
+      if (auraTpl.grantInvisibilityToAlliesOnElement) {
+        const sameEntity =
+          auraUnit === unit ||
+          (auraUnit?.uid && unit?.uid && auraUnit.uid === unit.uid);
+        if (sameEntity) continue; // Эдин не скрывает саму себя
+        const allowed = collectGrantElements(
+          auraTpl.grantInvisibilityToAlliesOnElement,
+          auraTpl.element,
+        );
+        if (allowed.size && cellElement && allowed.has(cellElement)) {
+          return true;
+        }
+      }
+
+      if (auraTpl.invisibilityAuraSameElement) {
+        const sameCell = rr === r && cc === c;
+        if (!sameCell) {
+          const auraElement = normalizeElement(state.board?.[rr]?.[cc]?.element);
+          if (auraElement && cellElement && auraElement === cellElement) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+export default { hasAuraInvisibility };

--- a/src/core/abilityHandlers/startPhase.js
+++ b/src/core/abilityHandlers/startPhase.js
@@ -1,0 +1,107 @@
+// Обработка эффектов начала хода (логика без визуала)
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+function getTemplate(unit) {
+  if (!unit) return null;
+  return CARDS[unit.tplId] || null;
+}
+
+function normalizeElement(value, fallback = null) {
+  const normalized = normalizeElementName(typeof value === 'string' ? value : null);
+  if (normalized) return normalized;
+  if (fallback && typeof fallback === 'string') {
+    return normalizeElementName(fallback);
+  }
+  return null;
+}
+
+function normalizeManaGainConfig(raw, tpl) {
+  if (raw == null) {
+    if (tpl?.manaGainOnNonElement === true) {
+      return {
+        element: normalizeElement(tpl.element),
+        amount: 1,
+      };
+    }
+    return null;
+  }
+  if (typeof raw === 'string') {
+    return {
+      element: normalizeElement(raw, tpl?.element),
+      amount: 1,
+    };
+  }
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    const amount = Math.max(0, Math.floor(raw));
+    if (amount <= 0) return null;
+    return {
+      element: normalizeElement(tpl?.element),
+      amount,
+    };
+  }
+  if (typeof raw === 'object') {
+    const element = normalizeElement(
+      raw.element || raw.base || raw.reference || raw.field,
+      tpl?.element,
+    );
+    const amountRaw = raw.amount || raw.value || raw.plus || raw.gain;
+    const amount = Math.max(0, Math.floor(Number.isFinite(amountRaw) ? amountRaw : 1));
+    if (!element || amount <= 0) return null;
+    return { element, amount };
+  }
+  return null;
+}
+
+function isUnitAlive(unit, tpl) {
+  const current = typeof unit?.currentHP === 'number' ? unit.currentHP : null;
+  const baseHp = tpl?.hp;
+  if (current != null) return current > 0;
+  if (typeof baseHp === 'number') return baseHp > 0;
+  return true;
+}
+
+export function applyTurnStartManaEffects(state, playerIndex) {
+  const result = { total: 0, entries: [] };
+  if (!state?.board || !Array.isArray(state.board)) return result;
+  const player = state.players?.[playerIndex];
+  if (!player) return result;
+
+  for (let r = 0; r < state.board.length; r += 1) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c += 1) {
+      const cell = row[c];
+      const unit = cell?.unit;
+      if (!unit || unit.owner !== playerIndex) continue;
+      const tpl = getTemplate(unit);
+      if (!tpl) continue;
+      if (!isUnitAlive(unit, tpl)) continue;
+      const cfg = normalizeManaGainConfig(tpl.manaGainOnNonElement, tpl);
+      if (!cfg) continue;
+      const nativeElement = cfg.element || normalizeElement(tpl.element);
+      if (!nativeElement) continue;
+      const cellElement = normalizeElement(cell?.element || null);
+      if (cellElement === nativeElement) continue;
+
+      const before = typeof player.mana === 'number' ? player.mana : 0;
+      const after = before + cfg.amount;
+      player.mana = after > 10 ? 10 : after;
+      const gained = player.mana - before;
+      if (gained > 0) {
+        result.total += gained;
+        result.entries.push({
+          r,
+          c,
+          tplId: tpl.id,
+          amount: gained,
+          fieldElement: cellElement,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+export default { applyTurnStartManaEffects };

--- a/src/core/abilityHandlers/summonReactions.js
+++ b/src/core/abilityHandlers/summonReactions.js
@@ -1,0 +1,115 @@
+// Реакции на призыв врага рядом с существами (чистая логика)
+import { CARDS } from '../cards.js';
+import { computeCellBuff } from '../fieldEffects.js';
+import { DIR_VECTORS, inBounds } from '../constants.js';
+
+function getTemplate(unit) {
+  if (!unit) return null;
+  return CARDS[unit.tplId] || null;
+}
+
+function normalizeAmount(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.floor(value));
+  }
+  if (value === true) return 1;
+  return 0;
+}
+
+function isUnitAlive(unit, tpl) {
+  const hp = typeof unit?.currentHP === 'number' ? unit.currentHP : null;
+  if (hp != null) return hp > 0;
+  if (typeof tpl?.hp === 'number') return tpl.hp > 0;
+  return true;
+}
+
+function healUnit(state, r, c, amount) {
+  if (!state?.board) return null;
+  const cell = state.board?.[r]?.[c];
+  const unit = cell?.unit;
+  if (!unit) return null;
+  const tpl = getTemplate(unit);
+  if (!tpl) return null;
+  if (!isUnitAlive(unit, tpl)) return null;
+  const cellElement = cell?.element || null;
+  const buff = computeCellBuff(cellElement, tpl.element);
+  const prevBonus = typeof unit.bonusHP === 'number' ? unit.bonusHP : 0;
+  const bonusDelta = Math.max(0, amount);
+  const newBonus = prevBonus + bonusDelta;
+  if (newBonus !== prevBonus) {
+    unit.bonusHP = newBonus;
+  }
+  const baseHp = tpl.hp || 0;
+  const maxHp = baseHp + buff.hp + (unit.bonusHP || 0);
+  if (typeof unit.currentHP !== 'number') {
+    unit.currentHP = baseHp;
+  }
+  const before = typeof unit.currentHP === 'number' ? unit.currentHP : baseHp;
+  const healDelta = Math.min(amount, Math.max(0, maxHp - before));
+  if (healDelta > 0) {
+    unit.currentHP = before + healDelta;
+  }
+  if (!healDelta && newBonus === prevBonus) return null;
+  return {
+    r,
+    c,
+    before,
+    after: typeof unit.currentHP === 'number' ? unit.currentHP : baseHp,
+    amount: healDelta,
+    bonusDelta: newBonus - prevBonus,
+  };
+}
+
+export function applyEnemySummonReactions(state, context = {}) {
+  const events = { heals: [] };
+  if (!state?.board) return events;
+  const { r, c, unit } = context;
+  if (typeof r !== 'number' || typeof c !== 'number') return events;
+  if (!unit) return events;
+  const enemyOwner = unit.owner;
+
+  const processed = [];
+  for (const [dir, vec] of Object.entries(DIR_VECTORS)) {
+    const [dr, dc] = vec;
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) continue;
+    const reactor = state.board?.[nr]?.[nc]?.unit;
+    if (!reactor || reactor.owner === enemyOwner) continue;
+    const tplReactor = getTemplate(reactor);
+    if (!tplReactor) continue;
+    if (!isUnitAlive(reactor, tplReactor)) continue;
+    const amount = normalizeAmount(tplReactor.onEnemySummonAdjacentHealAllies);
+    if (amount <= 0) continue;
+    processed.push({ r: nr, c: nc, unit: reactor, tpl: tplReactor, amount, dir });
+  }
+
+  if (!processed.length) return events;
+
+  for (const trigger of processed) {
+    const owner = trigger.unit.owner;
+    const healedList = [];
+    for (let rr = 0; rr < state.board.length; rr += 1) {
+      const row = state.board[rr];
+      if (!Array.isArray(row)) continue;
+      for (let cc = 0; cc < row.length; cc += 1) {
+        if (rr === trigger.r && cc === trigger.c) continue; // "other" союзники
+        const ally = row[cc]?.unit;
+        if (!ally || ally.owner !== owner) continue;
+        const healed = healUnit(state, rr, cc, trigger.amount);
+        if (healed) healedList.push(healed);
+      }
+    }
+    if (healedList.length) {
+      events.heals.push({
+        source: { r: trigger.r, c: trigger.c, tplId: trigger.tpl.id, dir: trigger.dir },
+        amount: trigger.amount,
+        healed: healedList,
+      });
+    }
+  }
+
+  return events;
+}
+
+export default { applyEnemySummonReactions };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -358,6 +358,22 @@ export const CARDS = {
     ],
     desc: 'Verzar Elephant Brigade must use its secondary attack while it is on an Earth field. While Verzar Elephant Brigade is on an Earth field, allied creatures on adjacent fields add 2 to their Attack and 1 to their Activation Cost.'
   },
+  EARTH_DUNGEON_OF_TEN_TYRANTS: {
+    id: 'EARTH_DUNGEON_OF_TEN_TYRANTS', name: 'Dungeon of Ten Tyrants', type: 'UNIT', cost: 4, activation: 2,
+    element: 'EARTH', atk: 1, hp: 4,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1] },
+      { dir: 'E', ranges: [1] },
+      { dir: 'S', ranges: [1] },
+      { dir: 'W', ranges: [1] }
+    ],
+    blindspots: [],
+    fortress: true,
+    manaGainOnNonElement: 'EARTH',
+    diesOnElement: 'FOREST',
+    desc: 'Fortress: cannot attack unless counterattacking. While on a non‑Earth field, its summoner gains 1 mana during their resolution phase. Destroy if on a Forest field.'
+  },
   WATER_WOLF_NINJA: {
     id: 'WATER_WOLF_NINJA', name: 'Wolf Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 1, hp: 3,
@@ -436,6 +452,32 @@ export const CARDS = {
     invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
     rotateTargetOnDamage: true,
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+  FOREST_JUNO_PRISONER_TRAP: {
+    id: 'FOREST_JUNO_PRISONER_TRAP', name: 'Juno Prisoner Trap', type: 'UNIT', cost: 4, activation: 2,
+    element: 'FOREST', atk: 0, hp: 4,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1] },
+      { dir: 'E', ranges: [1] },
+      { dir: 'S', ranges: [1] },
+      { dir: 'W', ranges: [1] }
+    ],
+    blindspots: [],
+    fortress: true,
+    onEnemySummonAdjacentHealAllies: 1,
+    diesOnElement: 'EARTH',
+    desc: 'Fortress: cannot attack unless counterattacking. When an enemy creature is summoned adjacent to it, all other allied creatures gain 1 HP. Destroy if on an Earth field.'
+  },
+  FOREST_EDIN_THE_PERSECUTED: {
+    id: 'FOREST_EDIN_THE_PERSECUTED', name: 'Edin the Persecuted', type: 'UNIT', cost: 3, activation: 2,
+    element: 'FOREST', atk: 2, hp: 3,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    plus1IfTargetOnElement: 'FOREST',
+    grantInvisibilityToAlliesOnElement: 'FOREST',
+    desc: '+1 Attack while attacking a creature on a Forest field. Allied creatures on Forest fields have Invisibility.'
   },
   FOREST_ELVEN_DEATH_DANCER: {
     id: 'FOREST_ELVEN_DEATH_DANCER', name: 'Elven Death Dancer', type: 'UNIT', cost: 5, activation: 4,
@@ -553,6 +595,22 @@ export const CARDS = {
     friendlyFire: true,
     blindspots: ['S'],
     desc: ''
+  },
+
+  BIOLITH_AEGIS_CITADEL: {
+    id: 'BIOLITH_AEGIS_CITADEL', name: 'Aegis Citadel', type: 'UNIT', cost: 5, activation: 3,
+    element: 'BIOLITH', atk: 1, hp: 5,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1] },
+      { dir: 'E', ranges: [1] },
+      { dir: 'S', ranges: [1] },
+      { dir: 'W', ranges: [1] }
+    ],
+    blindspots: [],
+    fortress: true,
+    invisibilityAuraSameElement: true,
+    desc: 'Fortress: cannot attack except when counterattacking. Grants Invisibility to all allied creatures of the same element as the field it occupies.'
   },
 
   BIOLITH_TAURUS_MONOLITH: {

--- a/src/core/mana.js
+++ b/src/core/mana.js
@@ -1,0 +1,27 @@
+// Утилиты для массового изменения маны игроков (без визуализации)
+import { capMana } from './constants.js';
+
+export function grantManaToAllPlayers(state, amount = 0) {
+  const result = { total: 0, entries: [] };
+  if (!state || !Array.isArray(state.players)) {
+    return result;
+  }
+  const delta = Number.isFinite(amount) ? Math.floor(amount) : 0;
+  if (delta <= 0) {
+    return result;
+  }
+  state.players.forEach((player, index) => {
+    if (!player) return;
+    const before = typeof player.mana === 'number' ? player.mana : 0;
+    const after = capMana(before + delta);
+    player.mana = after;
+    const gained = after - before;
+    if (gained > 0) {
+      result.total += gained;
+      result.entries.push({ playerIndex: index, before, after, gained });
+    }
+  });
+  return result;
+}
+
+export default { grantManaToAllPlayers };

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -22,6 +22,7 @@ import {
 } from './abilities.js';
 import { countUnits } from './board.js';
 import { computeCellBuff } from './fieldEffects.js';
+import { normalizeElementName } from './utils/elements.js';
 
 export function hasAdjacentGuard(state, r, c) {
   const target = state.board?.[r]?.[c]?.unit;
@@ -319,11 +320,14 @@ export function stagedAttack(state, r, c, opts = {}) {
   const targetBonus = getTargetElementBonus(tplA, base, hitsRaw);
   const plusCfg = tplA.plusAtkIfTargetOnElement || (tplA.plus1IfTargetOnElement ? { element: tplA.plus1IfTargetOnElement, amount: 1 } : null);
   if (plusCfg) {
-    const { element: el, amount } = plusCfg;
-    const has = hitsRaw.some(h => base.board?.[h.r]?.[h.c]?.element === el);
-    if (has) {
-      atk += amount;
-      logLines.push(`${tplA.name}: +${amount} ATK по целям на поле ${el}`);
+    const el = normalizeElementName(plusCfg.element);
+    const amount = plusCfg.amount;
+    if (el) {
+      const has = hitsRaw.some(h => normalizeElementName(base.board?.[h.r]?.[h.c]?.element) === el);
+      if (has) {
+        atk += amount;
+        logLines.push(`${tplA.name}: +${amount} ATK по целям на поле ${el}`);
+      }
     }
   }
   const costBonus = getTargetCostBonus(base, tplA, hitsRaw);
@@ -691,9 +695,12 @@ export function magicAttack(state, fr, fc, tr, tc) {
 
   const plusCfg2 = tplA.plusAtkIfTargetOnElement || (tplA.plus1IfTargetOnElement ? { element: tplA.plus1IfTargetOnElement, amount: 1 } : null);
   if (plusCfg2) {
-    const { element: el, amount } = plusCfg2;
-    const cellEl = n1.board?.[tr]?.[tc]?.element;
-    if (cellEl === el) atk += amount;
+    const el = normalizeElementName(plusCfg2.element);
+    const amount = plusCfg2.amount;
+    if (el) {
+      const cellEl = normalizeElementName(n1.board?.[tr]?.[tc]?.element);
+      if (cellEl === el) atk += amount;
+    }
   }
   if (mainTarget) {
     const costBonus2 = getTargetCostBonus(n1, tplA, [ { r: tr, c: tc } ]);

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,6 +1,7 @@
 ﻿// Game state: reducer + helpers
 import { capMana } from './constants.js';
 import { shuffle, drawOne, drawOneNoAdd, countControlled, countUnits, randomBoard, startGame } from './board.js';
+import { applyTurnStartManaEffects } from './abilities.js';
 
 export { shuffle, drawOne, drawOneNoAdd, countControlled, countUnits, randomBoard, startGame };
 
@@ -34,11 +35,12 @@ export function reducer(state, action) {
       s.turn += 1;
       const pl = s.players[s.active];
       const before = pl.mana || 0;
-      
+
       // ВАЖНО: Сохраняем предыдущее значение маны для правильной анимации
       pl._beforeMana = before;
       pl.mana = capMana(before + 2);
-      
+      applyTurnStartManaEffects(s, s.active);
+
       // Optional draw: only enqueue for animation elsewhere; here push straight for logic
       const drawn = drawOneNoAdd(s, s.active);
       if (drawn) pl.hand.push(drawn);

--- a/src/core/utils/elements.js
+++ b/src/core/utils/elements.js
@@ -1,0 +1,20 @@
+// Вспомогательные функции для нормализации названий стихий
+export function normalizeElementName(value) {
+  if (typeof value !== 'string') return null;
+  const upper = value.toUpperCase();
+  if (upper === 'WOOD') return 'FOREST';
+  return upper;
+}
+
+export function normalizeElementSet(raw) {
+  const set = new Set();
+  if (raw == null) return set;
+  const list = Array.isArray(raw) ? raw : [raw];
+  for (const item of list) {
+    const el = normalizeElementName(item);
+    if (el) set.add(el);
+  }
+  return set;
+}
+
+export default { normalizeElementName, normalizeElementSet };

--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,7 @@ import { playDeltaAnimations } from './scene/delta.js';
 import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
 import * as CancelButton from './ui/cancelButton.js';
+import { initDebugControls } from './ui/debugControls.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -217,4 +218,6 @@ try {
 
 import * as UISync from './ui/sync.js';
 try { UISync.attachSocketUIRefresh(); if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.sync = UISync; } } catch {}
+
+try { initDebugControls(); } catch {}
 

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -795,6 +795,19 @@ export function placeUnitWithDirection(direction) {
         }
       } catch {}
     }
+    if (Array.isArray(summonEvents?.heals) && summonEvents.heals.length) {
+      try {
+        const cards = window.CARDS || {};
+        for (const heal of summonEvents.heals) {
+          const tplSource = cards[heal?.source?.tplId];
+          const sourceName = tplSource?.name || 'Существо';
+          const totalHealed = Array.isArray(heal.healed)
+            ? heal.healed.reduce((acc, item) => acc + (item?.amount || 0), 0)
+            : heal.amount;
+          window.addLog?.(`${sourceName}: союзники восстанавливают ${totalHealed} HP.`);
+        }
+      } catch {}
+    }
     const gained = applyFreedonianAura(gameState, gameState.active);
     if (gained > 0) {
       window.addLog(`Фридонийский Странник приносит ${gained} маны.`);
@@ -830,6 +843,17 @@ export function placeUnitWithDirection(direction) {
       window.updateUnits();
       window.updateUI();
       const tpl = window.CARDS?.[cardData.id];
+      if (tpl?.fortress) {
+        interactionState.autoEndTurnAfterAttack = false;
+        if (unlockTriggered) {
+          setTimeout(() => {
+            try { window.__ui?.summonLock?.playUnlockAnimation(); } catch {}
+          }, 0);
+        }
+        endTurnAfterSummon();
+        try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
+        return;
+      }
       const profile = window.resolveAttackProfile
         ? window.resolveAttackProfile(gameState, row, col, tpl)
         : { attacks: tpl?.attacks || [], chooseDir: tpl?.chooseDir, attackType: tpl?.attackType };

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -7,6 +7,7 @@ import {
   canAttack,
   collectUnitActions,
   executeUnitAction,
+  applyTurnStartManaEffects,
 } from '../core/abilities.js';
 import {
   interactionState,
@@ -364,6 +365,17 @@ export function confirmUnitAbilityOrientation(context, direction) {
       }
     }
 
+    if (Array.isArray(result.summonEvents?.heals) && result.summonEvents.heals.length) {
+      for (const heal of result.summonEvents.heals) {
+        const tplSource = w.CARDS?.[heal?.source?.tplId];
+        const sourceName = tplSource?.name || 'Существо';
+        const totalHealed = Array.isArray(heal.healed)
+          ? heal.healed.reduce((acc, item) => acc + (item?.amount || 0), 0)
+          : heal.amount;
+        w.addLog?.(`${sourceName}: союзники восстанавливают ${totalHealed} HP.`);
+      }
+    }
+
     if (result.freedonianMana > 0) {
       w.addLog?.(`Фридонийский Странник приносит ${result.freedonianMana} маны.`);
     }
@@ -499,7 +511,13 @@ export async function endTurn() {
 
     const player = gameState.players[gameState.active];
     const before = player.mana;
-    const manaAfter = (typeof w.capMana === 'function') ? w.capMana(before + 2) : before + 2;
+    const capFn = (typeof w.capMana === 'function')
+      ? w.capMana
+      : ((value) => Math.min(10, value));
+    let manaAfter = capFn(before + 2);
+    player.mana = manaAfter;
+    const manaEffects = applyTurnStartManaEffects(gameState, gameState.active) || { total: 0, entries: [] };
+    manaAfter = player.mana;
     let drawnTpl = null;
     try {
       if (typeof w.drawOneNoAdd === 'function' && !player._drewThisTurn) {
@@ -510,7 +528,11 @@ export async function endTurn() {
 
     try {
       if (!w.PENDING_MANA_ANIM && !manaGainActive) {
-        w.PENDING_MANA_ANIM = { ownerIndex: gameState.active, startIdx: Math.max(0, Math.min(9, before)), endIdx: Math.max(-1, Math.min(9, manaAfter - 1)) };
+        w.PENDING_MANA_ANIM = {
+          ownerIndex: gameState.active,
+          startIdx: Math.max(0, Math.min(9, before)),
+          endIdx: Math.max(-1, Math.min(9, manaAfter - 1)),
+        };
       }
     } catch {}
     try { if (w.gameState && w.gameState.players && w.gameState.players[gameState.active]) { w.gameState.players[gameState.active]._beforeMana = before; } } catch {}
@@ -585,7 +607,17 @@ export async function endTurn() {
       }
     } catch { w.pendingDrawCount = 0; }
 
-    w.addLog?.(`Ход ${gameState.turn}. ${player.name} получает +2 маны и добирает карту.`);
+    if (Array.isArray(manaEffects.entries) && manaEffects.entries.length) {
+      const cards = w.CARDS || {};
+      for (const entry of manaEffects.entries) {
+        const tpl = cards[entry.tplId];
+        const sourceName = tpl?.name || 'Существо';
+        const field = entry.fieldElement ? `поле ${entry.fieldElement}` : 'нейтральное поле';
+        w.addLog?.(`${sourceName}: дополнительная мана +${entry.amount} (${field}).`);
+      }
+    }
+    const totalGain = Math.max(0, manaAfter - before);
+    w.addLog?.(`Ход ${gameState.turn}. ${player.name} получает +${totalGain} маны и добирает карту.`);
 
     w.__endTurnInProgress = false;
     w.manaGainActive = false;

--- a/src/ui/debugControls.js
+++ b/src/ui/debugControls.js
@@ -1,0 +1,71 @@
+// Простейшие отладочные элементы управления (чистый UI-код)
+import { grantManaToAllPlayers } from '../core/mana.js';
+
+let initialized = false;
+
+function isOnline() {
+  try {
+    if (typeof window.NET_ON === 'function') {
+      return !!window.NET_ON();
+    }
+    return !!window.NET_ACTIVE;
+  } catch {
+    return false;
+  }
+}
+
+function isActivePlayer(gameState) {
+  try {
+    if (typeof window.MY_SEAT === 'number') {
+      return gameState?.active === window.MY_SEAT;
+    }
+  } catch {}
+  return true;
+}
+
+export function initDebugControls() {
+  if (initialized) return;
+  if (typeof window === 'undefined') return;
+
+  const setup = () => {
+    if (initialized) return;
+    const button = document.getElementById('debug-mana-btn');
+    if (!button) return;
+
+    const handleClick = () => {
+      try {
+        const state = window.gameState;
+        if (!state) return;
+        if (isOnline() && !isActivePlayer(state)) {
+          window.showNotification?.('Сейчас ходит оппонент — бонусная мана недоступна.', 'warning');
+          return;
+        }
+        const result = grantManaToAllPlayers(state, 10);
+        if (!result.entries.length) {
+          window.showNotification?.('Мана уже на максимуме.', 'info');
+          return;
+        }
+        window.addLog?.('DEBUG: оба игрока получают +10 маны.');
+        window.updateUI?.(state);
+        window.updateUnits?.(state);
+        window.updateHand?.(state);
+        try {
+          window.schedulePush?.('debug-mana', { force: true });
+        } catch {}
+      } catch (err) {
+        console.error('[debugControls] Ошибка применения бонусной маны', err);
+      }
+    };
+
+    button.addEventListener('click', handleClick);
+    initialized = true;
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setup, { once: true });
+  } else {
+    setup();
+  }
+}
+
+export default { initDebugControls };

--- a/tests/abilitiesExtra.test.js
+++ b/tests/abilitiesExtra.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { applyTurnStartManaEffects } from '../src/core/abilityHandlers/startPhase.js';
+import { applyEnemySummonReactions } from '../src/core/abilityHandlers/summonReactions.js';
+import { grantManaToAllPlayers } from '../src/core/mana.js';
+
+function makeBoard() {
+  const board = Array.from({ length: 3 }, () => Array.from({ length: 3 }, () => ({ element: 'FIRE', unit: null })));
+  board[1][1].element = 'BIOLITH';
+  return board;
+}
+
+describe('эффекты начала хода', () => {
+  it('Dungeon of Ten Tyrants начисляет ману вне Земли', () => {
+    const state = {
+      board: makeBoard(),
+      players: [{ mana: 0 }, { mana: 0 }],
+    };
+    state.board[0][0].element = 'FOREST';
+    state.board[0][0].unit = {
+      owner: 0,
+      tplId: 'EARTH_DUNGEON_OF_TEN_TYRANTS',
+      currentHP: 4,
+    };
+    const result = applyTurnStartManaEffects(state, 0);
+    expect(result.total).toBe(1);
+    expect(state.players[0].mana).toBe(1);
+  });
+
+  it('Dungeon не даёт бонус на родной стихии', () => {
+    const state = {
+      board: makeBoard(),
+      players: [{ mana: 2 }, { mana: 0 }],
+    };
+    state.board[0][0].element = 'EARTH';
+    state.board[0][0].unit = {
+      owner: 0,
+      tplId: 'EARTH_DUNGEON_OF_TEN_TYRANTS',
+    };
+    const result = applyTurnStartManaEffects(state, 0);
+    expect(result.total).toBe(0);
+    expect(state.players[0].mana).toBe(2);
+  });
+});
+
+describe('реакции на призыв врага', () => {
+  it('Juno Prisoner Trap лечит остальных союзников', () => {
+    const state = {
+      board: makeBoard(),
+      players: [{ mana: 0 }, { mana: 0 }],
+    };
+    state.board[1][1].element = 'FOREST';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'FOREST_JUNO_PRISONER_TRAP',
+      currentHP: 4,
+    };
+    state.board[1][0].element = 'FOREST';
+    state.board[1][0].unit = {
+      owner: 0,
+      tplId: 'FOREST_SWALLOW_NINJA',
+      currentHP: 1,
+    };
+    const reaction = applyEnemySummonReactions(state, {
+      r: 1,
+      c: 2,
+      unit: { owner: 1, tplId: 'FIRE_PARTMOLE_FLAME_LIZARD', currentHP: 2 },
+    });
+    expect(reaction.heals).toHaveLength(1);
+    expect(reaction.heals[0].healed[0].amount).toBe(1);
+    expect(state.board[1][0].unit.currentHP).toBe(2);
+    expect(state.board[1][0].unit.bonusHP).toBe(1);
+  });
+});
+
+describe('глобальное добавление маны', () => {
+  it('grantManaToAllPlayers добавляет и ограничивает по капу', () => {
+    const state = {
+      players: [
+        { mana: 5 },
+        { mana: 9 },
+      ],
+    };
+    const res = grantManaToAllPlayers(state, 10);
+    expect(res.total).toBe(6);
+    expect(res.entries).toHaveLength(2);
+    expect(state.players[0].mana).toBe(10);
+    expect(state.players[1].mana).toBe(10);
+  });
+});

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -10,7 +10,7 @@ import {
   refreshBoardDodgeStates,
 } from '../src/core/rules.js';
 import { computeFieldquakeLockedCells } from '../src/core/fieldLocks.js';
-import { hasFirstStrike, applySummonAbilities, shouldUseMagicAttack, refreshContinuousPossessions, activationCost } from '../src/core/abilities.js';
+import { hasFirstStrike, applySummonAbilities, shouldUseMagicAttack, refreshContinuousPossessions, activationCost, hasInvisibility } from '../src/core/abilities.js';
 import { CARDS } from '../src/core/cards.js';
 
 function makeBoard() {
@@ -1058,6 +1058,59 @@ describe('Water cards — добор и уклонения', () => {
     const dodgeState = state.board[2][2].unit.dodgeState;
     expect(dodgeState).toBeTruthy();
     expect(dodgeState?.remaining ?? 0).toBe(1);
+  });
+});
+
+describe('Новые способности существ', () => {
+  it('Juno Prisoner Trap лечит союзников при призыве врага рядом', () => {
+    const board = makeBoard();
+    const state = {
+      board,
+      players: [ { mana: 0 }, { mana: 0 } ],
+    };
+    board[1][1].element = 'FOREST';
+    board[1][1].unit = { owner: 0, tplId: 'FOREST_JUNO_PRISONER_TRAP', currentHP: 4, facing: 'N' };
+    board[0][1].element = 'FOREST';
+    board[0][1].unit = { owner: 0, tplId: 'FOREST_SWALLOW_NINJA', currentHP: 4, facing: 'S' };
+    board[1][2].element = 'FIRE';
+    board[1][2].unit = { owner: 1, tplId: 'FIRE_HELLFIRE_SPITTER', currentHP: 1, facing: 'W' };
+
+    const events = applySummonAbilities(state, 1, 2);
+    expect(Array.isArray(events.heals)).toBe(true);
+    expect(events.heals.length).toBeGreaterThan(0);
+    expect(board[0][1].unit.currentHP).toBe(5);
+    expect(board[0][1].unit.bonusHP).toBe(1);
+    expect(board[1][1].unit.currentHP).toBe(4);
+  });
+
+  it('Edin делает союзников на древесных полях невидимыми', () => {
+    const board = makeBoard();
+    const state = { board };
+    board[0][0].element = 'FOREST';
+    board[0][0].unit = { owner: 0, tplId: 'FOREST_EDIN_THE_PERSECUTED', facing: 'N' };
+    board[0][1].element = 'FOREST';
+    board[0][1].unit = { owner: 0, tplId: 'FOREST_ELVEN_DEATH_DANCER', facing: 'S' };
+    board[2][2].element = 'FIRE';
+    board[2][2].unit = { owner: 0, tplId: 'FIRE_HELLFIRE_SPITTER', facing: 'N' };
+
+    expect(hasInvisibility(state, 0, 0)).toBe(false);
+    expect(hasInvisibility(state, 0, 1)).toBe(true);
+    expect(hasInvisibility(state, 2, 2)).toBe(false);
+  });
+
+  it('Aegis Citadel даёт невидимость союзникам на полях той же стихии', () => {
+    const board = makeBoard();
+    const state = { board };
+    board[1][1].element = 'FIRE';
+    board[1][1].unit = { owner: 0, tplId: 'BIOLITH_AEGIS_CITADEL', facing: 'N' };
+    board[0][1].element = 'FIRE';
+    board[0][1].unit = { owner: 0, tplId: 'BIOLITH_BOMBER', facing: 'S' };
+    board[0][2].element = 'WATER';
+    board[0][2].unit = { owner: 0, tplId: 'BIOLITH_NINJA', facing: 'S' };
+
+    expect(hasInvisibility(state, 1, 1)).toBe(false);
+    expect(hasInvisibility(state, 0, 1)).toBe(true);
+    expect(hasInvisibility(state, 0, 2)).toBe(false);
   });
 });
 

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -101,6 +101,25 @@ describe('reducer', () => {
     expect(next.__ver).toBeGreaterThan(state.__ver);
   });
 
+  it('A.END_TURN: Dungeon of Ten Tyrants grants extra mana on non-Earth fields', () => {
+    const board = makeEmptyBoard();
+    board[0][0].element = 'WATER';
+    board[0][0].unit = { owner: 1, tplId: 'EARTH_DUNGEON_OF_TEN_TYRANTS', currentHP: 4, facing: 'N' };
+    const state = {
+      board,
+      players: [
+        { deck: [], hand: [], mana: 0 },
+        { deck: [], hand: [], mana: 0 }
+      ],
+      active: 0,
+      turn: 1,
+      winner: null,
+      __ver: 0,
+    };
+    const next = reducer(state, { type: A.END_TURN });
+    expect(next.players[1].mana).toBe(3);
+  });
+
   it('A.END_TURN: declares winner if 5+ controlled by active', () => {
     const board = makeEmptyBoard();
     // Active player 0 controls 5 cells


### PR DESCRIPTION
## Summary
- ensure Juno Prisoner Trap grants allies lasting health when enemies summon nearby and cover the behavior with unit tests
- prevent Edin the Persecuted from applying her invisibility aura to herself
- move the +10 mana debug button upward so it no longer overlaps with the multiplayer HUD indicator

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce275291848330bb571e92de422c27