### PR TITLE
Полировка анимаций начала хода

### DIFF
--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -599,7 +599,8 @@ export async function endTurn() {
     } catch {}
     try {
       if (w.__ui && w.__ui.mana && typeof w.__ui.mana.animateTurnManaGain === 'function') {
-        await w.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 900);
+        // Разрешаем анимации маны завершаться визуально самостоятельно, ускоряя переход к добору карты
+        await w.__ui.mana.animateTurnManaGain(gameState.active, before, manaAfter, 900, 1000);
       } else {
         console.warn('Module mana animation not available, skipping');
       }


### PR DESCRIPTION
## Summary
- Увеличена и стабилизирована анимация баннера начала хода, чтобы заставка шла 1.3 секунды без мерцаний
- Добавлено раннее завершение ожидания для анимации получения маны и обновлён вызов, чтобы быстрее запускать добор карты
- Переработана анимация проявления карты: ориентация совпадает с положением в руке, ускорено проявление и перелёт

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce6c3c3b608330a80c921f4f6b4c37