### PR TITLE
Добавлены карты Dragon of Voice Sea и Tritonan Ice Guard

### DIFF
--- a/src/core/abilityHandlers/allySummon.js
+++ b/src/core/abilityHandlers/allySummon.js
@@ -1,0 +1,99 @@
+// Реакции на призыв союзников рядом с источником (чистая логика)
+// Модуль не зависит от визуальных компонентов, чтобы упростить перенос на Unity
+import { CARDS } from '../cards.js';
+import { DIR_VECTORS, inBounds } from '../constants.js';
+import { drawCards } from './draw.js';
+
+function toUpper(value) {
+  if (!value) return null;
+  return String(value).toUpperCase();
+}
+
+function safeAmount(value, fallback = 1) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.floor(value));
+  }
+  if (value === true) return 1;
+  if (value === false || value == null) return Math.max(0, Math.floor(fallback));
+  return Math.max(0, Math.floor(fallback));
+}
+
+function normalizeAdjacentDrawConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) return { amount: 1 };
+  if (typeof raw === 'number') return { amount: safeAmount(raw) };
+  if (typeof raw === 'object') {
+    const amount = safeAmount(raw.amount ?? raw.count ?? 1);
+    const requireSourceField = toUpper(raw.requireSourceField || raw.sourceField || raw.requireField);
+    const forbidSourceField = toUpper(raw.forbidSourceField || raw.excludeSourceField || raw.sourceFieldNot || raw.forbidField);
+    const requireSummonedField = toUpper(raw.requireSummonedField || raw.targetField || raw.requireSummonField);
+    const forbidSummonedField = toUpper(raw.forbidSummonedField || raw.excludeSummonedField || raw.forbidSummonField);
+    const reason = raw.reason ? String(raw.reason) : null;
+    return {
+      amount,
+      requireSourceField,
+      forbidSourceField,
+      requireSummonedField,
+      forbidSummonedField,
+      reason,
+    };
+  }
+  return null;
+}
+
+function getTemplate(unit) {
+  if (!unit) return null;
+  return CARDS[unit.tplId] || null;
+}
+
+export function applyAdjacentAllySummonDraw(state, context = {}) {
+  const result = { total: 0, details: [] };
+  if (!state?.board) return result;
+  const { r, c, unit } = context;
+  if (typeof r !== 'number' || typeof c !== 'number') return result;
+  if (!unit) return result;
+  const owner = unit.owner;
+  if (owner == null) return result;
+  const summonField = state.board?.[r]?.[c]?.element || null;
+
+  for (const vec of Object.values(DIR_VECTORS)) {
+    const nr = r + vec[0];
+    const nc = c + vec[1];
+    if (!inBounds(nr, nc)) continue;
+    const neighbor = state.board?.[nr]?.[nc]?.unit;
+    if (!neighbor || neighbor.owner !== owner) continue;
+    const tpl = getTemplate(neighbor);
+    if (!tpl) continue;
+    const cfg = normalizeAdjacentDrawConfig(tpl.drawOnAdjacentAllySummon || tpl.drawOnAllySummonAdjacent);
+    if (!cfg || cfg.amount <= 0) continue;
+
+    const sourceField = state.board?.[nr]?.[nc]?.element || null;
+    if (cfg.requireSourceField && sourceField !== cfg.requireSourceField) continue;
+    if (cfg.forbidSourceField && sourceField === cfg.forbidSourceField) continue;
+    if (cfg.requireSummonedField && summonField !== cfg.requireSummonedField) continue;
+    if (cfg.forbidSummonedField && summonField === cfg.forbidSummonedField) continue;
+
+    const drawn = drawCards(state, owner, cfg.amount);
+    if (!drawn.drawn) continue;
+
+    result.total += drawn.drawn;
+    result.details.push({
+      amount: drawn.drawn,
+      cards: drawn.cards,
+      element: sourceField,
+      reason: cfg.reason || 'ADJACENT_ALLY_SUMMON',
+      source: {
+        type: 'ADJACENT_ALLY_SUMMON',
+        r: nr,
+        c: nc,
+        tplId: tpl?.id || neighbor.tplId,
+      },
+    });
+  }
+
+  return result;
+}
+
+export default {
+  applyAdjacentAllySummonDraw,
+};

