### PR TITLE
Улучшение механики защиты и отображения

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,10 +561,11 @@
           await sleep(700);
           const ret = staged.step2() || { total: 0, retaliators: [] };
           const retaliation = typeof ret === 'number' ? ret : (ret.total || 0);
+          const retaliators = Array.isArray(ret?.retaliators) ? ret.retaliators : [];
+          const shouldAnimateRetaliation = retaliators.length > 0;
           let animDelayMs = 0;
-          if (retaliation > 0) {
+          if (shouldAnimateRetaliation) {
             // Выпад всех контратакующих
-            const retaliators = (ret.retaliators || []);
             let maxDur = 0;
             for (const rrObj of retaliators) {
               const rMesh = unitMeshes.find(m => m.userData.row === rrObj.r && m.userData.col === rrObj.c);
@@ -580,12 +581,12 @@
               }
             }
             // После лунжей контратаки — тряска и числа урона по атакующему
-            setTimeout(() => { 
-              const aLive = unitMeshes.find(m => m.userData.row === r && m.userData.col === c) || aMesh; 
-              if (aLive) { 
-                window.__fx.shakeMesh(aLive, 6, 0.14); 
+            setTimeout(() => {
+              const aLive = unitMeshes.find(m => m.userData.row === r && m.userData.col === c) || aMesh;
+              if (aLive) {
+                window.__fx.shakeMesh(aLive, 6, 0.14);
                 window.__fx.spawnDamageText(aLive, `-${retaliation}`, '#ffd166');
-              } 
+              }
             }, Math.max(0, maxDur * 1000 - 10));
             animDelayMs = Math.max(animDelayMs, Math.floor(maxDur * 1000) + 160);
             // Синхронизация контратаки для наблюдателя

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -374,7 +374,9 @@ export const CARDS = {
     blindspots: ['S'],
     ignoreAlliedBlocking: true,
     plusAtkIfTargetHpAtLeast: { threshold: 5, amount: 2 },
-    protectionEqualsAlliedElementCount: 'BIOLITH',
+    protectionSources: [
+      { type: 'ALLY_ELEMENT', element: 'BIOLITH', includeSelf: false },
+    ],
     desc: 'Morning Star Warrior adds 2 to its Attack if the target creature has 5 or more HPs.\nMorning Star Warrior gains Protection equal to the number of allied Biolith creatures.'
   },
 

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -373,8 +373,10 @@ export function stagedAttack(state, r, c, opts = {}) {
     const isMagic = attackType === 'MAGIC';
     const tplB = CARDS[B.tplId];
     if (sameOwner) {
-      // Союзники не уклоняются от массового удара, но учитывают защиту
-      const protection = getUnitProtection(base, h.r, h.c, { unit: B, tpl: tplB });
+      // Союзники не уклоняются от массового удара, но учитывают защиту (кроме магии)
+      const protection = isMagic
+        ? 0
+        : getUnitProtection(base, h.r, h.c, { unit: B, tpl: tplB });
       const dealt = Math.max(0, h.dmg - protection);
       return { ...h, dealt, dodge: false, invisible: false, sameOwner: true };
     }
@@ -385,7 +387,7 @@ export function stagedAttack(state, r, c, opts = {}) {
       dodgeInfo = attemptUnitDodge(base, h.r, h.c, { rng: randomFn });
     }
     const dodgeSuccess = !isMagic && !invisible && (perfect || (dodgeInfo?.success === true));
-    const protection = (invisible || dodgeSuccess)
+    const protection = (invisible || dodgeSuccess || isMagic)
       ? 0
       : getUnitProtection(base, h.r, h.c, { unit: B, tpl: tplB });
     const rawDamage = Math.max(0, h.dmg - protection);
@@ -782,8 +784,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
     const before = u.currentHP ?? tplB.hp;
     let dealt = 0;
     if (!invisible) {
-      const protection = getUnitProtection(n1, cell.r, cell.c, { unit: u, tpl: tplB });
-      dealt = Math.max(0, dmg - protection);
+      dealt = dmg;
       u.currentHP = Math.max(0, before - dealt);
     }
     addSummary(cell.r, cell.c, dealt, { invisible });
@@ -805,8 +806,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
       const before2 = u2.currentHP ?? tplB2.hp;
       let dealt2 = 0;
       if (!invisible) {
-        const protection2 = getUnitProtection(n1, cell.r, cell.c, { unit: u2, tpl: tplB2 });
-        dealt2 = Math.max(0, dmg - protection2);
+        dealt2 = dmg;
         u2.currentHP = Math.max(0, before2 - dealt2);
       }
       addSummary(cell.r, cell.c, dealt2, { invisible });

--- a/src/scene/units.js
+++ b/src/scene/units.js
@@ -2,10 +2,11 @@
 import { getCtx } from './context.js';
 import { createCard3D, drawCardFace } from './cards.js';
 import { renderFieldLocks } from './fieldlocks.js';
-import { isUnitPossessed, hasInvisibility } from '../core/abilities.js';
+import { isUnitPossessed, hasInvisibility, getUnitProtection } from '../core/abilities.js';
 import { attachPossessionOverlay, disposePossessionOverlay } from './possessionOverlay.js';
 import { setInvisibilityFx } from './unitFx.js';
 import { resetUnitHover } from './unitTooltip.js';
+import { spawnDamageText } from './effects.js';
 
 function getTHREE() {
   const ctx = getCtx();
@@ -190,7 +191,14 @@ export function updateUnits(gameState) {
         }
       }
 
+      const protectionValue = Math.max(0, getUnitProtection(gameState, r, c, { unit, tpl: cardData }));
       mesh.userData = mesh.userData || {};
+      const prevProtection = typeof mesh.userData.lastProtection === 'number' ? mesh.userData.lastProtection : 0;
+      if (protectionValue > prevProtection) {
+        try {
+          spawnDamageText(mesh, `Protection -${protectionValue}`, '#60a5fa');
+        } catch {}
+      }
       mesh.userData.type = 'unit';
       mesh.userData.row = r;
       mesh.userData.col = c;
@@ -200,6 +208,7 @@ export function updateUnits(gameState) {
       mesh.userData.lastHp = hpValue;
       mesh.userData.lastAtk = atkValue;
       mesh.userData.lastActivation = activationValue;
+      mesh.userData.lastProtection = protectionValue;
 
       const targetRotation = (facingDeg[unit.facing] || 0) * Math.PI / 180;
       mesh.rotation.y = targetRotation;

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -10,7 +10,7 @@ import {
   refreshBoardDodgeStates,
 } from '../src/core/rules.js';
 import { computeFieldquakeLockedCells } from '../src/core/fieldLocks.js';
-import { hasFirstStrike, applySummonAbilities, shouldUseMagicAttack, refreshContinuousPossessions, activationCost, hasInvisibility } from '../src/core/abilities.js';
+import { hasFirstStrike, applySummonAbilities, shouldUseMagicAttack, refreshContinuousPossessions, activationCost, hasInvisibility, getUnitProtection } from '../src/core/abilities.js';
 import { CARDS } from '../src/core/cards.js';
 
 function makeBoard() {
@@ -636,6 +636,113 @@ describe('magicAttack', () => {
     expect(hitCoords).toContain('0,0');
     expect(hitCoords).toContain('0,1');
     delete CARDS.TEST_MAGIC_SPLASH;
+  });
+});
+
+describe('механика защиты', () => {
+  it('магическая атака игнорирует защиту цели', () => {
+    const added = !CARDS.TEST_PROTECTED;
+    if (added) {
+      CARDS.TEST_PROTECTED = {
+        id: 'TEST_PROTECTED',
+        name: 'Shielded Dummy',
+        type: 'UNIT',
+        cost: 0,
+        element: 'EARTH',
+        atk: 0,
+        hp: 2,
+        protection: 2,
+        attackType: 'STANDARD',
+        attacks: [ { dir: 'N', ranges: [1] } ],
+      };
+    }
+
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[2][1].unit = { owner: 0, tplId: 'FIRE_FLAME_MAGUS', facing: 'N' };
+    state.board[1][1].unit = {
+      owner: 1,
+      tplId: 'TEST_PROTECTED',
+      facing: 'S',
+      currentHP: CARDS.TEST_PROTECTED.hp,
+    };
+
+    try {
+      const res = magicAttack(state, 2, 1, 1, 1);
+      expect(res).toBeTruthy();
+      const hit = res.targets.find(t => t.r === 1 && t.c === 1);
+      expect(hit?.dmg).toBe(CARDS.FIRE_FLAME_MAGUS.atk);
+      const survivor = res.n1.board[1][1].unit;
+      expect(survivor?.currentHP).toBe(CARDS.TEST_PROTECTED.hp - CARDS.FIRE_FLAME_MAGUS.atk);
+    } finally {
+      if (added) delete CARDS.TEST_PROTECTED;
+    }
+  });
+
+  it('Morning Star Warrior не учитывает себя при расчёте защиты', () => {
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][1].unit = { owner: 0, tplId: 'BIOLITH_MORNING_STAR_WARRIOR', facing: 'N' };
+
+    let prot = getUnitProtection(state, 1, 1, { unit: state.board[1][1].unit });
+    expect(prot).toBe(0);
+
+    state.board[0][1].unit = { owner: 0, tplId: 'BIOLITH_TAURUS_MONOLITH', facing: 'S' };
+    prot = getUnitProtection(state, 1, 1, { unit: state.board[1][1].unit });
+    expect(prot).toBe(1);
+
+    state.board[2][1].unit = { owner: 1, tplId: 'BIOLITH_TAURUS_MONOLITH', facing: 'N' };
+    prot = getUnitProtection(state, 1, 1, { unit: state.board[1][1].unit });
+    expect(prot).toBe(1);
+
+    state.board[1][2].unit = { owner: 0, tplId: 'BIOLITH_PHASEUS', facing: 'W' };
+    prot = getUnitProtection(state, 1, 1, { unit: state.board[1][1].unit });
+    expect(prot).toBe(2);
+  });
+
+  it('контратака происходит даже при нулевом уроне по атакующему', () => {
+    const added = !CARDS.TEST_ARMORED_ATTACKER;
+    if (added) {
+      CARDS.TEST_ARMORED_ATTACKER = {
+        id: 'TEST_ARMORED_ATTACKER',
+        name: 'Armored Tester',
+        type: 'UNIT',
+        cost: 0,
+        element: 'EARTH',
+        atk: 1,
+        hp: 3,
+        protection: 2,
+        attackType: 'STANDARD',
+        attacks: [ { dir: 'N', ranges: [1] } ],
+      };
+    }
+
+    try {
+      const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+      state.board[2][1].unit = {
+        owner: 0,
+        tplId: 'TEST_ARMORED_ATTACKER',
+        facing: 'N',
+        currentHP: CARDS.TEST_ARMORED_ATTACKER.hp,
+      };
+      state.board[1][1].unit = {
+        owner: 1,
+        tplId: 'FIRE_FREEDONIAN_WANDERER',
+        facing: 'S',
+        currentHP: CARDS.FIRE_FREEDONIAN_WANDERER.hp,
+      };
+
+      const staged = stagedAttack(state, 2, 1);
+      expect(staged).toBeTruthy();
+      staged.step1();
+      const ret = staged.step2();
+      expect(ret).toBeTruthy();
+      const total = typeof ret === 'number' ? ret : (ret.total || 0);
+      const retaliators = typeof ret === 'number' ? [] : (ret.retaliators || []);
+      expect(total).toBe(0);
+      expect(retaliators.length).toBeGreaterThan(0);
+      expect(retaliators[0]).toMatchObject({ r: 1, c: 1 });
+    } finally {
+      if (added) delete CARDS.TEST_ARMORED_ATTACKER;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- запретил защите уменьшать урон от магических атак и добавил проверки в тестах
- скорректировал способность Morning Star Warrior и вывел всплывающие подсказки при росте защиты
- включил анимацию контратак даже при нулевом уроне и синхронизировал её по сети

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d393b49ecc8330bc19af2547e448a6