### PR TITLE
Исправить блокировку хода во время принудительного сброса

### DIFF
--- a/src/core/abilityHandlers/discard.js
+++ b/src/core/abilityHandlers/discard.js
@@ -1,0 +1,205 @@
+// Логика эффектов принудительного сброса карт
+import { CARDS } from '../cards.js';
+
+const DEFAULT_TIMER_MS = 20000;
+
+function ensureQueue(state) {
+  if (!state) return null;
+  if (!Array.isArray(state.pendingDiscards)) {
+    state.pendingDiscards = [];
+  }
+  return state.pendingDiscards;
+}
+
+function nextRequestId(state) {
+  if (!state) return Date.now();
+  const current = Number(state.nextDiscardRequestId) || 0;
+  const next = current + 1;
+  state.nextDiscardRequestId = next;
+  return next;
+}
+
+function normalizeDeathConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    return { element: raw.toUpperCase() };
+  }
+  if (typeof raw === 'object') {
+    const cfg = { ...raw };
+    if (cfg.element) cfg.element = String(cfg.element).toUpperCase();
+    if (cfg.count == null && typeof cfg.amount === 'number') {
+      cfg.count = cfg.amount;
+    }
+    return cfg;
+  }
+  return null;
+}
+
+function normalizeWatcherConfig(raw) {
+  const cfg = normalizeDeathConfig(raw);
+  if (!cfg) return null;
+  cfg.amount = typeof cfg.amount === 'number' ? cfg.amount : (typeof cfg.count === 'number' ? cfg.count : 1);
+  if (cfg.element) cfg.element = String(cfg.element).toUpperCase();
+  return cfg;
+}
+
+function resolveCount(spec, state) {
+  if (spec == null) return 0;
+  if (typeof spec === 'number') return Math.max(0, Math.floor(spec));
+  if (typeof spec === 'object') {
+    const type = String(spec.type || spec.mode || '').toUpperCase();
+    if (type === 'FIELD_COUNT' || type === 'FIELDS') {
+      const element = String(spec.element || spec.field || '').toUpperCase();
+      if (!state?.board || !element) return 0;
+      let count = 0;
+      for (let r = 0; r < 3; r += 1) {
+        for (let c = 0; c < 3; c += 1) {
+          if (state.board?.[r]?.[c]?.element === element) count += 1;
+        }
+      }
+      return count;
+    }
+    if (type === 'FIXED' || type === 'CONST') {
+      if (typeof spec.value === 'number') return Math.max(0, Math.floor(spec.value));
+    }
+  }
+  return 0;
+}
+
+function makeRequest(state, opts) {
+  const queue = ensureQueue(state);
+  if (!queue) return null;
+  const { target, count, source, durationMs = DEFAULT_TIMER_MS } = opts;
+  const targetPlayer = state?.players?.[target];
+  const handSize = Array.isArray(targetPlayer?.hand) ? targetPlayer.hand.length : 0;
+  const remaining = Math.min(Math.max(0, count), handSize);
+  if (remaining <= 0) {
+    return { skipped: true, handSize, requested: count };
+  }
+  const request = {
+    id: nextRequestId(state),
+    target,
+    requested: count,
+    remaining,
+    source: source ? { ...source } : null,
+    autoRandomMs: durationMs,
+  };
+  queue.push(request);
+  return request;
+}
+
+function formatCount(count) {
+  const n = Math.max(0, Number(count) || 0);
+  if (n === 1) return '1 карту';
+  if (n >= 2 && n <= 4) return `${n} карты`;
+  return `${n} карт`;
+}
+
+export function applyDeathDiscardEffects(state, deaths = [], context = {}) {
+  const events = { logs: [], requests: [] };
+  if (!state || !Array.isArray(deaths) || deaths.length === 0) return events;
+
+  const queue = ensureQueue(state);
+  if (!queue) return events;
+
+  for (const death of deaths) {
+    if (!death) continue;
+    const tpl = CARDS[death.tplId];
+    if (!tpl) continue;
+    const fieldElement = death.element || state?.board?.[death.r]?.[death.c]?.element || null;
+    const baseSource = {
+      tplId: tpl.id,
+      name: tpl.name || tpl.id,
+      owner: death.owner,
+    };
+
+    const cfgOn = normalizeDeathConfig(tpl.deathDiscardOnElement);
+    if (cfgOn?.element && fieldElement === cfgOn.element) {
+      const count = resolveCount(cfgOn.count ?? cfgOn.amount ?? 0, state);
+      const target = death.owner === 0 ? 1 : 0;
+      const req = makeRequest(state, { target, count, source: baseSource, durationMs: cfgOn.durationMs || DEFAULT_TIMER_MS });
+      if (req?.skipped) {
+        events.logs.push(`${baseSource.name}: оппоненту нечего сбрасывать.`);
+      } else if (req) {
+        events.requests.push(req);
+        const label = formatCount(req.remaining);
+        if (req.remaining < (req.requested || req.remaining)) {
+          events.logs.push(`${baseSource.name}: оппонент сбрасывает ${label} (доступных карт меньше требуемого).`);
+        } else {
+          events.logs.push(`${baseSource.name}: оппонент сбрасывает ${label}.`);
+        }
+      }
+    }
+
+    const cfgOff = normalizeDeathConfig(tpl.deathDiscardOnNonElement);
+    if (cfgOff?.element && fieldElement && fieldElement !== cfgOff.element) {
+      const count = resolveCount(cfgOff.count ?? cfgOff.amount ?? 0, state);
+      const target = death.owner === 0 ? 1 : 0;
+      const req = makeRequest(state, { target, count, source: baseSource, durationMs: cfgOff.durationMs || DEFAULT_TIMER_MS });
+      if (req?.skipped) {
+        events.logs.push(`${baseSource.name}: оппоненту нечего сбрасывать.`);
+      } else if (req) {
+        events.requests.push(req);
+        const label = formatCount(req.remaining);
+        if (req.remaining < (req.requested || req.remaining)) {
+          events.logs.push(`${baseSource.name}: оппонент сбрасывает ${label} (доступных карт меньше требуемого).`);
+        } else {
+          events.logs.push(`${baseSource.name}: оппонент сбрасывает ${label}.`);
+        }
+      }
+    }
+  }
+
+  const watchers = [];
+
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      const unit = state.board?.[r]?.[c]?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      const cfg = normalizeWatcherConfig(tpl.allyDeathDiscardOnElement);
+      if (!cfg) continue;
+      const elementHere = state.board?.[r]?.[c]?.element || null;
+      if (cfg.element && elementHere !== cfg.element) continue;
+      watchers.push({ owner: unit.owner, amount: cfg.amount ?? 1, source: { tplId: tpl.id, name: tpl.name || tpl.id, owner: unit.owner } });
+    }
+  }
+
+  for (const death of deaths) {
+    const tpl = CARDS[death.tplId];
+    if (!tpl) continue;
+    const cfg = normalizeWatcherConfig(tpl.allyDeathDiscardOnElement);
+    if (!cfg) continue;
+    const element = death.element || state?.board?.[death.r]?.[death.c]?.element || null;
+    if (cfg.element && element !== cfg.element) continue;
+    watchers.push({ owner: death.owner, amount: cfg.amount ?? 1, source: { tplId: tpl.id, name: tpl.name || tpl.id, owner: death.owner } });
+  }
+
+  if (watchers.length) {
+    const alliedDeathCount = new Map();
+    for (const death of deaths) {
+      if (death?.owner == null) continue;
+      alliedDeathCount.set(death.owner, (alliedDeathCount.get(death.owner) || 0) + 1);
+    }
+    for (const watcher of watchers) {
+      const deathsForOwner = alliedDeathCount.get(watcher.owner) || 0;
+      if (deathsForOwner <= 0) continue;
+      const total = deathsForOwner * (watcher.amount || 1);
+      if (total <= 0) continue;
+      const target = watcher.owner === 0 ? 1 : 0;
+      const req = makeRequest(state, { target, count: total, source: watcher.source, durationMs: DEFAULT_TIMER_MS });
+      if (req?.skipped) {
+        events.logs.push(`${watcher.source.name}: оппоненту нечего сбрасывать.`);
+      } else if (req) {
+        events.requests.push(req);
+        const label = formatCount(req.remaining);
+        events.logs.push(`${watcher.source.name}: оппонент сбрасывает ${label}.`);
+      }
+    }
+  }
+
+  return events;
+}
+
+export default applyDeathDiscardEffects;

