### PR TITLE
Add Dragon of Voice Sea and Tritonan Ice Guard

### DIFF
--- a/src/core/abilityHandlers/attackScaling.js
+++ b/src/core/abilityHandlers/attackScaling.js
@@ -1,0 +1,132 @@
+// Модуль вычисления динамических бонусов к атаке (чистая логика)
+// Здесь нет зависимостей от визуального слоя, чтобы упростить миграцию на Unity
+import { CARDS } from '../cards.js';
+import { countUnits } from '../board.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+function isSamePosition(a, b) {
+  return a && b && a.r === b.r && a.c === b.c;
+}
+
+function unitMatchesOwner(unit, ownerMode, ownerId) {
+  if (!unit) return false;
+  if (ownerMode === 'ANY' || ownerMode == null) return true;
+  if (ownerId == null) return false;
+  if (ownerMode === 'ALLY') return unit.owner === ownerId;
+  if (ownerMode === 'ENEMY') return unit.owner !== ownerId;
+  return true;
+}
+
+function countCreaturesByElement(state, element, opts = {}) {
+  if (!state?.board || !element) return 0;
+  const includeSelf = !!opts.includeSelf;
+  const ownerMode = opts.ownerMode || 'ANY';
+  const origin = opts.origin || null;
+  let count = 0;
+  for (let r = 0; r < state.board.length; r += 1) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c += 1) {
+      const cell = row[c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      if (!includeSelf && origin && isSamePosition(origin, { r, c })) continue;
+      if (!unitMatchesOwner(unit, ownerMode, opts.ownerId)) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      if (normalizeElementName(tpl.element) !== element) continue;
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function parseElementScope(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const element = normalizeElementName(raw);
+    if (!element) return null;
+    return { element, ownerMode: 'ANY', includeSelf: false };
+  }
+  if (typeof raw === 'object') {
+    const element = normalizeElementName(raw.element || raw.type || raw.kind || raw.elementType);
+    if (!element) return null;
+    const includeSelf = !!raw.includeSelf;
+    const owner = String(raw.owner || raw.side || 'ANY').toUpperCase();
+    const ownerMode = owner === 'ALLY' || owner === 'ENEMY' ? owner : 'ANY';
+    return {
+      element,
+      includeSelf,
+      ownerMode,
+    };
+  }
+  return null;
+}
+
+function normalizeConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    if (raw === 'OTHERS_ON_BOARD') {
+      return { type: 'OTHERS_ON_BOARD' };
+    }
+    if (raw.endsWith('_CREATURES')) {
+      const code = raw.slice(0, -'_CREATURES'.length);
+      const element = normalizeElementName(code);
+      if (!element) return null;
+      return { type: 'ELEMENT_CREATURES', element, includeSelf: false, ownerMode: 'ANY' };
+    }
+    const parts = raw.split(':');
+    if (parts[0] === 'ELEMENT' && parts[1]) {
+      const element = normalizeElementName(parts[1]);
+      if (!element) return null;
+      return { type: 'ELEMENT_CREATURES', element, includeSelf: parts[2] === 'INCLUDE_SELF', ownerMode: 'ANY' };
+    }
+    return null;
+  }
+  if (typeof raw === 'object') {
+    const type = String(raw.type || raw.kind || raw.mode || '').toUpperCase();
+    if (type === 'OTHERS_ON_BOARD') {
+      return { type: 'OTHERS_ON_BOARD' };
+    }
+    if (type === 'TOTAL_UNITS' || raw.allUnits) {
+      return { type: 'OTHERS_ON_BOARD', includeSelf: !!raw.includeSelf };
+    }
+    if (type === 'ELEMENT_CREATURES' || raw.element) {
+      const scope = parseElementScope(raw.scope || raw.element || raw);
+      if (!scope) return null;
+      return { type: 'ELEMENT_CREATURES', ...scope };
+    }
+  }
+  return null;
+}
+
+export function computeDynamicAttackBonus(state, r, c, tpl, opts = {}) {
+  if (!tpl) return null;
+  const cfg = normalizeConfig(tpl.dynamicAtk);
+  if (!cfg) return null;
+  if (cfg.type === 'OTHERS_ON_BOARD') {
+    const total = Math.max(0, countUnits(state) - (cfg.includeSelf ? 0 : 1));
+    if (total <= 0) return null;
+    return {
+      amount: total,
+      reason: { type: 'OTHERS_ON_BOARD' },
+    };
+  }
+  if (cfg.type === 'ELEMENT_CREATURES') {
+    const element = cfg.element;
+    if (!element) return null;
+    const ownerMode = cfg.ownerMode || 'ANY';
+    const includeSelf = !!cfg.includeSelf;
+    const ownerId = opts.unit?.owner ?? opts.owner ?? null;
+    const origin = { r, c };
+    const count = countCreaturesByElement(state, element, { ownerMode, includeSelf, ownerId, origin });
+    if (count <= 0) return null;
+    return {
+      amount: count,
+      reason: { type: 'ELEMENT_CREATURES', element, ownerMode, includeSelf },
+    };
+  }
+  return null;
+}
+
+export default { computeDynamicAttackBonus };

