### PR TITLE
Добавить текстуру боковых граней тайлов поля

### DIFF
--- a/src/scene/context.js
+++ b/src/scene/context.js
@@ -24,6 +24,9 @@ const ctx = {
   // Textures cache
   TILE_TEXTURES: {},
   PROC_TILE_TEXTURES: {},
+  // Кэш боковой текстуры и материала тайлов поля
+  TILE_SIDE_TEXTURE: null,
+  TILE_SIDE_MATERIAL: null,
 };
 
 export function getCtx() { return ctx; }


### PR DESCRIPTION
## Summary
- добавлен переиспользуемый загрузчик боковой текстуры и материал для тайлов поля
- обновлено построение и обновление тайлов, чтобы использовать отдельные материалы для верхней и боковых граней
- расширен контекст сцены кэшем боковой текстуры

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfbae4318883309baaf079a7d377bb