--- a/src/core/abilityHandlers/incarnation.js
+++ b/src/core/abilityHandlers/incarnation.js
@@ -69,10 +69,14 @@ export function applyIncarnationSummon(state, context = {}) {
   const cell = board?.[r]?.[c];
   const removedUnit = cell?.unit || null;
   const removedTpl = getTemplate(removedUnit?.tplId);
+  const deathInfo = removedUnit
+    ? [{ r, c, owner: removedUnit.owner, tplId: removedUnit.tplId, uid: removedUnit.uid ?? null, element: cell?.element || null }]
+    : null;
   if (cell) cell.unit = null;
   return {
     ok: true,
     cost: check.cost,
     sacrifice: cloneSacrificeInfo(removedUnit, removedTpl, { r, c }),
+    death: deathInfo,
   };
 }

--- a/src/core/board.js
+++ b/src/core/board.js
@@ -83,6 +83,8 @@ export function startGame(deck0 = DEFAULT_DECK, deck1 = DEFAULT_DECK) {
     winner: null,
     __ver: 0,
     summoningUnlocked: false, // поле по умолчанию заблокировано
+    pendingDiscards: [],
+    nextDiscardRequestId: 0,
   };
   for (let i = 0; i < 5; i++) { drawOne(state, 0); drawOne(state, 1); }
   return state;

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -353,6 +353,17 @@ export const CARDS = {
     desc: 'Stone Wing Dwarf gains Protection equal to the number of allied Giant Axe Dwarves on the board.'
   },
 
