### PR TITLE
Adjust initial card draw pitch default to 30 degrees

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -209,7 +209,7 @@ export async function animateDrawnCardToHand(cardTpl) {
   // Подготавливаем изначальный поворот, чтобы карта сразу смотрела на игрока
   orientCardFaceTowardCamera(big, camera);
   applyEulerDegreeOffsets(big.rotation, {
-    pitchDeg: T.initialPitchDeg ?? 0,
+    pitchDeg: T.initialPitchDeg ?? 30,
     yawDeg: T.initialYawDeg ?? 0,
     rollDeg: T.initialRollDeg ?? 0
   });


### PR DESCRIPTION
## Summary
- изменить значение по умолчанию для начального тангажа карты при анимации добора на 30 градусов, чтобы карта сильнее наклонялась к игроку

## Testing
- не запускались (не требовалось)


------
https://chatgpt.com/codex/tasks/task_e_68ce9753bec48330b15970b19c28ede0