### PR TITLE
Убрать статичную фазу анимации добора карты

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -194,11 +194,11 @@ export async function animateDrawnCardToHand(cardTpl) {
   await new Promise(resolve => {
     const tl = gsap.timeline({ onComplete: resolve });
     const flightDuration = 0.46;
-    // Сначала проявляем карту, затем запускаем полёт в руку с одновременным доворотом под позу руки
-    tl.to(allMaterials, { opacity: 1, duration: 0.8, ease: 'power2.out' })
-      .to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: flightDuration, ease: 'power2.inOut' })
+    // Проявляем карту прямо во время полёта в руку и синхронно подстраиваем ориентацию
+    tl.to(big.position, { x: target.position.x, y: target.position.y, z: target.position.z, duration: flightDuration, ease: 'power2.inOut' })
       .to(big.rotation, { x: target.rotation.x, y: target.rotation.y, z: target.rotation.z, duration: flightDuration, ease: 'power2.inOut' }, '<')
-      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: flightDuration, ease: 'power2.inOut' }, '<');
+      .to(big.scale, { x: target.scale.x, y: target.scale.y, z: target.scale.z, duration: flightDuration, ease: 'power2.inOut' }, '<')
+      .to(allMaterials, { opacity: 1, duration: flightDuration, ease: 'power2.out' }, '<');
     try {
       big.rotateX(THREE.MathUtils.degToRad(T.pitchDeg || 0));
       big.rotateY(THREE.MathUtils.degToRad(T.yawDeg || 0));


### PR DESCRIPTION
## Summary
- синхронизировал проявление добираемой карты с её полётом в руку
- оставил параметры полёта и переориентацию карты без изменений, исключив статичную фазу проявления

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce83f5cf5c8330824fa8710dd07f31