### PR TITLE
Сгладить анимацию добора карт при доборе в руку

### DIFF
--- a/src/scene/hand.js
+++ b/src/scene/hand.js
@@ -25,6 +25,16 @@ function computeHandTransform(index, total) {
   return { position: pos, rotation: rot, scale };
 }
 
+// Собирает предрасчётную раскладку руки для всех индексов
+function computeHandLayout(total) {
+  const transforms = [];
+  const cappedTotal = Math.max(0, total | 0);
+  for (let i = 0; i < cappedTotal; i++) {
+    transforms.push(computeHandTransform(i, cappedTotal));
+  }
+  return transforms;
+}
+
 // Разворачивает карту так, чтобы её лицевая сторона была направлена прямо на камеру
 function orientCardFaceTowardCamera(card, camera) {
   if (!card || !camera) return;
@@ -61,6 +71,110 @@ function applyEulerDegreeOffsets(euler, { pitchDeg = 0, yawDeg = 0, rollDeg = 0 
   euler.z += THREE.MathUtils.degToRad(rollDeg || 0);
 }
 
+function clamp01(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 0;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+// Плавно переводит значение в диапазоне [0, 1], чтобы убрать резкие границы
+function smoothstep01(value) {
+  const t = clamp01(value);
+  return t * t * (3 - 2 * t);
+}
+
+function eulersDiffer(a, b, epsilon = 1e-4) {
+  if (!a || !b) return false;
+  return (
+    Math.abs(a.x - b.x) > epsilon ||
+    Math.abs(a.y - b.y) > epsilon ||
+    Math.abs(a.z - b.z) > epsilon
+  );
+}
+
+function slerpEuler(fromEuler, toEuler, ratio) {
+  const THREE = getTHREE();
+  if (!fromEuler && !toEuler) return new THREE.Euler();
+  if (!fromEuler) return toEuler.clone();
+  if (!toEuler) return fromEuler.clone();
+
+  const amount = clamp01(ratio);
+  if (amount <= 0) return fromEuler.clone();
+  if (amount >= 1) return toEuler.clone();
+
+  const fromQuat = new THREE.Quaternion().setFromEuler(fromEuler);
+  const toQuat = new THREE.Quaternion().setFromEuler(toEuler);
+  const blended = fromQuat.clone().slerp(toQuat, amount);
+  const order = fromEuler.order || toEuler.order || 'XYZ';
+  return new THREE.Euler().setFromQuaternion(blended, order);
+}
+
+// Вычисляет тайминги фаз поворота добираемой карты для разнесения визуальных шагов
+function computeRotationPhaseTimings(flightDuration, tune = {}) {
+  const flight = Math.max(0, typeof flightDuration === 'number' ? flightDuration : 0);
+  const rotationLeadOverride = Number.isFinite(tune.rotationLead) ? tune.rotationLead : undefined;
+  const rotationLeadShare = clamp01(Number.isFinite(tune.rotationLeadShare) ? tune.rotationLeadShare : DEFAULT_ROTATION_LEAD_SHARE);
+  const rotationLead = Math.max(0, Math.min(flight, rotationLeadOverride ?? (flight * rotationLeadShare)));
+
+  const settleStartTime = Math.max(0, flight - rotationLead);
+  const rotationLeanDelayRaw = Number.isFinite(tune.rotationLeanDelay) ? tune.rotationLeanDelay : DEFAULT_ROTATION_LEAN_DELAY;
+  const rotationLeanDelay = Math.max(0, Math.min(settleStartTime, rotationLeanDelayRaw));
+  const leanStartTime = Math.max(0, Math.min(rotationLeanDelay, settleStartTime));
+  const leanDuration = Math.max(0, settleStartTime - leanStartTime);
+
+  const rotationLeanFraction = clamp01(tune.rotationLeanFraction ?? DEFAULT_DRAW_ROTATION_LEAN_FRACTION);
+  const rotationTiltShare = clamp01(tune.rotationTiltShare ?? DEFAULT_DRAW_ROTATION_TILT_SHARE);
+  const tiltDuration = rotationLead * smoothstep01(rotationTiltShare);
+  const settleDuration = Math.max(0, rotationLead - tiltDuration);
+
+  return {
+    rotationLead,
+    settleStartTime,
+    leanStartTime,
+    leanDuration,
+    rotationLeanFraction,
+    rotationTiltShare,
+    tiltDuration,
+    settleDuration
+  };
+}
+
+// Планирует траекторию полёта карты, чтобы она подлетала выше и сбрасывала высоту в конце
+function computeFlightPositionPlan(startPosition, targetPosition, flightDuration, tune = {}) {
+  const THREE = getTHREE();
+  const total = Math.max(0, typeof flightDuration === 'number' ? flightDuration : 0);
+  const settleShareRaw = Number.isFinite(tune.positionSettleShare) ? tune.positionSettleShare : DEFAULT_POSITION_SETTLE_SHARE;
+  const settleShare = clamp01(settleShareRaw);
+  const settleDuration = total * settleShare;
+  const travelDuration = Math.max(0, total - settleDuration);
+
+  const start = (startPosition instanceof THREE.Vector3)
+    ? startPosition.clone()
+    : new THREE.Vector3(startPosition?.x || 0, startPosition?.y || 0, startPosition?.z || 0);
+  const target = (targetPosition instanceof THREE.Vector3)
+    ? targetPosition.clone()
+    : new THREE.Vector3(targetPosition?.x || 0, targetPosition?.y || 0, targetPosition?.z || 0);
+
+  const arcProgressRaw = Number.isFinite(tune.flightArcProgress) ? tune.flightArcProgress : DEFAULT_FLIGHT_ARC_PROGRESS;
+  const arcProgress = clamp01(arcProgressRaw);
+  const arcLift = Number.isFinite(tune.flightArcLift) ? tune.flightArcLift : DEFAULT_FLIGHT_ARC_LIFT;
+  const arcForward = Number.isFinite(tune.flightArcForward) ? tune.flightArcForward : DEFAULT_FLIGHT_ARC_FORWARD;
+  const arcSide = Number.isFinite(tune.flightArcSideOffset) ? tune.flightArcSideOffset : DEFAULT_FLIGHT_ARC_SIDE_OFFSET;
+
+  const midPosition = start.clone().lerp(target, arcProgress);
+  midPosition.x += arcSide;
+  midPosition.y += arcLift;
+  midPosition.z += arcForward;
+
+  return {
+    travelDuration,
+    settleDuration,
+    midPosition,
+    totalDuration: total
+  };
+}
+
 // Собирает все материалы меша, чтобы управлять прозрачностью при анимациях
 function gatherMeshMaterials(root, sink = []) {
   if (!root) return sink;
@@ -73,11 +187,12 @@ function gatherMeshMaterials(root, sink = []) {
 }
 
 // Плавно перестраивает текущие карты в руке перед добавлением новой
-function relayoutHandDuringDraw(handMeshes, totalAfter, duration) {
+function relayoutHandDuringDraw(handMeshes, layoutAfterDraw, duration) {
   if (!Array.isArray(handMeshes) || handMeshes.length === 0) return;
 
   handMeshes.forEach((mesh, idx) => {
-    const t = computeHandTransform(idx, totalAfter);
+    const t = layoutAfterDraw?.[idx];
+    if (!t) return;
     gsap.to(mesh.position, {
       x: t.position.x,
       y: t.position.y,
@@ -85,12 +200,13 @@ function relayoutHandDuringDraw(handMeshes, totalAfter, duration) {
       duration,
       ease: 'power2.inOut'
     });
+    const rotationDuration = duration > 0 ? duration * HAND_ROTATION_DURATION_MULTIPLIER : duration;
     gsap.to(mesh.rotation, {
       x: t.rotation.x,
       y: t.rotation.y,
       z: t.rotation.z,
-      duration,
-      ease: 'power2.inOut'
+      duration: rotationDuration,
+      ease: HAND_ROTATION_EASE
     });
     gsap.to(mesh.scale, { x: 0.54, y: 1, z: 0.54, duration: Math.min(0.2, duration * 0.3) });
     try { mesh.userData.originalPosition.copy(t.position); } catch {}
@@ -101,6 +217,34 @@ function relayoutHandDuringDraw(handMeshes, totalAfter, duration) {
 // Базовые длительности показа и перелёта добираемой карты
 const DRAW_REVEAL_DURATION = 0.7;
 const DRAW_FLIGHT_DURATION = 0.7;
+// Дефолтный масштаб крупного отображения карты при доборе
+const DEFAULT_DRAW_CARD_SCALE = 1.4;
+// Сколько долей от длительности полёта занимает досаживание поворота
+const DEFAULT_ROTATION_LEAD_SHARE = 0.64;
+// Насколько долго карта держит исходный наклон перед началом плавного поворота в полёте
+const DEFAULT_ROTATION_LEAN_DELAY = 0.02;
+// Какую долю «поворота» добираемой карты выполняем до финальной досадки
+const DEFAULT_DRAW_ROTATION_LEAN_FRACTION = 0.72;
+// Какая часть финального промежутка отводится на удержание полётного наклона
+const DEFAULT_DRAW_ROTATION_TILT_SHARE = 0.3;
+// Плавные кривые для фаз появления и движения добираемой карты
+const DRAW_REVEAL_EASE = 'sine.out';
+const DRAW_FLIGHT_EASE = 'sine.inOut';
+const DRAW_SCALE_EASE = 'sine.inOut';
+// Параметры траектории полёта, чтобы карта подлетала сверху и опускалась мягче
+const DEFAULT_POSITION_SETTLE_SHARE = 0.28;
+const DEFAULT_FLIGHT_ARC_LIFT = 1.05;
+const DEFAULT_FLIGHT_ARC_FORWARD = -0.75;
+const DEFAULT_FLIGHT_ARC_SIDE_OFFSET = 0;
+const DEFAULT_FLIGHT_ARC_PROGRESS = 0.62;
+const DRAW_POSITION_SETTLE_EASE = 'sine.in';
+// Плавные кривые для фаз поворота добираемой карты
+const DRAW_ROTATION_LEAN_EASE = 'sine.inOut';
+const DRAW_ROTATION_TILT_EASE = 'sine.inOut';
+const DRAW_ROTATION_SETTLE_EASE = 'sine.inOut';
+// Параметры плавности поворота карт, уже лежащих в руке
+const HAND_ROTATION_DURATION_MULTIPLIER = 1.15;
+const HAND_ROTATION_EASE = 'sine.inOut';
 
 export function setHandCardHoverVisual(mesh, hovered) {
   if (!mesh) return;
@@ -214,8 +358,13 @@ export async function animateDrawnCardToHand(cardTpl) {
     rollDeg: T.initialRollDeg ?? 0
   });
 
-  big.scale.set((T.scale ?? 1.7), (T.scale ?? 1.7), (T.scale ?? 1.7));
+  const initialRotation = big.rotation.clone();
+
+  const drawScale = (T.scale ?? DEFAULT_DRAW_CARD_SCALE);
+  big.scale.set(drawScale, drawScale, drawScale);
   big.renderOrder = 9000;
+
+  const flightStartPosition = big.position.clone();
 
   const allMaterials = gatherMeshMaterials(big, []);
   allMaterials.forEach(m => { if (m) { m.transparent = true; m.opacity = 0; } });
@@ -228,12 +377,14 @@ export async function animateDrawnCardToHand(cardTpl) {
   const totalVisible = Math.max(0, handMeshes.length);
   const totalAfter = totalVisible + 1;
   const indexAfter = totalAfter - 1;
-  const target = computeHandTransform(indexAfter, totalAfter);
+  const layoutAfterDraw = computeHandLayout(totalAfter);
+  const target = layoutAfterDraw[indexAfter] || computeHandTransform(indexAfter, totalAfter);
 
   try {
-    relayoutHandDuringDraw(handMeshes, totalAfter, revealDuration);
+    relayoutHandDuringDraw(handMeshes, layoutAfterDraw, revealDuration);
   } catch {}
 
+  const arrivalRotation = target.rotation.clone();
   const flightRotation = target.rotation.clone();
   try {
     applyEulerDegreeOffsets(flightRotation, {
@@ -243,6 +394,26 @@ export async function animateDrawnCardToHand(cardTpl) {
     });
   } catch {}
 
+  const positionPlan = computeFlightPositionPlan(flightStartPosition, target.position, flightDuration, T);
+  const {
+    travelDuration: positionTravelDuration,
+    settleDuration: positionSettleDuration,
+    midPosition
+  } = positionPlan;
+
+  // Запускаем финальное выравнивание угла заранее, чтобы оно шло в полёте
+  const rotationPlan = computeRotationPhaseTimings(flightDuration, T);
+  const {
+    rotationLead,
+    settleStartTime,
+    leanStartTime,
+    leanDuration,
+    rotationLeanFraction,
+    tiltDuration,
+    settleDuration: rotationSettleDuration
+  } = rotationPlan;
+  const leanRotation = slerpEuler(initialRotation, flightRotation, smoothstep01(rotationLeanFraction));
+
   try {
     await new Promise(resolve => {
       const tl = gsap.timeline({ onComplete: resolve });
@@ -250,30 +421,97 @@ export async function animateDrawnCardToHand(cardTpl) {
       tl.to(allMaterials, {
         opacity: 1,
         duration: revealDuration,
-        ease: 'power2.out'
+        ease: DRAW_REVEAL_EASE
       });
 
-      tl.to(big.position, {
-        x: target.position.x,
-        y: target.position.y,
-        z: target.position.z,
+      tl.addLabel('flightMotion');
+
+      if (positionTravelDuration > 0.0001 && midPosition) {
+        tl.to(big.position, {
+          x: midPosition.x,
+          y: midPosition.y,
+          z: midPosition.z,
+          duration: positionTravelDuration,
+          ease: DRAW_FLIGHT_EASE
+        }, 'flightMotion');
+      }
+
+      const settleStartLabel = `flightMotion+=${Math.max(positionTravelDuration, 0)}`;
+      if (positionSettleDuration > 0.0001) {
+        tl.to(big.position, {
+          x: target.position.x,
+          y: target.position.y,
+          z: target.position.z,
+          duration: positionSettleDuration,
+          ease: DRAW_POSITION_SETTLE_EASE
+        }, settleStartLabel);
+      } else {
+        tl.set(big.position, {
+          x: target.position.x,
+          y: target.position.y,
+          z: target.position.z
+        }, settleStartLabel);
+      }
+
+      tl.to(big.scale, {
+        x: target.scale.x,
+        y: target.scale.y,
+        z: target.scale.z,
         duration: flightDuration,
-        ease: 'power2.inOut'
-      })
-        .to(big.rotation, {
+        ease: DRAW_SCALE_EASE
+      }, 'flightMotion');
+
+      const leanStartLabel = `flightMotion+=${leanStartTime}`;
+      const leanFinishLabel = `flightMotion+=${settleStartTime}`;
+      if (leanDuration > 0.0001 && eulersDiffer(initialRotation, leanRotation)) {
+        tl.to(big.rotation, {
+          x: leanRotation.x,
+          y: leanRotation.y,
+          z: leanRotation.z,
+          duration: leanDuration,
+          ease: DRAW_ROTATION_LEAN_EASE
+        }, leanStartLabel);
+      } else if (eulersDiffer(initialRotation, leanRotation)) {
+        tl.set(big.rotation, {
+          x: leanRotation.x,
+          y: leanRotation.y,
+          z: leanRotation.z
+        }, leanFinishLabel);
+      }
+
+      const tiltStart = `flightMotion+=${settleStartTime}`;
+      if (tiltDuration > 0.0001 && eulersDiffer(leanRotation, flightRotation)) {
+        tl.to(big.rotation, {
           x: flightRotation.x,
           y: flightRotation.y,
           z: flightRotation.z,
-          duration: flightDuration,
-          ease: 'power2.inOut'
-        }, '<')
-        .to(big.scale, {
-          x: target.scale.x,
-          y: target.scale.y,
-          z: target.scale.z,
-          duration: flightDuration,
-          ease: 'power2.inOut'
-        }, '<');
+          duration: tiltDuration,
+          ease: DRAW_ROTATION_TILT_EASE
+        }, tiltStart);
+      } else if (rotationLead > 0.0001 && eulersDiffer(leanRotation, flightRotation)) {
+        tl.set(big.rotation, {
+          x: flightRotation.x,
+          y: flightRotation.y,
+          z: flightRotation.z
+        }, tiltStart);
+      }
+
+      const settleStart = `flightMotion+=${settleStartTime + tiltDuration}`;
+      if (rotationSettleDuration > 0.0001 && eulersDiffer(flightRotation, arrivalRotation)) {
+        tl.to(big.rotation, {
+          x: arrivalRotation.x,
+          y: arrivalRotation.y,
+          z: arrivalRotation.z,
+          duration: rotationSettleDuration,
+          ease: DRAW_ROTATION_SETTLE_EASE
+        }, settleStart);
+      } else {
+        tl.set(big.rotation, {
+          x: arrivalRotation.x,
+          y: arrivalRotation.y,
+          z: arrivalRotation.z
+        }, settleStart);
+      }
     });
   } catch {}
 


### PR DESCRIPTION
## Summary
- добавлена предрасчётная раскладка руки и вспомогательные функции сглаживания
- переработаны параметры анимаций добора карт, включая более ранний и растянутый поворот по крену
- переработан GSAP-таймлайн анимации добора: карта последовательно проходит фазы наклона, удержания и досадки с индивидуальными easing-кривыми и масштабом
- добавлен расчёт траектории полёта с подъёмом над рукой и мягким опусканием, чтобы убрать зацепы за соседние карты
- уменьшен стартовый масштаб отображаемой карты до 1.4 для аккуратного появления

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d25d11275c8330bef1f3967659c577