### PR TITLE
Adjust default draw card pitch

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -209,7 +209,7 @@ export async function animateDrawnCardToHand(cardTpl) {
   // Подготавливаем изначальный поворот, чтобы карта сразу смотрела на игрока
   orientCardFaceTowardCamera(big, camera);
   applyEulerDegreeOffsets(big.rotation, {
-    pitchDeg: T.initialPitchDeg ?? 0,
+    pitchDeg: T.initialPitchDeg ?? 30,
     yawDeg: T.initialYawDeg ?? 0,
     rollDeg: T.initialRollDeg ?? 0
   });


### PR DESCRIPTION
## Summary
- increase the default initial pitch for drawn cards to 30 degrees so they start angled toward the player

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce9753bec48330b15970b19c28ede0