### PR TITLE
Add Dragon of Voice Sea and Tritonan Ice Guard cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -659,7 +659,13 @@
               try { schedulePush('battle-finish', { force: true }); } catch {}
               if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
                 window.__interactions.interactionState.autoEndTurnAfterAttack = false;
-                try { endTurn(); } catch {}
+                try {
+                  if (window.__interactions?.requestAutoEndTurn) {
+                    window.__interactions.requestAutoEndTurn();
+                  } else {
+                    endTurn();
+                  }
+                } catch {}
               }
             }, 1000);
             setTimeout(() => {
@@ -676,7 +682,13 @@
           try { schedulePush('battle-finish', { force: true }); } catch {}
           if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
             window.__interactions.interactionState.autoEndTurnAfterAttack = false;
-            try { endTurn(); } catch {}
+            try {
+              if (window.__interactions?.requestAutoEndTurn) {
+                window.__interactions.requestAutoEndTurn();
+              } else {
+                endTurn();
+              }
+            } catch {}
           }
             }, Math.max(0, animDelayMs));
             setTimeout(() => {
@@ -789,7 +801,13 @@
           try { schedulePush('magic-battle-finish', { force: true }); } catch {}
           if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
             window.__interactions.interactionState.autoEndTurnAfterAttack = false;
-            try { endTurn(); } catch {}
+            try {
+              if (window.__interactions?.requestAutoEndTurn) {
+                window.__interactions.requestAutoEndTurn();
+              } else {
+                endTurn();
+              }
+            } catch {}
           }
         }, 1000);
       } else {
@@ -805,7 +823,13 @@
         try { schedulePush('magic-battle-finish', { force: true }); } catch {}
         if (window.__interactions?.interactionState?.autoEndTurnAfterAttack) {
           window.__interactions.interactionState.autoEndTurnAfterAttack = false;
-          try { endTurn(); } catch {}
+          try {
+            if (window.__interactions?.requestAutoEndTurn) {
+              window.__interactions.requestAutoEndTurn();
+            } else {
+              endTurn();
+            }
+          } catch {}
         }
       }
     }

--- a/src/core/abilityHandlers/draw.js
+++ b/src/core/abilityHandlers/draw.js
@@ -1,39 +1,67 @@
-// Модуль обработки эффектов добора карт при призыве существ
-// Вся логика изолирована от визуального слоя, чтобы облегчить перенос на другие движки
+// Модуль обработки эффектов добора карт
+// Логика отделена от визуального слоя для упрощения миграции на другие движки
 import { drawOneNoAdd } from '../board.js';
+import { DIR_VECTORS, inBounds } from '../constants.js';
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
 
