### PR TITLE
Start final rotation earlier during draw

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -25,6 +25,16 @@ function computeHandTransform(index, total) {
   return { position: pos, rotation: rot, scale };
 }
 
+// Предварительно вычисляет целиком раскладку руки для указанного количества карт
+function computeHandLayout(total) {
+  const layout = [];
+  const count = Math.max(0, total);
+  for (let i = 0; i < count; i++) {
+    layout.push(computeHandTransform(i, count));
+  }
+  return layout;
+}
+
 // Разворачивает карту так, чтобы её лицевая сторона была направлена прямо на камеру
 function orientCardFaceTowardCamera(card, camera) {
   if (!card || !camera) return;
@@ -73,11 +83,12 @@ function gatherMeshMaterials(root, sink = []) {
 }
 
 // Плавно перестраивает текущие карты в руке перед добавлением новой
-function relayoutHandDuringDraw(handMeshes, totalAfter, duration) {
+function relayoutHandDuringDraw(handMeshes, layoutAfterDraw, duration) {
   if (!Array.isArray(handMeshes) || handMeshes.length === 0) return;
 
   handMeshes.forEach((mesh, idx) => {
-    const t = computeHandTransform(idx, totalAfter);
+    const t = layoutAfterDraw?.[idx];
+    if (!t) return;
     gsap.to(mesh.position, {
       x: t.position.x,
       y: t.position.y,
@@ -101,6 +112,7 @@ function relayoutHandDuringDraw(handMeshes, totalAfter, duration) {
 // Базовые длительности показа и перелёта добираемой карты
 const DRAW_REVEAL_DURATION = 0.7;
 const DRAW_FLIGHT_DURATION = 0.7;
+const DRAW_ROTATION_SETTLE_LEAD = 0.5; // За сколько секунд до посадки начинаем выравнивание угла
 
 export function setHandCardHoverVisual(mesh, hovered) {
   if (!mesh) return;
@@ -228,20 +240,27 @@ export async function animateDrawnCardToHand(cardTpl) {
   const totalVisible = Math.max(0, handMeshes.length);
   const totalAfter = totalVisible + 1;
   const indexAfter = totalAfter - 1;
-  const target = computeHandTransform(indexAfter, totalAfter);
+  const layoutAfterDraw = computeHandLayout(totalAfter);
+  const target = layoutAfterDraw[indexAfter] || computeHandTransform(indexAfter, totalAfter);
 
   try {
-    relayoutHandDuringDraw(handMeshes, totalAfter, revealDuration);
+    relayoutHandDuringDraw(handMeshes, layoutAfterDraw, revealDuration);
   } catch {}
 
+  const arrivalRotation = target.rotation.clone();
   const flightRotation = target.rotation.clone();
   try {
+    // Небольшой наклон во время полёта (финальный угол берётся из раскладки руки)
     applyEulerDegreeOffsets(flightRotation, {
       pitchDeg: T.pitchDeg || 0,
       yawDeg: T.yawDeg || 0,
       rollDeg: T.rollDeg || 0
     });
   } catch {}
+
+  const settleLead = Math.min(flightDuration, DRAW_ROTATION_SETTLE_LEAD);
+  const approachDuration = Math.max(0, flightDuration - settleLead);
+  const settleDuration = Math.max(0, settleLead);
 
   try {
     await new Promise(resolve => {
@@ -259,21 +278,43 @@ export async function animateDrawnCardToHand(cardTpl) {
         z: target.position.z,
         duration: flightDuration,
         ease: 'power2.inOut'
-      })
-        .to(big.rotation, {
+      });
+
+      if (approachDuration > 0.0001) {
+        tl.to(big.rotation, {
           x: flightRotation.x,
           y: flightRotation.y,
           z: flightRotation.z,
-          duration: flightDuration,
-          ease: 'power2.inOut'
-        }, '<')
-        .to(big.scale, {
-          x: target.scale.x,
-          y: target.scale.y,
-          z: target.scale.z,
-          duration: flightDuration,
+          duration: approachDuration,
           ease: 'power2.inOut'
         }, '<');
+      } else {
+        tl.add(() => {
+          big.rotation.copy(flightRotation);
+        }, '<');
+      }
+
+      tl.to(big.scale, {
+        x: target.scale.x,
+        y: target.scale.y,
+        z: target.scale.z,
+        duration: flightDuration,
+        ease: 'power2.inOut'
+      }, '<');
+
+      if (settleDuration > 0.0001) {
+        tl.to(big.rotation, {
+          x: arrivalRotation.x,
+          y: arrivalRotation.y,
+          z: arrivalRotation.z,
+          duration: settleDuration,
+          ease: 'power1.out'
+        }, `-=${settleDuration}`);
+      } else {
+        tl.add(() => {
+          big.rotation.copy(arrivalRotation);
+        });
+      }
     });
   } catch {}
 


### PR DESCRIPTION
## Summary
- begin the final rotation alignment half a second before the card finishes its flight
- keep the initial lean stage only when there is remaining time before the settle phase
- ensure the drawn card still reaches the predicted final rotation without abrupt snapping

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf8a14ba588330ae86a07020ca5563