+  EARTH_BLACK_HOOD_DWARF_VULITRA: {
+    id: 'EARTH_BLACK_HOOD_DWARF_VULITRA', name: 'Black Hood Dwarf Vulitra', type: 'UNIT', cost: 3, activation: 2,
+    element: 'EARTH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true, pierce: true,
+    plusAtkVsElement: { element: 'EARTH', amount: 1 },
+    deathDiscardOnNonElement: { element: 'EARTH', count: { type: 'FIELD_COUNT', element: 'EARTH' } },
+    desc: 'Vulitra adds 1 to his attack if at least one target creature is an earth creature. If Vulitra is destroyed on a non-Earth field, your opponent must discard cards equal to the number of Earth fields.'
+  },
+
   EARTH_VERZAR_CANINE: {
     id: 'EARTH_VERZAR_CANINE', name: 'Verzar Canine', type: 'UNIT', cost: 1, activation: 1,
     element: 'EARTH', atk: 1, hp: 1,
@@ -602,6 +613,15 @@ export const CARDS = {
     enemyActivationTaxAdjacent: 3,
     desc: 'Magic Attack. If Elven Death Dancer damages (but does not destroy) a creature, she switches locations with that creature (which cannot counterattack). Enemies on adjacent fields add 3 to their Activation Cost.'
   },
+  FOREST_ELVEN_RIDER: {
+    id: 'FOREST_ELVEN_RIDER', name: 'Elven Rider', type: 'UNIT', cost: 4, activation: 2,
+    element: 'FOREST', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true, pierce: true,
+    deathDiscardOnNonElement: { element: 'FOREST', count: { type: 'FIELD_COUNT', element: 'FOREST' } },
+    desc: 'If Elven Rider is destroyed on a non-Wood field, your opponent must discard cards equal to the number of Wood fields.'
+  },
   FOREST_JUNO_FOREST_DRAGON: {
     id: 'FOREST_JUNO_FOREST_DRAGON', name: 'Juno Forest Dragon', type: 'UNIT', cost: 7, activation: 4,
     element: 'FOREST', atk: 5, hp: 8,
@@ -635,6 +655,39 @@ export const CARDS = {
       { key: 'SACRIFICE_TRANSFORM', element: 'FOREST', label: 'Sacrifice', requireNonCubic: true },
     ],
     desc: 'Sacrifice Green Cubic to summon a non‑cubic Wood creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
+  },
+  FOREST_GREEN_ERLKING_ZOMBA: {
+    id: 'FOREST_GREEN_ERLKING_ZOMBA', name: 'Green Erlking Zomba', type: 'UNIT', cost: 6, activation: 3,
+    element: 'FOREST', atk: 6, hp: 3,
+    attackType: 'STANDARD', friendlyFire: true,
+    attacks: [ { dir: 'N', ranges: [1, 2], ignoreAlliedBlocking: true } ],
+    attackSchemes: [
+      { key: 'BASE', label: 'Base', attackType: 'STANDARD', attacks: [ { dir: 'N', ranges: [1, 2], ignoreAlliedBlocking: true } ] },
+      { key: 'ALT', label: 'Wood', attackType: 'STANDARD', attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ] }
+    ],
+    defaultAttackScheme: 'BASE',
+    mustUseSchemeOnElement: { element: 'FOREST', scheme: 'ALT' },
+    blindspots: ['S'], ignoreAlliedBlocking: true, pierce: true,
+    allyDeathDiscardOnElement: { element: 'FOREST', amount: 1 },
+    desc: 'Zomba must use its secondary attack while it is on a Wood field. While Zomba is on a Wood field, each time an allied creature is destroyed, your opponent must discard a card.'
+  },
+  FOREST_LEAPFROG_BANDIT: {
+    id: 'FOREST_LEAPFROG_BANDIT', name: 'Leapfrog Bandit', type: 'UNIT', cost: 1, activation: 1,
+    element: 'FOREST', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [2], ignoreBlocking: true, ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    deathDiscardOnNonElement: { element: 'FOREST', count: 1 },
+    desc: 'If Leapfrog Bandit is destroyed on a non-Wood field, your opponent must discard 1 card.'
+  },
+  SAMURAI_NAGIRASHU: {
+    id: 'SAMURAI_NAGIRASHU', name: 'Samurai Nagirashu', type: 'UNIT', cost: 2, activation: 2,
+    element: 'FOREST', atk: 2, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    deathDiscardOnElement: { element: 'FOREST', count: 1 },
+    desc: 'If Samurai Nagirashu is destroyed on a Wood field, your opponent must discard 1 card.'
   },
   NEUTRAL_WHITE_CUBIC: {
     id: 'NEUTRAL_WHITE_CUBIC', name: 'White Cubic', type: 'UNIT', cost: 1, activation: 1,

--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,7 @@ import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
 import * as CancelButton from './ui/cancelButton.js';
 import { initDebugControls } from './ui/debugControls.js';
+import { initDiscardManager, syncWithState as syncDiscardManager } from './ui/discardManager.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -150,6 +151,7 @@ export function applyGameState(state) {
     // Сообщаем страницам с локальной переменной gameState о новом состоянии
     // (например, index.html держит собственную копию)
     window.setGameState?.(state);
+    try { syncDiscardManager(state); } catch {}
   } catch {}
 }
 try { if (typeof window !== 'undefined') window.applyGameState = applyGameState; } catch {}
