### PR TITLE
Adjust draw card animation timing

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -225,7 +225,8 @@ export async function animateDrawnCardToHand(cardTpl) {
     rollDeg: T.initialRollDeg ?? 0
   });
 
-  big.scale.set((T.scale ?? 1.7), (T.scale ?? 1.7), (T.scale ?? 1.7));
+  // Поддерживаем более компактное появление карты при доборе
+  big.scale.set((T.scale ?? 1.5), (T.scale ?? 1.5), (T.scale ?? 1.5));
   big.renderOrder = 9000;
 
   const allMaterials = gatherMeshMaterials(big, []);
@@ -257,8 +258,8 @@ export async function animateDrawnCardToHand(cardTpl) {
     });
   } catch {}
 
-  // Запускаем финальное выравнивание угла заранее, чтобы оно шло в полёте
-  const rotationLead = Math.max(0, Math.min(flightDuration, (T.rotationLead ?? 0.5)));
+  // Запускаем финальное выравнивание угла заранее, чтобы оно шло в полёте (по умолчанию последние 0.4 секунды)
+  const rotationLead = Math.max(0, Math.min(flightDuration, (T.rotationLead ?? 0.4)));
   const settleStartTime = Math.max(0, flightDuration - rotationLead);
   const leanDuration = Math.max(0, settleStartTime);
 


### PR DESCRIPTION
## Summary
- скорректирована анимация добора карты: финальное выравнивание начинается за 0.4 секунды до окончания перелёта
- уменьшен базовый масштаб карты при появлении в начале хода до 1.5

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cfa8ea8e4083309d2cfea7e60dc5d0