--- a/src/core/abilityHandlers/dynamicAttack.js
+++ b/src/core/abilityHandlers/dynamicAttack.js
@@ -1,0 +1,51 @@
+// Логика динамического изменения атаки существ (чистая логика без визуала)
+import { CARDS } from '../cards.js';
+import { countUnits } from '../board.js';
+
+const ELEMENT_DYNAMIC_MAP = {
+  FIRE_CREATURES: 'FIRE',
+  FOREST_CREATURES: 'FOREST',
+  WATER_CREATURES: 'WATER',
+};
+
+function countElementCreatures(state, element, exclude) {
+  if (!state?.board) return 0;
+  let count = 0;
+  for (let r = 0; r < state.board.length; r += 1) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c += 1) {
+      if (exclude && exclude.r === r && exclude.c === c) continue;
+      const unit = row[c]?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (tpl?.element === element) count += 1;
+    }
+  }
+  return count;
+}
+
+export function computeDynamicAttackBonuses(state, r, c, tpl) {
+  const bonuses = [];
+  if (!tpl || !tpl.dynamicAtk) return bonuses;
+  const key = tpl.dynamicAtk;
+  if (key === 'OTHERS_ON_BOARD') {
+    const total = Math.max(0, countUnits(state) - 1);
+    if (total > 0) {
+      bonuses.push({ amount: total, reason: 'OTHERS_ON_BOARD' });
+    }
+    return bonuses;
+  }
+  const element = ELEMENT_DYNAMIC_MAP[key];
+  if (element) {
+    const count = countElementCreatures(state, element, { r, c });
+    if (count > 0) {
+      bonuses.push({ amount: count, reason: key, element });
+    }
+  }
+  return bonuses;
+}
+
+export default {
+  computeDynamicAttackBonuses,
+};

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -205,6 +205,27 @@ export const CARDS = {
     desc: 'Dodge attempt. When Cloud Runner is summoned, draw cards equal to the number of Water fields.'
   },
 
+  WATER_TRITONAN_ICE_GUARD: {
+    id: 'WATER_TRITONAN_ICE_GUARD', name: 'Tritonan Ice Guard', type: 'UNIT', cost: 1, activation: 1,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    drawCardsOnSummon: { amount: 1, requireFieldNot: 'WATER' },
+    desc: 'When Tritonan Ice Guard is summoned to a non-Water field, draw a card.'
+  },
+
+  WATER_DRAGON_OF_VOICE_SEA: {
+    id: 'WATER_DRAGON_OF_VOICE_SEA', name: 'Dragon of Voice Sea', type: 'UNIT', cost: 7, activation: 4,
+    element: 'WATER', atk: 5, hp: 8,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY', ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    dynamicAtk: 'WATER_CREATURES',
+    drawOnAdjacentAllySummon: { amount: 1, requireSourceField: 'WATER' },
+    desc: 'Attack = 5 plus the number of other Water creatures on the board. While Dragon of Voice Sea is on a Water field, if you summon a creature to an adjacent field, draw a card.'
+  },
+
   WATER_DON_OF_VENOA: {
     id: 'WATER_DON_OF_VENOA', name: 'Don of Venoa', type: 'UNIT', cost: 5, activation: 3,
     element: 'WATER', atk: 2, hp: 3,


### PR DESCRIPTION
## Summary
- добавлены карточки Dragon of Voice Sea и Tritonan Ice Guard вместе с их шаблонами
- вынесена логика динамической атаки и реакций на призыв союзников в отдельные обработчики
- расширена система добора карт, чтобы поддерживать новые условия, и доработаны события призыва
- покрыты новые механики тестами для водных карт

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d759fbb88330b0f6854c8c9b2a70