### PR TITLE
Убираем статичную фазу проявления карты при доборе

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -194,11 +194,11 @@ export async function animateDrawnCardToHand(cardTpl) {
   await new Promise(resolve => {
     const tl = gsap.timeline({ onComplete: resolve });
     const flightDuration = 0.46;
-    // Сначала проявляем карту, затем запускаем полёт в руку с одновременным доворотом под позу руки
-    tl.to(allMaterials, { opacity: 1, duration: 0.8, ease: 'power2.out' })
-      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: flightDuration, ease: 'power2.inOut' })
+    // Запускаем проявление одновременно с полётом в руку, чтобы не было статичной паузы
+    tl.to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: flightDuration, ease: 'power2.inOut' })
       .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: flightDuration, ease: 'power2.inOut' }, '<')
-      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: flightDuration, ease: 'power2.inOut' }, '<');
+      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: flightDuration, ease: 'power2.inOut' }, '<')
+      .to(allMaterials, { opacity: 1, duration: flightDuration, ease: 'power2.out' }, '<');
     try {
       big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
       big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));


### PR DESCRIPTION
## Summary
- запускаем проявление карты одновременно с её полётом в руку, чтобы убрать статичную паузу

## Testing
- не запускались (не запрошено)


------
https://chatgpt.com/codex/tasks/task_e_68ce83f5cf5c8330824fa8710dd07f31