--- a/src/core/abilityHandlers/draw.js
+++ b/src/core/abilityHandlers/draw.js
@@ -1,24 +1,27 @@
 // Модуль обработки эффектов добора карт при призыве существ
-// Вся логика изолирована от визуального слоя, чтобы облегчить перенос на другие движки
+// Логика полностью отделена от визуальной части, чтобы упростить перенос на другие движки
+import { CARDS } from '../cards.js';
 import { drawOneNoAdd } from '../board.js';
+import { normalizeElementName, normalizeElementSet } from '../utils/elements.js';
 
-function normalizeConfig(raw) {
+function normalizeFieldDrawConfig(raw) {
   if (!raw) return null;
   if (typeof raw === 'string') {
-    return { element: raw.toUpperCase() };
+    const element = normalizeElementName(raw);
+    if (!element) return null;
+    return { element, limit: null, includeSelf: true, includeCenter: true, min: 0 };
   }
   if (typeof raw === 'object') {
-    const element = raw.element || raw.field || raw.elementType;
-    const limit = raw.limit || raw.max || null;
-    const includeSelf = raw.includeSelf !== false;
-    const includeCenter = raw.includeCenter !== false;
-    const min = raw.min || raw.minimum || 0;
+    const element = normalizeElementName(raw.element || raw.field || raw.elementType);
+    if (!element) return null;
+    const limitRaw = raw.limit ?? raw.max ?? raw.maximum ?? null;
+    const minRaw = raw.min ?? raw.minimum ?? 0;
     return {
-      element: element ? String(element).toUpperCase() : null,
-      limit: typeof limit === 'number' && Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : null,
-      includeSelf,
-      includeCenter,
-      min: typeof min === 'number' && Number.isFinite(min) ? Math.max(0, Math.floor(min)) : 0,
+      element,
+      limit: Number.isFinite(limitRaw) ? Math.max(0, Math.floor(limitRaw)) : null,
+      includeSelf: raw.includeSelf !== false,
+      includeCenter: raw.includeCenter !== false,
+      min: Number.isFinite(minRaw) ? Math.max(0, Math.floor(minRaw)) : 0,
     };
   }
   return null;
@@ -28,11 +31,11 @@ function countMatchingFields(state, cfg) {
   if (!state?.board) return 0;
   const element = cfg?.element || null;
   let count = 0;
-  for (let r = 0; r < 3; r++) {
-    for (let c = 0; c < 3; c++) {
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
       if (!cfg.includeCenter && r === 1 && c === 1) continue;
       if (!cfg.includeSelf && r === cfg?.self?.r && c === cfg?.self?.c) continue;
-      const cellEl = state.board?.[r]?.[c]?.element || null;
+      const cellEl = normalizeElementName(state.board?.[r]?.[c]?.element || null);
       if (element && cellEl !== element) continue;
       count += 1;
     }
@@ -40,26 +43,92 @@ function countMatchingFields(state, cfg) {
   return count;
 }
 
-export function computeSummonDraw(state, r, c, tpl) {
-  if (!tpl) return null;
-  const cfgRaw = tpl.drawOnSummonByElementFields || tpl.drawCardsOnSummon;
-  const cfg = normalizeConfig(cfgRaw);
-  if (!cfg || !cfg.element) return null;
+function normalizeDrawCondition(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const el = normalizeElementName(raw);
+    return el ? { cellElement: el } : null;
+  }
+  if (typeof raw === 'object') {
+    const cond = {};
+    const cellElement = normalizeElementName(raw.cellElement || raw.element || raw.field || raw.fieldElement);
+    if (cellElement) cond.cellElement = cellElement;
+    const cellElementNot = normalizeElementName(raw.cellElementNot || raw.notElement || raw.notField || raw.exclude);
+    if (cellElementNot) cond.cellElementNot = cellElementNot;
+    const includeSet = normalizeElementSet(raw.cellElementIn || raw.allowedElements || raw.elements || raw.oneOf);
+    if (includeSet.size) cond.cellElementIn = includeSet;
+    const excludeSet = normalizeElementSet(raw.cellElementNotIn || raw.excludeElements || raw.notIn);
+    if (excludeSet.size) cond.cellElementNotIn = excludeSet;
+    return Object.keys(cond).length ? cond : null;
+  }
+  return null;
+}
+
+function normalizeDirectDrawConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'number') {
+    if (!Number.isFinite(raw)) return null;
+    return { amount: Math.max(0, Math.floor(raw)), min: 0, limit: null, condition: null };
+  }
+  if (raw === true) {
+    return { amount: 1, min: 0, limit: null, condition: null };
+  }
+  if (typeof raw === 'object') {
+    const amountRaw = raw.amount ?? raw.count ?? raw.cards ?? raw.value ?? raw.draw ?? 1;
+    const limitRaw = raw.limit ?? raw.max ?? raw.maximum ?? null;
+    const minRaw = raw.min ?? raw.minimum ?? 0;
+    const amount = Number.isFinite(amountRaw) ? Math.max(0, Math.floor(amountRaw)) : 0;
+    return {
+      amount,
+      limit: Number.isFinite(limitRaw) ? Math.max(0, Math.floor(limitRaw)) : null,
+      min: Number.isFinite(minRaw) ? Math.max(0, Math.floor(minRaw)) : 0,
+      condition: normalizeDrawCondition(raw.condition || raw.when || raw.if),
+    };
+  }
+  return null;
+}
+
+function evaluateDirectCondition(state, r, c, cond) {
+  if (!cond) return true;
+  const cellElement = normalizeElementName(state?.board?.[r]?.[c]?.element || null);
+  if (cond.cellElement && cellElement !== cond.cellElement) return false;
+  if (cond.cellElementNot && cellElement === cond.cellElementNot) return false;
+  if (cond.cellElementIn && cond.cellElementIn.size && !cond.cellElementIn.has(cellElement)) return false;
+  if (cond.cellElementNotIn && cond.cellElementNotIn.has(cellElement)) return false;
+  return true;
+}
+
+function computeFieldDraw(state, r, c, cfg) {
+  if (!cfg?.element) return null;
   const count = countMatchingFields(state, { ...cfg, self: { r, c } });
   const limited = cfg.limit != null ? Math.min(cfg.limit, count) : count;
   const amount = Math.max(cfg.min || 0, limited);
   if (amount <= 0) return null;
-  return { element: cfg.element, amount };
+  return {
+    amount,
+    reason: { type: 'FIELD_COUNT', element: cfg.element, counted: count },
+  };
 }
 
-export function applySummonDraw(state, r, c, unit, tpl) {
-  const info = computeSummonDraw(state, r, c, tpl);
-  if (!info || !unit) return { drawn: 0, cards: [] };
-  const owner = unit.owner;
-  if (owner == null || !state?.players?.[owner]) return { drawn: 0, cards: [] };
+function computeDirectDraw(state, r, c, cfg) {
+  if (!cfg) return null;
+  if (!evaluateDirectCondition(state, r, c, cfg.condition)) return null;
+  const limit = cfg.limit != null ? Math.max(0, Math.floor(cfg.limit)) : null;
+  const amountBase = Math.max(cfg.min || 0, cfg.amount || 0);
+  const amount = limit != null ? Math.min(limit, amountBase) : amountBase;
+  if (amount <= 0) return null;
+  return {
+    amount,
+    reason: { type: 'DIRECT', condition: cfg.condition || null },
+  };
+}
+
+function drawCardsForPlayer(state, owner, amount) {
+  if (!state?.players || owner == null) return { drawn: 0, cards: [] };
   const player = state.players[owner];
+  if (!player) return { drawn: 0, cards: [] };
   const drawn = [];
-  for (let i = 0; i < info.amount; i++) {
+  for (let i = 0; i < amount; i += 1) {
     const card = drawOneNoAdd(state, owner);
     if (!card) break;
     player.hand.push(card);
@@ -67,3 +136,120 @@ export function applySummonDraw(state, r, c, unit, tpl) {
   }
   return { drawn: drawn.length, cards: drawn };
 }
+
+export function computeSummonDraw(state, r, c, tpl) {
+  if (!tpl) return null;
+  const fieldCfg = normalizeFieldDrawConfig(tpl.drawOnSummonByElementFields);
+  if (fieldCfg) {
+    const info = computeFieldDraw(state, r, c, fieldCfg);
+    if (info) return info;
+  }
+  const directCfg = normalizeDirectDrawConfig(tpl.drawCardsOnSummon);
+  if (directCfg) {
+    const info = computeDirectDraw(state, r, c, directCfg);
+    if (info) return info;
+  }
+  return null;
+}
+
+export function applySummonDraw(state, r, c, unit, tpl) {
+  const info = computeSummonDraw(state, r, c, tpl);
+  if (!info || !unit) return { drawn: 0, cards: [], reason: null };
+  const res = drawCardsForPlayer(state, unit.owner, info.amount);
+  return { ...res, reason: info.reason };
+}
+
+function isUnitAlive(unit, tpl) {
+  if (!unit || !tpl) return false;
+  if (typeof unit.currentHP === 'number') return unit.currentHP > 0;
+  if (typeof tpl.hp === 'number') return tpl.hp > 0;
+  return true;
+}
+
+function isAdjacent(r1, c1, r2, c2) {
+  if (!Number.isInteger(r1) || !Number.isInteger(c1) || !Number.isInteger(r2) || !Number.isInteger(c2)) return false;
+  return Math.abs(r1 - r2) + Math.abs(c1 - c2) === 1;
+}
+
+function normalizeAdjacentDrawConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'number') {
+    if (!Number.isFinite(raw)) return null;
+    return { amount: Math.max(0, Math.floor(raw)), ownerMode: 'ALLY' };
+  }
+  if (raw === true) {
+    return { amount: 1, ownerMode: 'ALLY' };
+  }
+  if (typeof raw === 'object') {
+    const amountRaw = raw.amount ?? raw.count ?? raw.cards ?? 1;
+    const ownerCode = String(raw.owner || raw.scope || raw.ownerMode || 'ALLY').toUpperCase();
+    const ownerMode = ownerCode === 'ENEMY' ? 'ENEMY' : 'ALLY';
+    const sourceElement = normalizeElementName(raw.sourceElement || raw.sourceOnElement || raw.selfElement || raw.field || raw.element);
+    const sourceElementNot = normalizeElementName(raw.sourceElementNot || raw.notSourceElement);
+    const summonFieldElement = normalizeElementName(raw.summonFieldElement || raw.targetField || raw.summonField);
+    const summonFieldNot = normalizeElementName(raw.summonFieldNot || raw.notSummonField);
+    const amount = Number.isFinite(amountRaw) ? Math.max(0, Math.floor(amountRaw)) : 0;
+    return {
+      amount,
+      ownerMode,
+      sourceElement,
+      sourceElementNot,
+      summonFieldElement,
+      summonFieldNot,
+    };
+  }
+  return null;
+}
+
+export function applyAdjacentAllySummonDraws(state, context = {}) {
+  const result = { draws: [] };
+  if (!state?.board) return result;
+  const { r, c, unit } = context;
+  if (!Number.isInteger(r) || !Number.isInteger(c) || !unit) return result;
+  const ownerSummoned = unit.owner;
+  if (ownerSummoned == null) return result;
+  const tplSummoned = context.tpl || CARDS[unit.tplId] || null;
+
+  for (let rr = 0; rr < state.board.length; rr += 1) {
+    for (let cc = 0; cc < state.board[rr].length; cc += 1) {
+      if (!isAdjacent(rr, cc, r, c)) continue;
+      const watcherCell = state.board?.[rr]?.[cc];
+      const watcher = watcherCell?.unit;
+      if (!watcher) continue;
+      const tplWatcher = CARDS[watcher.tplId];
+      if (!tplWatcher) continue;
+      const cfg = normalizeAdjacentDrawConfig(tplWatcher.drawOnAdjacentAllySummon);
+      if (!cfg || cfg.amount <= 0) continue;
+      if (!isUnitAlive(watcher, tplWatcher)) continue;
+      if (cfg.ownerMode === 'ALLY' && watcher.owner !== ownerSummoned) continue;
+      if (cfg.ownerMode === 'ENEMY' && watcher.owner === ownerSummoned) continue;
+      const cellElement = normalizeElementName(watcherCell?.element || null);
+      if (cfg.sourceElement && cellElement !== cfg.sourceElement) continue;
+      if (cfg.sourceElementNot && cellElement === cfg.sourceElementNot) continue;
+      const summonCellElement = normalizeElementName(state.board?.[r]?.[c]?.element || null);
+      if (cfg.summonFieldElement && summonCellElement !== cfg.summonFieldElement) continue;
+      if (cfg.summonFieldNot && summonCellElement === cfg.summonFieldNot) continue;
+      const drawRes = drawCardsForPlayer(state, watcher.owner, cfg.amount);
+      if (!drawRes.drawn) continue;
+      result.draws.push({
+        player: watcher.owner,
+        count: drawRes.drawn,
+        cards: drawRes.cards,
+        element: cellElement,
+        source: {
+          type: 'ADJACENT_ALLY_SUMMON',
+          watcher: { r: rr, c: cc, tplId: tplWatcher.id },
+          summoned: { r, c, tplId: tplSummoned?.id || unit.tplId },
+        },
+      });
+    }
+  }
+
+  return result;
+}
+
+export default {
+  computeSummonDraw,
+  applySummonDraw,
+  applyAdjacentAllySummonDraws,
+};

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -205,6 +205,27 @@ export const CARDS = {
     desc: 'Dodge attempt. When Cloud Runner is summoned, draw cards equal to the number of Water fields.'
   },
 
+  WATER_TRITONAN_ICE_GUARD: {
+    id: 'WATER_TRITONAN_ICE_GUARD', name: 'Tritonan Ice Guard', type: 'UNIT', cost: 1, activation: 1,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    drawCardsOnSummon: { amount: 1, condition: { cellElementNot: 'WATER' } },
+    desc: 'When Tritonan Ice Guard is summoned to a non-Water field, draw a card.'
+  },
+
+  WATER_DRAGON_OF_VOICE_SEA: {
+    id: 'WATER_DRAGON_OF_VOICE_SEA', name: 'Dragon of Voice Sea', type: 'UNIT', cost: 7, activation: 4,
+    element: 'WATER', atk: 5, hp: 8,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY', ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    dynamicAtk: 'WATER_CREATURES',
+    drawOnAdjacentAllySummon: { amount: 1, sourceElement: 'WATER' },
+    desc: 'Attack equals 5 plus the number of other Water creatures on the board. While on a Water field, when you summon an allied creature to an adjacent field, draw a card.'
+  },
+
   WATER_DON_OF_VENOA: {
     id: 'WATER_DON_OF_VENOA', name: 'Don of Venoa', type: 'UNIT', cost: 5, activation: 3,
     element: 'WATER', atk: 2, hp: 3,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -19,8 +19,8 @@ import {
   applyDamageInteractionResults,
   resolveAttackProfile,
   refreshBoardDodgeStates,
+  computeDynamicAttackBonus,
 } from './abilities.js';
-import { countUnits } from './board.js';
 import { computeCellBuff } from './fieldEffects.js';
 import { normalizeElementName } from './utils/elements.js';
 
@@ -288,34 +288,16 @@ export function stagedAttack(state, r, c, opts = {}) {
   const hitsRaw = computeHits(base, r, c, { ...opts, profile });
   if (!hitsRaw.length) return { empty: true };
 
-  if (tplA.dynamicAtk === 'OTHERS_ON_BOARD') {
-    const others = countUnits(base) - 1;
-    atk += others;
-    logLines.push(`${tplA.name}: атака увеличена на ${others}`);
-  }
-  if (tplA.dynamicAtk === 'FIRE_CREATURES') {
-    let cnt = 0;
-    for (let rr = 0; rr < 3; rr++) {
-      for (let cc = 0; cc < 3; cc++) {
-        if (rr === r && cc === c) continue;
-        const u = base.board[rr][cc]?.unit;
-        if (u && CARDS[u.tplId]?.element === 'FIRE') cnt++;
-      }
+  const dynamicBonus = computeDynamicAttackBonus(base, r, c, tplA, { unit: attacker });
+  if (dynamicBonus?.amount) {
+    atk += dynamicBonus.amount;
+    const reason = dynamicBonus.reason || {};
+    if (reason.type === 'ELEMENT_CREATURES') {
+      const el = reason.element || 'UNKNOWN';
+      logLines.push(`${tplA.name}: +${dynamicBonus.amount} ATK за других существ стихии ${el}`);
+    } else {
+      logLines.push(`${tplA.name}: атака увеличена на ${dynamicBonus.amount}`);
     }
-    atk += cnt;
-    logLines.push(`${tplA.name}: атака увеличена на ${cnt}`);
-  }
-  if (tplA.dynamicAtk === 'FOREST_CREATURES') {
-    let cnt = 0;
-    for (let rr = 0; rr < 3; rr++) {
-      for (let cc = 0; cc < 3; cc++) {
-        if (rr === r && cc === c) continue;
-        const u = base.board[rr][cc]?.unit;
-        if (u && CARDS[u.tplId]?.element === 'FOREST') cnt++;
-      }
-    }
-    atk += cnt;
-    logLines.push(`${tplA.name}: атака увеличена на ${cnt}`);
   }
   const targetBonus = getTargetElementBonus(tplA, base, hitsRaw);
   const plusCfg = tplA.plusAtkIfTargetOnElement || (tplA.plus1IfTargetOnElement ? { element: tplA.plus1IfTargetOnElement, amount: 1 } : null);


### PR DESCRIPTION
## Summary
- add reusable attack scaling handler for element-based bonuses and update rules to use it
- expand summon draw logic to support conditional and adjacent ally triggers and adjust UI handling
- introduce Dragon of Voice Sea and Tritonan Ice Guard cards with corresponding tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d759fbb88330b0f6854c8c9b2a70