### PR TITLE
Add side textures to board tiles

### DIFF
--- a/src/scene/context.js
+++ b/src/scene/context.js
@@ -24,6 +24,7 @@ const ctx = {
   // Textures cache
   TILE_TEXTURES: {},
   PROC_TILE_TEXTURES: {},
+  TILE_SIDE_TEXTURE: null,
 };
 
 export function getCtx() { return ctx; }


### PR DESCRIPTION
## Summary
- load and cache a shared texture for tile side faces
- construct board tiles with dedicated materials for top, sides, and bottom faces
- refresh existing tiles once the side texture finishes loading

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfbae4318883309baaf079a7d377bb