@@ -198,6 +200,7 @@ try {
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
   window.__ui.deckSelect = DeckSelect;
+  window.__ui.discardManager = window.__ui.discardManager || { initDiscardManager, syncWithState: syncDiscardManager };
   window.__ui.deckBuilder = DeckBuilder;
   window.__ui.mainMenu = MainMenu;
   window.updateUI = updateUI;
@@ -220,4 +223,5 @@ import * as UISync from './ui/sync.js';
 try { UISync.attachSocketUIRefresh(); if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.sync = UISync; } } catch {}
 
 try { initDebugControls(); } catch {}
+try { initDiscardManager(); } catch {}
 

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -159,7 +159,8 @@ import { getServerBase } from './config.js';
           // фиксируем фактическое здоровье, а не базовое
           const hp = (typeof u?.currentHP === 'number') ? u.currentHP : u?.hp;
           return u ? { o: u.owner, h: hp, a: u.atk, f: u.facing, t: u.tplId } : null;
-        }))
+        })),
+        pendingDiscards: (state.pendingDiscards||[]).map(req => req ? ({ id: req.id, target: req.target, remaining: req.remaining, requested: req.requested }) : null)
       };
       return JSON.stringify(compact);
     } catch { return '';}

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -12,6 +12,7 @@ import {
   isIncarnationCard,
 } from '../core/abilities.js';
 import { capMana } from '../core/constants.js';
