### PR TITLE
Раннее выравнивание вращения карты при доборе

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -25,6 +25,16 @@ function computeHandTransform(index, total) {
   return { position: pos, rotation: rot, scale };
 }
 
+// Предварительно вычисляет целиком раскладку руки для указанного количества карт
+function computeHandLayout(total) {
+  const layout = [];
+  const count = Math.max(0, total);
+  for (let i = 0; i < count; i++) {
+    layout.push(computeHandTransform(i, count));
+  }
+  return layout;
+}
+
 // Разворачивает карту так, чтобы её лицевая сторона была направлена прямо на камеру
 function orientCardFaceTowardCamera(card, camera) {
   if (!card || !camera) return;
@@ -73,11 +83,12 @@ function gatherMeshMaterials(root, sink = []) {
 }
 
 // Плавно перестраивает текущие карты в руке перед добавлением новой
-function relayoutHandDuringDraw(handMeshes, totalAfter, duration) {
+function relayoutHandDuringDraw(handMeshes, layoutAfterDraw, duration) {
   if (!Array.isArray(handMeshes) || handMeshes.length === 0) return;
 
   handMeshes.forEach((mesh, idx) => {
-    const t = computeHandTransform(idx, totalAfter);
+    const t = layoutAfterDraw?.[idx];
+    if (!t) return;
     gsap.to(mesh.position, {
       x: t.position.x,
       y: t.position.y,
@@ -228,20 +239,28 @@ export async function animateDrawnCardToHand(cardTpl) {
   const totalVisible = Math.max(0, handMeshes.length);
   const totalAfter = totalVisible + 1;
   const indexAfter = totalAfter - 1;
-  const target = computeHandTransform(indexAfter, totalAfter);
+  const layoutAfterDraw = computeHandLayout(totalAfter);
+  const target = layoutAfterDraw[indexAfter] || computeHandTransform(indexAfter, totalAfter);
 
   try {
-    relayoutHandDuringDraw(handMeshes, totalAfter, revealDuration);
+    relayoutHandDuringDraw(handMeshes, layoutAfterDraw, revealDuration);
   } catch {}
 
+  const arrivalRotation = target.rotation.clone();
   const flightRotation = target.rotation.clone();
   try {
+    // Небольшой наклон во время полёта (финальный угол берётся из раскладки руки)
     applyEulerDegreeOffsets(flightRotation, {
       pitchDeg: T.pitchDeg || 0,
       yawDeg: T.yawDeg || 0,
       rollDeg: T.rollDeg || 0
     });
   } catch {}
+
+  // Запускаем финальное выравнивание угла заранее, чтобы оно шло в полёте
+  const rotationLead = Math.max(0, Math.min(flightDuration, (T.rotationLead ?? 0.5)));
+  const settleStartTime = Math.max(0, flightDuration - rotationLead);
+  const leanDuration = Math.max(0, settleStartTime);
 
   try {
     await new Promise(resolve => {
@@ -253,27 +272,54 @@ export async function animateDrawnCardToHand(cardTpl) {
         ease: 'power2.out'
       });
 
+      tl.addLabel('flightMotion');
+
       tl.to(big.position, {
         x: target.position.x,
         y: target.position.y,
         z: target.position.z,
         duration: flightDuration,
         ease: 'power2.inOut'
-      })
-        .to(big.rotation, {
-          x: flightRotation.x,
-          y: flightRotation.y,
-          z: flightRotation.z,
-          duration: flightDuration,
-          ease: 'power2.inOut'
-        }, '<')
+      }, 'flightMotion')
         .to(big.scale, {
           x: target.scale.x,
           y: target.scale.y,
           z: target.scale.z,
           duration: flightDuration,
           ease: 'power2.inOut'
-        }, '<');
+        }, 'flightMotion');
+
+      if (leanDuration > 0.0001) {
+        tl.to(big.rotation, {
+          x: flightRotation.x,
+          y: flightRotation.y,
+          z: flightRotation.z,
+          duration: leanDuration,
+          ease: 'power2.inOut'
+        }, 'flightMotion');
+      } else {
+        tl.set(big.rotation, {
+          x: flightRotation.x,
+          y: flightRotation.y,
+          z: flightRotation.z
+        }, 'flightMotion');
+      }
+
+      if (rotationLead > 0.0001) {
+        tl.to(big.rotation, {
+          x: arrivalRotation.x,
+          y: arrivalRotation.y,
+          z: arrivalRotation.z,
+          duration: rotationLead,
+          ease: 'power1.out'
+        }, `flightMotion+=${settleStartTime}`);
+      } else {
+        tl.set(big.rotation, {
+          x: arrivalRotation.x,
+          y: arrivalRotation.y,
+          z: arrivalRotation.z
+        }, `flightMotion+=${settleStartTime}`);
+      }
     });
   } catch {}
 


### PR DESCRIPTION
## Summary
- запускаю финальное выравнивание угла прилетающей карты ещё во время полёта
- управляю фазой наклона через отдельную метку таймлайна, чтобы избежать рывков при смене твинов
- сохраняю возможность настраивать тайминг через DRAW_CARD_TUNE.rotationLead

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf8a14ba588330ae86a07020ca5563