-function normalizeConfig(raw) {
+function toInt(value, fallback = 0) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return Math.max(0, Math.floor(fallback));
+  return Math.max(0, Math.floor(num));
+}
+
+function drawCardsForPlayer(state, player, amount) {
+  const result = { requested: toInt(amount, 0), count: 0, cards: [] };
+  if (!state?.players || player == null) return result;
+  const pl = state.players[player];
+  if (!pl) return result;
+  const iterations = result.requested;
+  for (let i = 0; i < iterations; i += 1) {
+    const card = drawOneNoAdd(state, player);
+    if (!card) break;
+    pl.hand.push(card);
+    result.cards.push(card);
+  }
+  result.count = result.cards.length;
+  return result;
+}
+
+function normalizeFieldCountConfig(raw) {
   if (!raw) return null;
   if (typeof raw === 'string') {
-    return { element: raw.toUpperCase() };
+    const element = normalizeElementName(raw);
+    return element ? { element, includeSelf: true, includeCenter: true, limit: null, min: 0 } : null;
   }
   if (typeof raw === 'object') {
-    const element = raw.element || raw.field || raw.elementType;
-    const limit = raw.limit || raw.max || null;
+    const element = normalizeElementName(raw.element || raw.field || raw.elementType);
+    if (!element) return null;
+    const limit = raw.limit ?? raw.max ?? raw.maximum ?? null;
     const includeSelf = raw.includeSelf !== false;
     const includeCenter = raw.includeCenter !== false;
-    const min = raw.min || raw.minimum || 0;
+    const min = raw.min ?? raw.minimum ?? 0;
     return {
-      element: element ? String(element).toUpperCase() : null,
-      limit: typeof limit === 'number' && Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : null,
+      element,
       includeSelf,
       includeCenter,
-      min: typeof min === 'number' && Number.isFinite(min) ? Math.max(0, Math.floor(min)) : 0,
+      limit: limit != null ? Math.max(0, Math.floor(limit)) : null,
+      min: Math.max(0, Math.floor(min)),
     };
   }
   return null;
 }
 
 function countMatchingFields(state, cfg) {
-  if (!state?.board) return 0;
-  const element = cfg?.element || null;
+  if (!state?.board || !cfg?.element) return 0;
   let count = 0;
-  for (let r = 0; r < 3; r++) {
-    for (let c = 0; c < 3; c++) {
+  for (let r = 0; r < state.board.length; r += 1) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c += 1) {
       if (!cfg.includeCenter && r === 1 && c === 1) continue;
-      if (!cfg.includeSelf && r === cfg?.self?.r && c === cfg?.self?.c) continue;
-      const cellEl = state.board?.[r]?.[c]?.element || null;
-      if (element && cellEl !== element) continue;
+      if (!cfg.includeSelf && r === cfg.self?.r && c === cfg.self?.c) continue;
+      const cellElement = normalizeElementName(row[c]?.element);
+      if (cellElement !== cfg.element) continue;
       count += 1;
     }
   }
@@ -43,27 +71,158 @@ function countMatchingFields(state, cfg) {
 export function computeSummonDraw(state, r, c, tpl) {
   if (!tpl) return null;
   const cfgRaw = tpl.drawOnSummonByElementFields || tpl.drawCardsOnSummon;
-  const cfg = normalizeConfig(cfgRaw);
-  if (!cfg || !cfg.element) return null;
-  const count = countMatchingFields(state, { ...cfg, self: { r, c } });
-  const limited = cfg.limit != null ? Math.min(cfg.limit, count) : count;
-  const amount = Math.max(cfg.min || 0, limited);
-  if (amount <= 0) return null;
-  return { element: cfg.element, amount };
+  const cfg = normalizeFieldCountConfig(cfgRaw);
+  if (!cfg) return null;
+  const amount = countMatchingFields(state, { ...cfg, self: { r, c } });
+  const limited = cfg.limit != null ? Math.min(cfg.limit, amount) : amount;
+  const final = Math.max(cfg.min || 0, limited);
+  if (final <= 0) return null;
+  return { element: cfg.element, amount: final };
+}
+
+function normalizeOffElementConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const element = normalizeElementName(raw);
+    return element ? { element, amount: 1 } : null;
+  }
+  if (typeof raw === 'object') {
+    const element = normalizeElementName(raw.element || raw.field || raw.elementType);
+    if (!element) return null;
+    const amount = raw.amount ?? raw.count ?? raw.draw ?? raw.value ?? 1;
+    return { element, amount: Math.max(0, Math.floor(amount)) || 0 };
+  }
+  return null;
+}
+
+function createEvent(base, extra = {}) {
+  return {
+    player: base.player,
+    count: base.count,
+    requested: base.requested,
+    cards: base.cards,
+    element: base.element ?? null,
+    source: base.source || null,
+    reason: base.reason || null,
+    ...extra,
+  };
 }
 
 export function applySummonDraw(state, r, c, unit, tpl) {
-  const info = computeSummonDraw(state, r, c, tpl);
-  if (!info || !unit) return { drawn: 0, cards: [] };
+  const result = { drawn: 0, cards: [], events: [] };
+  if (!tpl || !unit) return result;
   const owner = unit.owner;
-  if (owner == null || !state?.players?.[owner]) return { drawn: 0, cards: [] };
-  const player = state.players[owner];
-  const drawn = [];
-  for (let i = 0; i < info.amount; i++) {
-    const card = drawOneNoAdd(state, owner);
-    if (!card) break;
-    player.hand.push(card);
-    drawn.push(card);
+  if (owner == null) return result;
+
+  const fieldInfo = computeSummonDraw(state, r, c, tpl);
+  if (fieldInfo && fieldInfo.amount > 0) {
+    const drawRes = drawCardsForPlayer(state, owner, fieldInfo.amount);
+    if (drawRes.count > 0) {
+      result.events.push(createEvent({
+        player: owner,
+        count: drawRes.count,
+        requested: drawRes.requested,
+        cards: drawRes.cards,
+        element: state?.board?.[r]?.[c]?.element || null,
+        source: { type: 'SELF_SUMMON', r, c, tplId: tpl.id },
+        reason: { type: 'FIELD_COUNT', element: fieldInfo.element },
+      }));
+    }
   }
-  return { drawn: drawn.length, cards: drawn };
+
+  const offElementCfg = normalizeOffElementConfig(
+    tpl.drawOnSummonIfFieldNotElement || tpl.drawOnSummonOffElement
+  );
+  if (offElementCfg && offElementCfg.amount > 0) {
+    const fieldElement = normalizeElementName(state?.board?.[r]?.[c]?.element);
+    if (!fieldElement || fieldElement !== offElementCfg.element) {
+      const drawRes = drawCardsForPlayer(state, owner, offElementCfg.amount);
+      if (drawRes.count > 0) {
+        result.events.push(createEvent({
+          player: owner,
+          count: drawRes.count,
+          requested: drawRes.requested,
+          cards: drawRes.cards,
+          element: state?.board?.[r]?.[c]?.element || null,
+          source: { type: 'SELF_SUMMON', r, c, tplId: tpl.id },
+          reason: { type: 'FIELD_MISMATCH', element: offElementCfg.element },
+        }));
+      }
+    }
+  }
+
+  if (result.events.length) {
+    result.drawn = result.events.reduce((acc, ev) => acc + (ev.count || 0), 0);
+    result.cards = result.events.flatMap(ev => ev.cards || []);
+  }
+  return result;
 }
+
+function getAdjacentDrawConfig(tpl) {
+  if (!tpl) return null;
+  const raw = tpl.drawOnAllySummonAdjacent || tpl.drawOnAllySummonNearby;
+  if (!raw) return null;
+  if (raw === true) return { amount: 1 };
+  if (typeof raw === 'number') return { amount: Math.max(0, Math.floor(raw)) };
+  if (typeof raw === 'object') {
+    const amount = Math.max(0, Math.floor(raw.amount ?? raw.count ?? raw.draw ?? 1));
+    const sourceOnElement = normalizeElementName(
+      raw.sourceOnElement || raw.sourceElement || raw.element || raw.field
+    );
+    const summonedElement = normalizeElementName(
+      raw.requireSummonedElement || raw.summonedElement || raw.targetElement
+    );
+    return { amount, sourceOnElement, summonedElement };
+  }
+  return null;
+}
+
+export function applyAdjacentSummonDraws(state, context = {}) {
+  const events = [];
+  if (!state?.board) return events;
+  const { r, c, unit } = context;
+  if (typeof r !== 'number' || typeof c !== 'number' || !unit) return events;
+  const owner = unit.owner;
+  if (owner == null) return events;
+  const tplSummoned = CARDS[unit.tplId];
+
+  for (const [dir, vec] of Object.entries(DIR_VECTORS)) {
+    const [dr, dc] = vec;
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!inBounds(nr, nc)) continue;
+    const reactor = state.board?.[nr]?.[nc]?.unit;
+    if (!reactor || reactor.owner !== owner) continue;
+    const tplReactor = CARDS[reactor.tplId];
+    const cfg = getAdjacentDrawConfig(tplReactor);
+    if (!cfg || cfg.amount <= 0) continue;
+    if (cfg.sourceOnElement) {
+      const sourceElement = normalizeElementName(state.board?.[nr]?.[nc]?.element);
+      if (sourceElement !== cfg.sourceOnElement) continue;
+    }
+    if (cfg.summonedElement) {
+      const summonedElement = normalizeElementName(state.board?.[r]?.[c]?.element);
+      if (summonedElement !== cfg.summonedElement) continue;
+    }
+    const drawRes = drawCardsForPlayer(state, owner, cfg.amount);
+    if (drawRes.count <= 0) continue;
+    events.push(createEvent({
+      player: owner,
+      count: drawRes.count,
+      requested: drawRes.requested,
+      cards: drawRes.cards,
+      element: state?.board?.[r]?.[c]?.element || null,
+      source: { type: 'ALLY_SUMMON_ADJACENT', dir, r: nr, c: nc, tplId: tplReactor?.id },
+      reason: {
+        type: 'ALLY_SUMMON_ADJACENT',
+        sourceOnElement: cfg.sourceOnElement || null,
+        summonedElement: cfg.summonedElement || null,
+        summonedTplId: tplSummoned?.id || null,
+      },
+    }));
+  }
+
+  return events;
+}
+
+export default { applySummonDraw, applyAdjacentSummonDraws, computeSummonDraw };

