### PR TITLE
Polish start turn animations

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -129,6 +129,7 @@ export async function animateDrawnCardToHand(cardTpl) {
   const T = (typeof window !== 'undefined' ? window.DRAW_CARD_TUNE || {} : {});
   big.position.set(0, (T.posY ?? 10.0), (T.posZ ?? 2.4));
 
+  // Разворачиваем карту лицом к игроку, чтобы проявление выглядело естественно
   try {
     const camForward = new THREE.Vector3();
     camera.getWorldDirection(camForward);
@@ -165,7 +166,6 @@ export async function animateDrawnCardToHand(cardTpl) {
   const totalAfter = totalVisible + 1;
   const indexAfter = totalAfter - 1;
   const target = computeHandTransform(indexAfter, totalAfter);
-
   try {
     const preLayoutDuration = 0.6;
     handMeshes.forEach((mesh, idx) => {
@@ -192,11 +192,12 @@ export async function animateDrawnCardToHand(cardTpl) {
 
   await new Promise(resolve => {
     const tl = gsap.timeline({ onComplete: resolve });
-    // Сначала проявляем карту, затем запускаем полёт в руку
+    const flightDuration = 0.46;
+    // Сначала проявляем карту, затем запускаем полёт в руку с плавным разворотом
     tl.to(allMaterials, { opacity: 1, duration: 0.8, ease: 'power2.out' })
-      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: 0.7, ease: 'power2.inOut' })
-      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: 0.7, ease: 'power2.inOut' }, '<')
-      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: 0.7, ease: 'power2.inOut' }, '<');
+      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: flightDuration, ease: 'power2.inOut' })
+      .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: flightDuration, ease: 'power2.inOut' }, '<')
+      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: flightDuration, ease: 'power2.inOut' }, '<');
     try {
       big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
       big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));

--- a/src/ui/banner.js
+++ b/src/ui/banner.js
@@ -56,11 +56,24 @@ export async function showTurnSplash(title) {
         .to([bg, streaks], { opacity: 0.12, duration: 0.266 }, 0.406)
         .to([txt, ringOuter, ringInner], { opacity: 0, duration: 0.196, ease: 'power2.in' }, 1.134)
         .to(tb, { opacity: 0, duration: 0.14, ease: 'power2.in' }, 1.19);
-      tl.timeScale?.(0.75);
-      await sleep(1000);
+
+      // Точная синхронизация завершения анимации с нужной длительностью
+      const targetDuration = 1.3; // секунды
+      const totalDuration = typeof tl.totalDuration === 'function' ? tl.totalDuration() : 0;
+      if (totalDuration > 0 && typeof tl.timeScale === 'function') {
+        tl.timeScale(totalDuration / targetDuration);
+      }
+
+      await new Promise(resolve => {
+        try {
+          tl.eventCallback('onComplete', () => resolve());
+        } catch {
+          resolve();
+        }
+      });
     } else {
-      // Fallback: simple 1s show
-      await sleep(1000);
+      // Fallback: простая пауза нужной длительности
+      await sleep(1300);
     }
   } catch {}
   tb.classList.add('hidden'); tb.classList.remove('flex'); tb.style.display = 'none'; tb.style.opacity = '';


### PR DESCRIPTION
## Summary
- synchronize the turn splash timeline so it plays for 1.3s and awaits completion to avoid flicker
- trigger mana gain and draw animations sooner by reworking network/offline sequencing and overlapping the animations
- keep the drawn card facing the camera during its reveal while it now rotates into the hand pose during the faster flight

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6c3c3b608330a80c921f4f6b4c37