+import { applyDeathDiscardEffects } from '../core/abilityHandlers/discard.js';
 
 // Centralized interaction state
 export const interactionState = {
@@ -39,6 +40,14 @@ export const interactionState = {
 const AUTO_END_TURN_RETRY_MS = 120;
 const AUTO_END_TURN_MAX_ATTEMPTS = 60;
 
+export function hasPendingForcedDiscards() {
+  if (typeof window === 'undefined') return false;
+  const state = window.gameState;
+  if (!state) return false;
+  const queue = Array.isArray(state.pendingDiscards) ? state.pendingDiscards : [];
+  return queue.some(req => req && req.remaining > 0);
+}
+
 // Планировщик авто-завершения хода, который дожидается окончания анимаций и разблокировки ввода
 function scheduleAutoEndTurnRetry(delayMs = AUTO_END_TURN_RETRY_MS, maxAttempts = AUTO_END_TURN_MAX_ATTEMPTS) {
   if (typeof window === 'undefined') return;
@@ -50,6 +59,10 @@ function scheduleAutoEndTurnRetry(delayMs = AUTO_END_TURN_RETRY_MS, maxAttempts 
     if (attempts >= maxAttempts) return;
     attempts += 1;
     if (w.__endTurnInProgress) {
+      setTimeout(tryFinish, delayMs);
+      return;
+    }
+    if (hasPendingForcedDiscards()) {
       setTimeout(tryFinish, delayMs);
       return;
     }
@@ -760,6 +773,14 @@ export function placeUnitWithDirection(direction) {
       return;
     }
     incarnationResult = applied;
+    if (Array.isArray(applied.death) && applied.death.length) {
+      const discardInfo = applyDeathDiscardEffects(gameState, applied.death, { cause: 'INCARNATION' });
+      if (Array.isArray(discardInfo?.logs)) {
+        for (const text of discardInfo.logs) {
+          window.addLog(text);
+        }
+      }
+    }
   }
   const unit = {
     uid: window.uid(),
@@ -833,6 +854,8 @@ export function placeUnitWithDirection(direction) {
       window.addLog(`${cardData.name}: союзники получают +${amount} HP`);
     }
     const owner = unit.owner;
+    const deathElement = gameState.board?.[row]?.[col]?.element || null;
+    const deathInfo = [{ r: row, c: col, owner, tplId: unit.tplId, uid: unit.uid ?? null, element: deathElement }];
     const slotBeforeGain = gameState.players?.[owner]?.mana || 0;
     try { gameState.players[owner].graveyard.push(window.CARDS[unit.tplId]); } catch {}
     const ownerPlayer = gameState.players?.[owner];
@@ -844,6 +867,12 @@ export function placeUnitWithDirection(direction) {
     const pos = ctx.tileMeshes[row][col].position.clone().add(new THREE.Vector3(0, 1.2, 0));
     window.animateManaGainFromWorld(pos, owner, true, slotBeforeGain);
     gameState.board[row][col].unit = null;
+    const discardEffects = applyDeathDiscardEffects(gameState, deathInfo, { cause: 'SUMMON' });
+    if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
+      for (const text of discardEffects.logs) {
+        window.addLog(text);
+      }
+    }
   }
   if (gameState.board[row][col].unit) {
     const summonEvents = applySummonAbilities(gameState, row, col);

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -18,6 +18,7 @@ import {
   getPendingAbilityOrientation,
   clearPendingAbilityOrientation,
   showOracleDeathBuff,
+  hasPendingForcedDiscards,
 } from '../scene/interactions.js';
 
 export function rotateUnit(unitMesh, dir) {
@@ -358,6 +359,12 @@ export function confirmUnitAbilityOrientation(context, direction) {
       w.addLog?.(`${replacementName}: союзники получают +${amount} HP.`);
     }
 
+    if (Array.isArray(result.events?.discardLogs) && result.events.discardLogs.length) {
+      for (const text of result.events.discardLogs) {
+        if (text) w.addLog?.(text);
+      }
+    }
+
     if (result.summonEvents?.possessions?.length) {
       for (const ev of result.summonEvents.possessions) {
         const unitTaken = gameState.board?.[ev.r]?.[ev.c]?.unit;
@@ -419,6 +426,11 @@ export async function endTurn() {
     if (!gameState || gameState.winner !== null) return;
     const isInputLocked = w.isInputLocked || (() => false);
     if (isInputLocked()) return;
+    const forcedPending = hasPendingForcedDiscards();
+    if (forcedPending) {
+      w.showNotification?.('Нельзя завершить ход до окончания принудительного сброса.', 'error');
+      return;
+    }
     try {
       if (typeof w.MY_SEAT === 'number' && gameState.active !== w.MY_SEAT) {
         w.showNotification?.("Opponent's turn", 'error');

--- a/src/ui/discardManager.js
+++ b/src/ui/discardManager.js
@@ -1,0 +1,363 @@
+// Менеджер очереди принудительного сброса карт
+import { interactionState } from '../scene/interactions.js';
+import { discardHandCard } from '../scene/discard.js';
+
+const DEFAULT_AUTO_MS = 20000;
+
+const managerState = {
+  container: null,
+  titleEl: null,
+  timerEl: null,
+  subEl: null,
+  raf: null,
+  timeout: null,
+  active: null,
+  lastStateId: 0,
+};
+
+function ensureContainer() {
+  if (managerState.container) return managerState.container;
+  if (typeof document === 'undefined') return null;
+
+  const wrap = document.createElement('div');
+  wrap.id = 'discard-overlay';
+  wrap.style.position = 'fixed';
+  wrap.style.inset = '0';
+  wrap.style.display = 'none';
+  wrap.style.alignItems = 'center';
+  wrap.style.justifyContent = 'center';
+  wrap.style.pointerEvents = 'none';
+  wrap.style.zIndex = '1300';
+
+  const card = document.createElement('div');
+  card.style.minWidth = '320px';
+  card.style.maxWidth = '420px';
+  card.style.padding = '18px 20px';
+  card.style.borderRadius = '12px';
+  card.style.background = 'rgba(15,23,42,0.92)';
+  card.style.border = '1px solid rgba(148,163,184,0.35)';
+  card.style.color = '#e2e8f0';
+  card.style.fontFamily = 'system-ui, -apple-system, "Segoe UI", sans-serif';
+  card.style.textAlign = 'center';
+  card.style.boxShadow = '0 18px 40px rgba(2,6,23,0.55)';
+  card.style.pointerEvents = 'auto';
+
+  const title = document.createElement('div');
+  title.style.fontSize = '18px';
+  title.style.fontWeight = '700';
+  title.style.marginBottom = '10px';
+
+  const timer = document.createElement('div');
+  timer.style.fontSize = '32px';
+  timer.style.fontWeight = '800';
+  timer.style.letterSpacing = '0.05em';
+  timer.style.marginBottom = '12px';
+
+  const sub = document.createElement('div');
+  sub.style.fontSize = '14px';
+  sub.style.color = '#cbd5f5';
+  sub.style.lineHeight = '1.4';
+
+  card.appendChild(title);
+  card.appendChild(timer);
+  card.appendChild(sub);
+  wrap.appendChild(card);
+  document.body.appendChild(wrap);
+
+  managerState.container = wrap;
+  managerState.titleEl = title;
+  managerState.timerEl = timer;
+  managerState.subEl = sub;
+  return wrap;
+}
+
+function hideOverlay() {
+  if (managerState.container) managerState.container.style.display = 'none';
+}
+
+function showOverlay() {
+  const node = ensureContainer();
+  if (node) node.style.display = 'flex';
+}
+
+function clearTimers() {
+  if (managerState.timeout) {
+    clearTimeout(managerState.timeout);
+    managerState.timeout = null;
+  }
+  if (managerState.raf) {
+    cancelAnimationFrame(managerState.raf);
+    managerState.raf = null;
+  }
+}
+
+function getLocalSeats() {
+  try {
+    const netOn = typeof window.NET_ON === 'function' ? window.NET_ON() : false;
+    if (!netOn) return [0, 1];
+    const seat = (typeof window.MY_SEAT === 'number') ? window.MY_SEAT : 0;
+    return [seat];
+  } catch {
+    return [0, 1];
+  }
+}
+
+function resolvePlayerName(state, idx) {
+  const player = state?.players?.[idx];
+  return player?.name || `Player ${idx + 1}`;
+}
+
+function formatCardName(tplId) {
+  try {
+    const tpl = window.CARDS?.[tplId];
+    return tpl?.name || tplId || 'Card';
+  } catch {
+    return tplId || 'Card';
+  }
+}
+
+function formatSource(req) {
+  if (!req?.source) return 'Способность';
+  const name = req.source.name || formatCardName(req.source.tplId);
+  return `${name}`;
+}
+
+function formatRemaining(n) {
+  const val = Math.max(0, Number(n) || 0);
+  if (val === 1) return '1 карту';
+  if (val >= 2 && val <= 4) return `${val} карты`;
+  return `${val} карт`;
+}
+
+function updateTimerDisplay() {
+  const req = managerState.active;
+  if (!req || !managerState.timerEl) return;
+  const now = Date.now();
+  const msLeft = Math.max(0, (req.deadline || 0) - now);
+  const seconds = Math.ceil(msLeft / 1000);
+  managerState.timerEl.textContent = `${seconds} с`;
+  if (msLeft <= 0) {
+    managerState.raf = null;
+    managerState.timerEl.textContent = '0 с';
+    managerState.timeout = null;
+    managerState.deadline = null;
+    triggerAutoDiscard();
+    return;
+  }
+  managerState.raf = requestAnimationFrame(updateTimerDisplay);
+}
+
+function scheduleCountdown() {
+  clearTimers();
+  const req = managerState.active;
+  if (!req) return;
+  const duration = req.autoRandomMs || DEFAULT_AUTO_MS;
+  const deadline = Date.now() + duration;
+  req.deadline = deadline;
+  managerState.timeout = setTimeout(triggerAutoDiscard, duration + 20);
+  managerState.raf = requestAnimationFrame(updateTimerDisplay);
+}
+
+function resetSelectionState() {
+  if (interactionState.pendingDiscardSelection?.requestId === managerState.active?.id) {
+    interactionState.pendingDiscardSelection = null;
+  }
+}
+
+function finishRequest() {
+  clearTimers();
+  resetSelectionState();
+  hideOverlay();
+  managerState.active = null;
+}
+
+function applyStateMutation(updater) {
+  try {
+    const gs = window.gameState;
+    if (!gs) return;
+    updater(gs);
+    if (typeof window.schedulePush === 'function') {
+      window.schedulePush('forced-discard', { force: false });
+    }
+    if (typeof window.updateHand === 'function') {
+      window.updateHand(gs);
+    }
+    if (typeof window.__ui?.handCount?.update === 'function') {
+      window.__ui.handCount.update(gs);
+    }
+  } catch {}
+}
+
+function removeRequestFromState(reqId) {
+  applyStateMutation((gs) => {
+    const queue = Array.isArray(gs.pendingDiscards) ? gs.pendingDiscards : (gs.pendingDiscards = []);
+    const idx = queue.findIndex(item => item && item.id === reqId);
+    if (idx >= 0) {
+      queue.splice(idx, 1);
+    }
+  });
+}
+
+function updateRequestRemaining(reqId, remaining) {
+  applyStateMutation((gs) => {
+    const queue = Array.isArray(gs.pendingDiscards) ? gs.pendingDiscards : (gs.pendingDiscards = []);
+    const item = queue.find(entry => entry && entry.id === reqId);
+    if (item) item.remaining = remaining;
+  });
+}
+
+function handleDiscard(handIdx, { auto = false } = {}) {
+  const req = managerState.active;
+  const state = window.gameState;
+  if (!req || !state) return;
+  const player = state.players?.[req.target];
+  if (!player || !Array.isArray(player.hand) || player.hand.length === 0) {
+    removeRequestFromState(req.id);
+    finishRequest();
+    return;
+  }
+  if (typeof handIdx !== 'number' || handIdx < 0 || handIdx >= player.hand.length) {
+    return;
+  }
+  const cardTpl = player.hand[handIdx];
+  discardHandCard(player, handIdx);
+  const tplName = cardTpl?.name || formatCardName(cardTpl?.id || cardTpl?.tplId);
+  const playerName = resolvePlayerName(state, req.target);
+  const sourceName = formatSource(req);
+  if (auto) {
+    window.addLog?.(`${sourceName}: ${playerName} сбрасывает ${tplName} автоматически (таймер).`);
+  } else {
+    window.addLog?.(`${sourceName}: ${playerName} сбрасывает ${tplName}.`);
+  }
+
+  const newRemaining = Math.max(0, (req.remaining || 1) - 1);
+  req.remaining = newRemaining;
+  if (newRemaining <= 0) {
+    removeRequestFromState(req.id);
+    finishRequest();
+    syncWithState(window.gameState);
+    return;
+  }
+  updateRequestRemaining(req.id, newRemaining);
+  managerState.subEl.textContent = `${playerName}: сбросьте ${formatRemaining(newRemaining)}.`;
+  scheduleCountdown();
+  prepareSelection();
+}
+
+function triggerAutoDiscard() {
+  const req = managerState.active;
+  const state = window.gameState;
+  if (!req || !state) return;
+  const player = state.players?.[req.target];
+  const hand = Array.isArray(player?.hand) ? player.hand : [];
+  if (!hand.length) {
+    removeRequestFromState(req.id);
+    finishRequest();
+    syncWithState(state);
+    return;
+  }
+  const idx = Math.floor(Math.random() * hand.length);
+  handleDiscard(idx, { auto: true });
+}
+
+function prepareSelection() {
+  const req = managerState.active;
+  const state = window.gameState;
+  if (!req || !state) return;
+  const player = state.players?.[req.target];
+  if (!player || !Array.isArray(player.hand) || player.hand.length === 0) {
+    removeRequestFromState(req.id);
+    finishRequest();
+    syncWithState(state);
+    return;
+  }
+  interactionState.pendingDiscardSelection = {
+    forced: true,
+    keepAfterPick: true,
+    requestId: req.id,
+    onPicked: (handIdx) => {
+      handleDiscard(handIdx, { auto: false });
+    },
+  };
+}
+
+function beginRequest(state, req) {
+  const container = ensureContainer();
+  if (!container) return;
+  managerState.active = { ...req };
+  const playerName = resolvePlayerName(state, req.target);
+  const source = formatSource(req);
+  managerState.titleEl.textContent = `${source}: требуется сброс`;
+  managerState.subEl.textContent = `${playerName}: сбросьте ${formatRemaining(req.remaining)}.`;
+  showOverlay();
+  prepareSelection();
+  scheduleCountdown();
+}
+
+function cancelIfStale(state) {
+  const req = managerState.active;
+  if (!req) return;
+  const queue = Array.isArray(state?.pendingDiscards) ? state.pendingDiscards : [];
+  const match = queue.find(item => item && item.id === req.id);
+  if (!match || match.remaining <= 0) {
+    finishRequest();
+  }
+}
+
+function findNextLocalRequest(state) {
+  const queue = Array.isArray(state?.pendingDiscards) ? state.pendingDiscards : [];
+  if (!queue.length) return null;
+  const seats = getLocalSeats();
+  for (const req of queue) {
+    if (!req || req.remaining <= 0) continue;
+    if (seats.includes(req.target)) return req;
+  }
+  return null;
+}
+
+export function syncWithState(state) {
+  const seats = getLocalSeats();
+  if (!state || seats.length === 0) {
+    finishRequest();
+    return;
+  }
+  if (managerState.active) {
+    cancelIfStale(state);
+  }
+  const current = managerState.active;
+  if (current) {
+    const queue = Array.isArray(state.pendingDiscards) ? state.pendingDiscards : [];
+    const match = queue.find(item => item && item.id === current.id);
+    if (match && match.remaining !== current.remaining) {
+      current.remaining = match.remaining;
+      managerState.subEl.textContent = `${resolvePlayerName(state, match.target)}: сбросьте ${formatRemaining(match.remaining)}.`;
+      scheduleCountdown();
+      prepareSelection();
+    }
+    if (match && (!interactionState.pendingDiscardSelection || interactionState.pendingDiscardSelection.requestId !== match.id)) {
+      prepareSelection();
+    }
+    return;
+  }
+  const next = findNextLocalRequest(state);
+  if (!next) {
+    finishRequest();
+    return;
+  }
+  beginRequest(state, next);
+}
+
+export function initDiscardManager() {
+  ensureContainer();
+}
+
+const api = { initDiscardManager, syncWithState };
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.discardManager = api;
+  }
+} catch {}
+
+export default api;

--- a/tests/discard.test.js
+++ b/tests/discard.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { applyDeathDiscardEffects } from '../src/core/abilityHandlers/discard.js';
+
+function makePlayer(handIds = []) {
+  return {
+    hand: handIds.map(id => ({ id })),
+    deck: [],
+    discard: [],
+    graveyard: [],
+    mana: 0,
+    maxMana: 10,
+  };
+}
+
+function createBoard(elements) {
+  return elements.map(row => row.map(el => ({ element: el, unit: null })));
+}
+
+describe('discard ability handlers', () => {
+  it('adds discard request for Elven Rider on non-wood field', () => {
+    const elements = [
+      ['FOREST', 'FOREST', 'EARTH'],
+      ['FIRE', 'FOREST', 'FOREST'],
+      ['FOREST', 'WATER', 'FOREST'],
+    ];
+    const state = {
+      board: createBoard(elements),
+      players: [
+        makePlayer([]),
+        makePlayer([
+          'FIRE_FLAME_MAGUS',
+          'FIRE_HELLFIRE_SPITTER',
+          'FIRE_FLAME_ASCETIC',
+          'FIRE_PARTMOLE_FLAME_LIZARD',
+          'FIRE_PARTMOLE_FLAME_GUARD',
+        ]),
+      ],
+      pendingDiscards: [],
+      nextDiscardRequestId: 0,
+    };
+    const deaths = [
+      { r: 0, c: 0, owner: 0, tplId: 'FOREST_ELVEN_RIDER', element: 'EARTH' },
+    ];
+    const result = applyDeathDiscardEffects(state, deaths, { cause: 'TEST' });
+    expect(result.requests).toHaveLength(1);
+    expect(state.pendingDiscards).toHaveLength(1);
+    const request = state.pendingDiscards[0];
+    const forestCount = elements.flat().filter(el => el === 'FOREST').length;
+    expect(request.target).toBe(1);
+    const expectedCount = Math.min(forestCount, state.players[1].hand.length);
+    expect(request.remaining).toBe(expectedCount);
+    expect(result.logs.some(line => line.includes('оппонент'))).toBe(true);
+  });
+
+  it('creates discard for Zomba aura when allies die on forest', () => {
+    const elements = [
+      ['EARTH', 'FOREST', 'WATER'],
+      ['FIRE', 'FOREST', 'EARTH'],
+      ['FOREST', 'WATER', 'FIRE'],
+    ];
+    const state = {
+      board: createBoard(elements),
+      players: [
+        makePlayer([]),
+        makePlayer(['FIRE_FLAME_MAGUS', 'FIRE_HELLFIRE_SPITTER', 'FIRE_FLAME_ASCETIC']),
+      ],
+      pendingDiscards: [],
+      nextDiscardRequestId: 0,
+    };
+    state.board[1][1].unit = { tplId: 'FOREST_GREEN_ERLKING_ZOMBA', owner: 0 };
+    const deaths = [
+      { r: 0, c: 1, owner: 0, tplId: 'FOREST_GREEN_CUBIC', element: 'FOREST' },
+      { r: 0, c: 2, owner: 0, tplId: 'FOREST_SWALLOW_NINJA', element: 'WATER' },
+    ];
+    const result = applyDeathDiscardEffects(state, deaths, { cause: 'TEST_AURA' });
+    expect(result.requests).toHaveLength(1);
+    const request = state.pendingDiscards[0];
+    expect(request.target).toBe(1);
+    expect(request.remaining).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- заблокирован авто-энд-ход и кнопка завершения хода, пока в очереди остаются принудительные сбросы
- экспортирован помощник проверки очереди сбросов для повторного использования в UI
- доработан менеджер принудительного сброса: сохраняем выбор до выполнения всех сбросов и восстанавливаем обработчик при пересинхронизации

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3e2a44f3c833091d214a7a8d4c84c