--- a/src/core/abilityHandlers/dynamicAttack.js
+++ b/src/core/abilityHandlers/dynamicAttack.js
@@ -1,0 +1,84 @@
+// Модуль для вычисления динамических бонусов к атаке
+// Держим чистую игровую логику без привязки к визуальному слою
+import { countUnits } from '../board.js';
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+function parseElementFromToken(token) {
+  if (!token) return null;
+  return normalizeElementName(token);
+}
+
+function normalizeElementConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const match = raw.match(/^([A-Z]+)_CREATURES$/);
+    if (match) {
+      return { type: 'ELEMENT_CREATURES', element: parseElementFromToken(match[1]) };
+    }
+    const direct = parseElementFromToken(raw);
+    if (direct) {
+      return { type: 'ELEMENT_CREATURES', element: direct };
+    }
+    return null;
+  }
+  if (typeof raw === 'object') {
+    if (raw.type === 'ELEMENT_CREATURES' || raw.mode === 'ELEMENT_CREATURES') {
+      const element = parseElementFromToken(raw.element || raw.elementType || raw.elementName);
+      if (!element) return null;
+      return { type: 'ELEMENT_CREATURES', element };
+    }
+    if (!raw.type && raw.element) {
+      const element = parseElementFromToken(raw.element);
+      if (!element) return null;
+      return { type: 'ELEMENT_CREATURES', element };
+    }
+  }
+  return null;
+}
+
+function countElementCreatures(state, element, opts = {}) {
+  if (!state?.board || !element) return 0;
+  let count = 0;
+  for (let r = 0; r < state.board.length; r += 1) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c += 1) {
+      if (opts.exclude && r === opts.exclude.r && c === opts.exclude.c) continue;
+      const unit = row[c]?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      const tplElement = parseElementFromToken(tpl.element);
+      if (tplElement && tplElement === element) {
+        count += 1;
+      }
+    }
+  }
+  return count;
+}
+
+export function computeDynamicAttackBonus(state, r, c, tpl) {
+  if (!tpl || !tpl.dynamicAtk) return null;
+  const cfg = tpl.dynamicAtk;
+  if (cfg === 'OTHERS_ON_BOARD') {
+    const total = countUnits(state);
+    const others = Math.max(0, total - 1);
+    if (others <= 0) return null;
+    return { amount: others, type: 'OTHERS_ON_BOARD', count: others };
+  }
+  const elementCfg = normalizeElementConfig(cfg);
+  if (elementCfg?.type === 'ELEMENT_CREATURES' && elementCfg.element) {
+    const count = countElementCreatures(state, elementCfg.element, { exclude: { r, c } });
+    if (count <= 0) return null;
+    return {
+      amount: count,
+      type: 'ELEMENT_CREATURES',
+      element: elementCfg.element,
+      count,
+    };
+  }
+  return null;
+}
+
+export default { computeDynamicAttackBonus };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -205,6 +205,27 @@ export const CARDS = {
     desc: 'Dodge attempt. When Cloud Runner is summoned, draw cards equal to the number of Water fields.'
   },
 
