### PR TITLE
Полировка анимаций начала хода

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -120,7 +120,7 @@ export async function animateDrawnCardToHand(cardTpl) {
   if (!cardTpl) return;
   const ctx = getCtx();
   const THREE = getTHREE();
-  const { cardGroup, camera } = ctx;
+  const { cardGroup } = ctx;
 
   if (typeof window !== 'undefined') window.drawAnimationActive = true;
   try { if (typeof window !== 'undefined' && window.refreshInputLockUI) window.refreshInputLockUI(); } catch {}
@@ -129,20 +129,14 @@ export async function animateDrawnCardToHand(cardTpl) {
   const T = (typeof window !== 'undefined' ? window.DRAW_CARD_TUNE || {} : {});
   big.position.set(0, (T.posY ?? 10.0), (T.posZ ?? 2.4));
 
-  try {
-    const camForward = new THREE.Vector3();
-    camera.getWorldDirection(camForward);
-    const faceNormal = camForward.clone().negate().normalize();
-    const camUpWorld = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion).normalize();
-    let right = new THREE.Vector3().crossVectors(camUpWorld, faceNormal);
-    if (right.lengthSq() < 1e-6) right.set(1, 0, 0); else right.normalize();
-    const upInPlane = new THREE.Vector3().crossVectors(faceNormal, right).normalize();
-    const basis = new THREE.Matrix4().makeBasis(right, faceNormal, upInPlane);
-    const q = new THREE.Quaternion().setFromRotationMatrix(basis);
-    big.setRotationFromQuaternion(q);
-  } catch {
-    big.rotation.set(0, 0, 0);
-  }
+  const handMeshes = (ctx.handCardMeshes || []).filter(m => m?.userData?.isInHand);
+  const totalVisible = Math.max(0, handMeshes.length);
+  const totalAfter = totalVisible + 1;
+  const indexAfter = totalAfter - 1;
+  const target = computeHandTransform(indexAfter, totalAfter);
+
+  // Начальное проявление теперь совпадает с положением и углом карты в руке
+  big.rotation.copy(target.rotation);
 
   big.scale.set((T.scale ?? 1.7), (T.scale ?? 1.7), (T.scale ?? 1.7));
   big.renderOrder = 9000;
@@ -159,12 +153,6 @@ export async function animateDrawnCardToHand(cardTpl) {
   collectMaterials(big);
   allMaterials.forEach(m => { if (m) { m.transparent = true; m.opacity = 0; } });
   cardGroup.add(big);
-
-  const handMeshes = (ctx.handCardMeshes || []).filter(m => m?.userData?.isInHand);
-  const totalVisible = Math.max(0, handMeshes.length);
-  const totalAfter = totalVisible + 1;
-  const indexAfter = totalAfter - 1;
-  const target = computeHandTransform(indexAfter, totalAfter);
 
   try {
     const preLayoutDuration = 0.6;
@@ -192,11 +180,12 @@ export async function animateDrawnCardToHand(cardTpl) {
 
   await new Promise(resolve => {
     const tl = gsap.timeline({ onComplete: resolve });
-    // Сначала проявляем карту, затем запускаем полёт в руку
+    const flyDuration = 0.46; // Полёт в руку быстрее примерно на 50%
+    // Одновременно проявляем карту и отправляем её в руку
     tl.to(allMaterials, { opacity: 1, duration: 0.8, ease: 'power2.out' })
-      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.7, ease: 'power2.inOut' })
-      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.7, ease: 'power2.inOut' }, '<')
-      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.7, ease: 'power2.inOut' }, '<');
+      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: flyDuration, ease: 'power2.inOut' }, '<')
+      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: flyDuration, ease: 'power2.inOut' }, '<')
+      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: flyDuration, ease: 'power2.inOut' }, '<');
     try {
       big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
       big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));


### PR DESCRIPTION
## Summary
- скорректирована заставка начала хода: гарантированная длительность 1.3 секунды, синхронизация завершения с реальной анимацией
- убрано ожидание между получением маны и проявлением карты за счёт параллельного запуска анимаций
- выровнены углы и ускорено перемещение при доборе карты, чтобы избежать визуальных скачков

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6c3c3b608330a80c921f4f6b4c37