### PR TITLE
Полировка начала хода и анимации добора

### DIFF
--- a/src/net/client.js
+++ b/src/net/client.js
@@ -377,30 +377,16 @@ import { getServerBase } from './config.js';
         if (isNewTurn) {
           console.log(`[NETWORK] Processing new turn ${state.turn} (prev: ${prev?.turn || 'none'})`);
           
-          // Ensure turn splash is visible (robust, idempotent)
-          try {
-            if (window.__ui && window.__ui.banner) {
-              const b = window.__ui.banner;
-              if (typeof b.ensureTurnSplashVisible === 'function') {
-                await b.ensureTurnSplashVisible(3, state.turn);
-              } else if (typeof b.forceTurnSplashWithRetry === 'function') {
-                await b.forceTurnSplashWithRetry(3, state.turn);
-              }
-            } else if (typeof forceTurnSplashWithRetry === 'function') {
-              await forceTurnSplashWithRetry(3);
-            }
-          } catch (e) {
-            console.error('[NETWORK] Turn splash failed:', e);
-          }
-          
           // 1. Показываем заставку хода
           try {
             if (window.__ui && window.__ui.banner) {
               const b = window.__ui.banner;
-              if (typeof b.ensureTurnSplashVisible === 'function') {
-                await b.ensureTurnSplashVisible(3, state.turn);
+              if (typeof b.requestTurnSplash === 'function') {
+                await b.requestTurnSplash(state.turn);
+              } else if (typeof b.ensureTurnSplashVisible === 'function') {
+                await b.ensureTurnSplashVisible(2, state.turn);
               } else if (typeof b.forceTurnSplashWithRetry === 'function') {
-                await b.forceTurnSplashWithRetry(3, state.turn);
+                await b.forceTurnSplashWithRetry(2, state.turn);
               }
             }
           } catch (e) {
@@ -419,7 +405,8 @@ import { getServerBase } from './config.js';
             console.log(`[NETWORK] Animating mana for player ${owner}: ${beforeM} -> ${afterM}`);
             try {
               if (window.__ui && window.__ui.mana && typeof window.__ui.mana.animateTurnManaGain === 'function') {
-                await window.__ui.mana.animateTurnManaGain(owner, beforeM, afterM, 1500);
+                // Укорачиваем хронометраж, чтобы быстрее перейти к проявлению карты
+                await window.__ui.mana.animateTurnManaGain(owner, beforeM, afterM, 650);
               }
             } catch (e) {
               console.error('[NETWORK] Mana animation failed:', e);

--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -119,8 +119,8 @@ export function updateHand(gameState) {
 export async function animateDrawnCardToHand(cardTpl) {
   if (!cardTpl) return;
   const ctx = getCtx();
-  const THREE = getTHREE();
-  const { cardGroup, camera } = ctx;
+  getTHREE();
+  const { cardGroup } = ctx;
 
   if (typeof window !== 'undefined') window.drawAnimationActive = true;
   try { if (typeof window !== 'undefined' && window.refreshInputLockUI) window.refreshInputLockUI(); } catch {}
@@ -129,21 +129,14 @@ export async function animateDrawnCardToHand(cardTpl) {
   const T = (typeof window !== 'undefined' ? window.DRAW_CARD_TUNE || {} : {});
   big.position.set(0, (T.posY ?? 10.0), (T.posZ ?? 2.4));
 
-  try {
-    const camForward = new THREE.Vector3();
-    camera.getWorldDirection(camForward);
-    const faceNormal = camForward.clone().negate().normalize();
-    const camUpWorld = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion).normalize();
-    let right = new THREE.Vector3().crossVectors(camUpWorld, faceNormal);
-    if (right.lengthSq() < 1e-6) right.set(1, 0, 0); else right.normalize();
-    const upInPlane = new THREE.Vector3().crossVectors(faceNormal, right).normalize();
-    const basis = new THREE.Matrix4().makeBasis(right, faceNormal, upInPlane);
-    const q = new THREE.Quaternion().setFromRotationMatrix(basis);
-    big.setRotationFromQuaternion(q);
-  } catch {
-    big.rotation.set(0, 0, 0);
-  }
+  const handMeshes = (ctx.handCardMeshes || []).filter(m => m?.userData?.isInHand);
+  const totalVisible = Math.max(0, handMeshes.length);
+  const totalAfter = totalVisible + 1;
+  const indexAfter = totalAfter - 1;
+  const target = computeHandTransform(indexAfter, totalAfter);
 
+  // Совмещаем ориентации проявления и полёта, чтобы исключить рывок при смене мешей
+  big.rotation.copy(target.rotation);
   big.scale.set((T.scale ?? 1.7), (T.scale ?? 1.7), (T.scale ?? 1.7));
   big.renderOrder = 9000;
 
@@ -159,12 +152,6 @@ export async function animateDrawnCardToHand(cardTpl) {
   collectMaterials(big);
   allMaterials.forEach(m => { if (m) { m.transparent = true; m.opacity = 0; } });
   cardGroup.add(big);
-
-  const handMeshes = (ctx.handCardMeshes || []).filter(m => m?.userData?.isInHand);
-  const totalVisible = Math.max(0, handMeshes.length);
-  const totalAfter = totalVisible + 1;
-  const indexAfter = totalAfter - 1;
-  const target = computeHandTransform(indexAfter, totalAfter);
 
   try {
     const preLayoutDuration = 0.6;
@@ -194,14 +181,9 @@ export async function animateDrawnCardToHand(cardTpl) {
     const tl = gsap.timeline({ onComplete: resolve });
     // Сначала проявляем карту, затем запускаем полёт в руку
     tl.to(allMaterials, { opacity: 1, duration: 0.8, ease: 'power2.out' })
-      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.7, ease: 'power2.inOut' })
-      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.7, ease: 'power2.inOut' }, '<')
-      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.7, ease: 'power2.inOut' }, '<');
-    try {
-      big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
-      big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));
-      big.rotateZ(THREE.MathUtils.degToRad(T.rollDeg || 0));
-    } catch {}
+      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.45, ease: 'power2.inOut' })
+      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.45, ease: 'power2.inOut' }, '<')
+      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.45, ease: 'power2.inOut' }, '<');
   });
 
   try { cardGroup.remove(big); } catch {}

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -219,8 +219,11 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
         const tl = (typeof window !== 'undefined') ? window.gsap?.timeline?.({ onComplete: cleanup }) : null;
         if (tl) {
           tl.to(bar, { filter: 'brightness(2.1) drop-shadow(0 0 16px rgba(96,165,250,0.95))', duration: 0.154, ease: 'power2.out' })
-            .to(bar, { filter: 'none', duration: 0.42, ease: 'power2.inOut' })
-            .to({}, { duration: Math.max(0, (durationMs/1000) - 0.574) });
+            .to(bar, { filter: 'none', duration: 0.42, ease: 'power2.inOut' });
+          const baseGlowDuration = 0.574;
+          const desiredDuration = Math.max(durationMs / 1000, baseGlowDuration);
+          const tail = Math.min(0.25, Math.max(0, desiredDuration - baseGlowDuration));
+          if (tail > 0.001) tl.to({}, { duration: tail });
         } else {
           setTimeout(cleanup, durationMs);
         }
@@ -309,9 +312,12 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
         }
       }
       
-      // Добавляем паузу если анимация короче требуемой длительности
-      tl.to({}, { duration: Math.max(0, (durationMs/1000) - tl.duration()) });
-      
+      // Хвост для выравнивания длительности без ощутимой паузы
+      const baseDuration = tl.duration();
+      const desiredDuration = Math.max(durationMs / 1000, baseDuration);
+      const tail = Math.min(0.25, Math.max(0, desiredDuration - baseDuration));
+      if (tail > 0.001) tl.to({}, { duration: tail });
+
     } catch (e) {
       console.error('Error in animateTurnManaGain:', e);
       setManaGainActive(false);


### PR DESCRIPTION
## Изменения
- Продлил заставку начала хода до 1.3 секунды, убрал мигание и ускорил повторные запуски без лишних показов.
- Сократил паузы в анимации получения маны: теперь последовательность от заставки к мане запускается быстрее, а хронометраж выравнивается без длинных хвостов.
- Исправил рассинхрон поворота карты при проявлении и полёте в руку, одновременно ускорив перемещение примерно на 50%.

## Тестирование
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ce6c3c3b608330a80c921f4f6b4c37