+  WATER_TRITONAN_ICE_GUARD: {
+    id: 'WATER_TRITONAN_ICE_GUARD', name: 'Tritonan Ice Guard', type: 'UNIT', cost: 1, activation: 1,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    drawOnSummonIfFieldNotElement: 'WATER',
+    desc: 'When Tritonan Ice Guard is summoned to a non-Water field, draw a card.'
+  },
+
+  WATER_DRAGON_OF_VOICE_SEA: {
+    id: 'WATER_DRAGON_OF_VOICE_SEA', name: 'Dragon of Voice Sea', type: 'UNIT', cost: 7, activation: 4,
+    element: 'WATER', atk: 5, hp: 8,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY', ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    dynamicAtk: 'WATER_CREATURES',
+    drawOnAllySummonAdjacent: { amount: 1, sourceOnElement: 'WATER' },
+    desc: 'Dragon of Voice Sea\'s Attack is equal to 5 plus the number of other Water creatures on the board. While Dragon of Voice Sea is on a Water field, if you summon a creature to an adjacent field, draw a card.'
+  },
+
   WATER_DON_OF_VENOA: {
     id: 'WATER_DON_OF_VENOA', name: 'Don of Venoa', type: 'UNIT', cost: 5, activation: 3,
     element: 'WATER', atk: 2, hp: 3,


### PR DESCRIPTION
## Summary
- add Tritonan Ice Guard and Dragon of Voice Sea unit definitions with соответствующими атаками, blind spot и добором карт
- вынести расчёт динамического бонуса атаки в отдельный модуль и расширить обработку эффектов добора карт, включая реакции союзных существ
- обновить обработку событий призыва, UI-логирование и тесты для покрытия новых механик
- добавить планировщик авто-завершения хода после призыва и добора карт, чтобы ход автоматически завершается после завершения анимаций

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d759fbb88330b0f6854c8c9b2a70