### PR TITLE
Устойчивое управление очередью принудительного сброса

### DIFF
--- a/src/core/abilityHandlers/discard.js
+++ b/src/core/abilityHandlers/discard.js
@@ -1,0 +1,205 @@
+// Логика эффектов принудительного сброса карт
+import { CARDS } from '../cards.js';
+
+const DEFAULT_TIMER_MS = 20000;
+
+function ensureQueue(state) {
+  if (!state) return null;
+  if (!Array.isArray(state.pendingDiscards)) {
+    state.pendingDiscards = [];
+  }
+  return state.pendingDiscards;
+}
+
+function nextRequestId(state) {
+  if (!state) return Date.now();
+  const current = Number(state.nextDiscardRequestId) || 0;
+  const next = current + 1;
+  state.nextDiscardRequestId = next;
+  return next;
+}
+
+function normalizeDeathConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    return { element: raw.toUpperCase() };
+  }
+  if (typeof raw === 'object') {
+    const cfg = { ...raw };
+    if (cfg.element) cfg.element = String(cfg.element).toUpperCase();
+    if (cfg.count == null && typeof cfg.amount === 'number') {
+      cfg.count = cfg.amount;
+    }
+    return cfg;
+  }
+  return null;
+}
+
+function normalizeWatcherConfig(raw) {
+  const cfg = normalizeDeathConfig(raw);
+  if (!cfg) return null;
+  cfg.amount = typeof cfg.amount === 'number' ? cfg.amount : (typeof cfg.count === 'number' ? cfg.count : 1);
+  if (cfg.element) cfg.element = String(cfg.element).toUpperCase();
+  return cfg;
+}
+
+function resolveCount(spec, state) {
+  if (spec == null) return 0;
+  if (typeof spec === 'number') return Math.max(0, Math.floor(spec));
+  if (typeof spec === 'object') {
+    const type = String(spec.type || spec.mode || '').toUpperCase();
+    if (type === 'FIELD_COUNT' || type === 'FIELDS') {
+      const element = String(spec.element || spec.field || '').toUpperCase();
+      if (!state?.board || !element) return 0;
+      let count = 0;
+      for (let r = 0; r < 3; r += 1) {
+        for (let c = 0; c < 3; c += 1) {
+          if (state.board?.[r]?.[c]?.element === element) count += 1;
+        }
+      }
+      return count;
+    }
+    if (type === 'FIXED' || type === 'CONST') {
+      if (typeof spec.value === 'number') return Math.max(0, Math.floor(spec.value));
+    }
+  }
+  return 0;
+}
+
+function makeRequest(state, opts) {
+  const queue = ensureQueue(state);
+  if (!queue) return null;
+  const { target, count, source, durationMs = DEFAULT_TIMER_MS } = opts;
+  const targetPlayer = state?.players?.[target];
+  const handSize = Array.isArray(targetPlayer?.hand) ? targetPlayer.hand.length : 0;
+  const remaining = Math.min(Math.max(0, count), handSize);
+  if (remaining <= 0) {
+    return { skipped: true, handSize, requested: count };
+  }
+  const request = {
+    id: nextRequestId(state),
+    target,
+    requested: count,
+    remaining,
+    source: source ? { ...source } : null,
+    autoRandomMs: durationMs,
+  };
+  queue.push(request);
+  return request;
+}
+
+function formatCount(count) {
+  const n = Math.max(0, Number(count) || 0);
+  if (n === 1) return '1 карту';
+  if (n >= 2 && n <= 4) return `${n} карты`;
+  return `${n} карт`;
+}
+
+export function applyDeathDiscardEffects(state, deaths = [], context = {}) {
+  const events = { logs: [], requests: [] };
+  if (!state || !Array.isArray(deaths) || deaths.length === 0) return events;
+
+  const queue = ensureQueue(state);
+  if (!queue) return events;
+
+  for (const death of deaths) {
+    if (!death) continue;
+    const tpl = CARDS[death.tplId];
+    if (!tpl) continue;
+    const fieldElement = death.element || state?.board?.[death.r]?.[death.c]?.element || null;
+    const baseSource = {
+      tplId: tpl.id,
+      name: tpl.name || tpl.id,
+      owner: death.owner,
+    };
+
+    const cfgOn = normalizeDeathConfig(tpl.deathDiscardOnElement);
+    if (cfgOn?.element && fieldElement === cfgOn.element) {
+      const count = resolveCount(cfgOn.count ?? cfgOn.amount ?? 0, state);
+      const target = death.owner === 0 ? 1 : 0;
+      const req = makeRequest(state, { target, count, source: baseSource, durationMs: cfgOn.durationMs || DEFAULT_TIMER_MS });
+      if (req?.skipped) {
+        events.logs.push(`${baseSource.name}: оппоненту нечего сбрасывать.`);
+      } else if (req) {
+        events.requests.push(req);
+        const label = formatCount(req.remaining);
+        if (req.remaining < (req.requested || req.remaining)) {
+          events.logs.push(`${baseSource.name}: оппонент сбрасывает ${label} (доступных карт меньше требуемого).`);
+        } else {
+          events.logs.push(`${baseSource.name}: оппонент сбрасывает ${label}.`);
+        }
+      }
+    }
+
+    const cfgOff = normalizeDeathConfig(tpl.deathDiscardOnNonElement);
+    if (cfgOff?.element && fieldElement && fieldElement !== cfgOff.element) {
+      const count = resolveCount(cfgOff.count ?? cfgOff.amount ?? 0, state);
+      const target = death.owner === 0 ? 1 : 0;
+      const req = makeRequest(state, { target, count, source: baseSource, durationMs: cfgOff.durationMs || DEFAULT_TIMER_MS });
+      if (req?.skipped) {
+        events.logs.push(`${baseSource.name}: оппоненту нечего сбрасывать.`);
+      } else if (req) {
+        events.requests.push(req);
+        const label = formatCount(req.remaining);
+        if (req.remaining < (req.requested || req.remaining)) {
+          events.logs.push(`${baseSource.name}: оппонент сбрасывает ${label} (доступных карт меньше требуемого).`);
+        } else {
+          events.logs.push(`${baseSource.name}: оппонент сбрасывает ${label}.`);
+        }
+      }
+    }
+  }
+
+  const watchers = [];
+
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      const unit = state.board?.[r]?.[c]?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      const cfg = normalizeWatcherConfig(tpl.allyDeathDiscardOnElement);
+      if (!cfg) continue;
+      const elementHere = state.board?.[r]?.[c]?.element || null;
+      if (cfg.element && elementHere !== cfg.element) continue;
+      watchers.push({ owner: unit.owner, amount: cfg.amount ?? 1, source: { tplId: tpl.id, name: tpl.name || tpl.id, owner: unit.owner } });
+    }
+  }
+
+  for (const death of deaths) {
+    const tpl = CARDS[death.tplId];
+    if (!tpl) continue;
+    const cfg = normalizeWatcherConfig(tpl.allyDeathDiscardOnElement);
+    if (!cfg) continue;
+    const element = death.element || state?.board?.[death.r]?.[death.c]?.element || null;
+    if (cfg.element && element !== cfg.element) continue;
+    watchers.push({ owner: death.owner, amount: cfg.amount ?? 1, source: { tplId: tpl.id, name: tpl.name || tpl.id, owner: death.owner } });
+  }
+
+  if (watchers.length) {
+    const alliedDeathCount = new Map();
+    for (const death of deaths) {
+      if (death?.owner == null) continue;
+      alliedDeathCount.set(death.owner, (alliedDeathCount.get(death.owner) || 0) + 1);
+    }
+    for (const watcher of watchers) {
+      const deathsForOwner = alliedDeathCount.get(watcher.owner) || 0;
+      if (deathsForOwner <= 0) continue;
+      const total = deathsForOwner * (watcher.amount || 1);
+      if (total <= 0) continue;
+      const target = watcher.owner === 0 ? 1 : 0;
+      const req = makeRequest(state, { target, count: total, source: watcher.source, durationMs: DEFAULT_TIMER_MS });
+      if (req?.skipped) {
+        events.logs.push(`${watcher.source.name}: оппоненту нечего сбрасывать.`);
+      } else if (req) {
+        events.requests.push(req);
+        const label = formatCount(req.remaining);
+        events.logs.push(`${watcher.source.name}: оппонент сбрасывает ${label}.`);
+      }
+    }
+  }
+
+  return events;
+}
+
+export default applyDeathDiscardEffects;

--- a/src/core/abilityHandlers/incarnation.js
+++ b/src/core/abilityHandlers/incarnation.js
@@ -69,10 +69,14 @@ export function applyIncarnationSummon(state, context = {}) {
   const cell = board?.[r]?.[c];
   const removedUnit = cell?.unit || null;
   const removedTpl = getTemplate(removedUnit?.tplId);
+  const deathInfo = removedUnit
+    ? [{ r, c, owner: removedUnit.owner, tplId: removedUnit.tplId, uid: removedUnit.uid ?? null, element: cell?.element || null }]
+    : null;
   if (cell) cell.unit = null;
   return {
     ok: true,
     cost: check.cost,
     sacrifice: cloneSacrificeInfo(removedUnit, removedTpl, { r, c }),
+    death: deathInfo,
   };
 }

--- a/src/core/board.js
+++ b/src/core/board.js
@@ -83,6 +83,8 @@ export function startGame(deck0 = DEFAULT_DECK, deck1 = DEFAULT_DECK) {
     winner: null,
     __ver: 0,
     summoningUnlocked: false, // поле по умолчанию заблокировано
+    pendingDiscards: [],
+    nextDiscardRequestId: 0,
   };
   for (let i = 0; i < 5; i++) { drawOne(state, 0); drawOne(state, 1); }
   return state;

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -353,6 +353,18 @@ export const CARDS = {
     desc: 'Stone Wing Dwarf gains Protection equal to the number of allied Giant Axe Dwarves on the board.'
   },
 
+  EARTH_BLACK_HOOD_DWARF_VULITRA: {
+    id: 'EARTH_BLACK_HOOD_DWARF_VULITRA', name: 'Black Hood Dwarf Vulitra', type: 'UNIT', cost: 3, activation: 2,
+    element: 'EARTH', atk: 2, hp: 4,
+    attackType: 'STANDARD', friendlyFire: true,
+    attacks: [ { dir: 'N', ranges: [1, 2], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true, pierce: true,
+    retaliationRangeCap: 1,
+    plusAtkVsElement: { element: 'EARTH', amount: 1 },
+    deathDiscardOnNonElement: { element: 'EARTH', count: { type: 'FIELD_COUNT', element: 'EARTH' } },
+    desc: 'Vulitra adds 1 to his attack if at least one target creature is an earth creature. If Vulitra is destroyed on a non-Earth field, your opponent must discard cards equal to the number of Earth fields.'
+  },
+
   EARTH_VERZAR_CANINE: {
     id: 'EARTH_VERZAR_CANINE', name: 'Verzar Canine', type: 'UNIT', cost: 1, activation: 1,
     element: 'EARTH', atk: 1, hp: 1,
@@ -602,6 +614,15 @@ export const CARDS = {
     enemyActivationTaxAdjacent: 3,
     desc: 'Magic Attack. If Elven Death Dancer damages (but does not destroy) a creature, she switches locations with that creature (which cannot counterattack). Enemies on adjacent fields add 3 to their Activation Cost.'
   },
+  FOREST_ELVEN_RIDER: {
+    id: 'FOREST_ELVEN_RIDER', name: 'Elven Rider', type: 'UNIT', cost: 4, activation: 2,
+    element: 'FOREST', atk: 2, hp: 4,
+    attackType: 'STANDARD', friendlyFire: true,
+    attacks: [ { dir: 'N', ranges: [1, 2], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true, pierce: true,
+    deathDiscardOnNonElement: { element: 'FOREST', count: { type: 'FIELD_COUNT', element: 'FOREST' } },
+    desc: 'If Elven Rider is destroyed on a non-Wood field, your opponent must discard cards equal to the number of Wood fields.'
+  },
   FOREST_JUNO_FOREST_DRAGON: {
     id: 'FOREST_JUNO_FOREST_DRAGON', name: 'Juno Forest Dragon', type: 'UNIT', cost: 7, activation: 4,
     element: 'FOREST', atk: 5, hp: 8,
@@ -635,6 +656,39 @@ export const CARDS = {
       { key: 'SACRIFICE_TRANSFORM', element: 'FOREST', label: 'Sacrifice', requireNonCubic: true },
     ],
     desc: 'Sacrifice Green Cubic to summon a non‑cubic Wood creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
+  },
+  FOREST_GREEN_ERLKING_ZOMBA: {
+    id: 'FOREST_GREEN_ERLKING_ZOMBA', name: 'Green Erlking Zomba', type: 'UNIT', cost: 6, activation: 3,
+    element: 'FOREST', atk: 6, hp: 3,
+    attackType: 'STANDARD', friendlyFire: true,
+    attacks: [ { dir: 'N', ranges: [1, 2], ignoreAlliedBlocking: true } ],
+    attackSchemes: [
+      { key: 'BASE', label: 'Base', attackType: 'STANDARD', attacks: [ { dir: 'N', ranges: [1, 2], ignoreAlliedBlocking: true } ] },
+      { key: 'ALT', label: 'Wood', attackType: 'STANDARD', attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ] }
+    ],
+    defaultAttackScheme: 'BASE',
+    mustUseSchemeOnElement: { element: 'FOREST', scheme: 'ALT' },
+    blindspots: ['S'], ignoreAlliedBlocking: true, pierce: true,
+    allyDeathDiscardOnElement: { element: 'FOREST', amount: 1 },
+    desc: 'Zomba must use its secondary attack while it is on a Wood field. While Zomba is on a Wood field, each time an allied creature is destroyed, your opponent must discard a card.'
+  },
+  FOREST_LEAPFROG_BANDIT: {
+    id: 'FOREST_LEAPFROG_BANDIT', name: 'Leapfrog Bandit', type: 'UNIT', cost: 1, activation: 1,
+    element: 'FOREST', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [2], ignoreBlocking: true, ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    deathDiscardOnNonElement: { element: 'FOREST', count: 1 },
+    desc: 'If Leapfrog Bandit is destroyed on a non-Wood field, your opponent must discard 1 card.'
+  },
+  SAMURAI_NAGIRASHU: {
+    id: 'SAMURAI_NAGIRASHU', name: 'Samurai Nagirashu', type: 'UNIT', cost: 2, activation: 2,
+    element: 'FOREST', atk: 2, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    deathDiscardOnElement: { element: 'FOREST', count: 1 },
+    desc: 'If Samurai Nagirashu is destroyed on a Wood field, your opponent must discard 1 card.'
   },
   NEUTRAL_WHITE_CUBIC: {
     id: 'NEUTRAL_WHITE_CUBIC', name: 'White Cubic', type: 'UNIT', cost: 1, activation: 1,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -25,6 +25,7 @@ import {
 import { computeCellBuff } from './fieldEffects.js';
 import { normalizeElementName } from './utils/elements.js';
 import { computeDynamicAttackBonus } from './abilityHandlers/dynamicAttack.js';
+import { applyDeathDiscardEffects } from './abilityHandlers/discard.js';
 
 export function hasAdjacentGuard(state, r, c) {
   const target = state.board?.[r]?.[c]?.unit;
@@ -133,6 +134,9 @@ export function computeHits(state, r, c, opts = {}) {
   const baseSkipAllies = !!(tplA.ignoreAlliedBlocking || tplA.ignoreFriendlyBlocking || tplA.skipAlliedBlocking);
   const allowFriendly = !!tplA.friendlyFire; // может ли существо задевать союзников
   const forceBackAttack = !!tplA.backAttack;
+  const retaliationRangeCap = opts.retaliation && typeof tplA?.retaliationRangeCap === 'number'
+    ? tplA.retaliationRangeCap
+    : null;
   const grouped = new Map();
   let fallbackIdx = 0;
   for (const cell of cells) {
@@ -149,6 +153,7 @@ export function computeHits(state, r, c, opts = {}) {
       const nr = r + dr * cell.range;
       const nc = c + dc * cell.range;
       if (!inBounds(nr, nc)) continue;
+      if (retaliationRangeCap != null && cell.range > retaliationRangeCap) continue;
       evaluated.push({ cell, dr, dc, nr, nc });
     }
     if (!evaluated.length) continue;
@@ -218,19 +223,22 @@ export function computeHits(state, r, c, opts = {}) {
           continue; // охрана работает только против врагов
         }
         const backDir = { N: 'S', S: 'N', E: 'W', W: 'E' }[B.facing];
-        const [bdr, bdc] = DIR_VECTORS[backDir] || [0, 0];
-        let isBack = (nr + bdr === r && nc + bdc === c);
-        const dirAbsFromB = (() => {
-          if (r === nr - 1 && c === nc) return 'N';
-          if (r === nr + 1 && c === nc) return 'S';
-          if (r === nr && c === nc - 1) return 'W';
-          return 'E';
-        })();
+        const drBA = r - nr;
+        const dcBA = c - nc;
+        let dirAbsFromB;
+        if (drBA === 0 && dcBA === 0) {
+          dirAbsFromB = backDir || B.facing || 'S';
+        } else if (Math.abs(drBA) >= Math.abs(dcBA)) {
+          dirAbsFromB = drBA < 0 ? 'N' : 'S';
+        } else {
+          dirAbsFromB = dcBA < 0 ? 'W' : 'E';
+        }
         const ORDER = ['N', 'E', 'S', 'W'];
-        const absIdx = ORDER.indexOf(dirAbsFromB);
-        const faceIdx = ORDER.indexOf(B.facing);
+        const absIdx = ORDER.includes(dirAbsFromB) ? ORDER.indexOf(dirAbsFromB) : 0;
+        const faceIdx = ORDER.includes(B.facing) ? ORDER.indexOf(B.facing) : 0;
         const relIdx = (absIdx - faceIdx + 4) % 4;
         let dirRel = ORDER[relIdx];
+        let isBack = dirAbsFromB === backDir;
         if (forceBackAttack) {
           isBack = true;
           dirRel = 'S';
@@ -352,7 +360,7 @@ export function stagedAttack(state, r, c, opts = {}) {
     if (!B) continue;
     const tplB = CARDS[B.tplId];
     if (!attackerQuick && hasFirstStrike(tplB)) {
-      const hitsB = computeHits(base, h.r, h.c, { target: { r, c }, union: true });
+      const hitsB = computeHits(base, h.r, h.c, { target: { r, c }, union: true, retaliation: true });
       if (hitsB.length) {
         const { atk: batk } = effectiveStats(base.board[h.r][h.c], B, { state: base, r: h.r, c: h.c });
         const baseDmg = Math.max(0, batk);
@@ -492,7 +500,7 @@ export function stagedAttack(state, r, c, opts = {}) {
       if (tplB?.attackType === 'MAGIC' && !tplB?.allowMagicRetaliation) continue;
       // быстрота защитника уже сработала на stepQuick, если атакующий не был быстрым
       if (!attackerQuick && hasFirstStrike(tplB)) continue;
-      const hitsB = computeHits(n1, h.r, h.c, { target: { r, c }, union: true });
+      const hitsB = computeHits(n1, h.r, h.c, { target: { r, c }, union: true, retaliation: true });
       if (hitsB.length) {
         const { atk: batk } = effectiveStats(n1.board[h.r][h.c], B, { state: n1, r: h.r, c: h.c });
         const baseDmg = Math.max(0, batk);
@@ -534,10 +542,11 @@ export function stagedAttack(state, r, c, opts = {}) {
 
     const deaths = [];
     for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
-      const u = nFinal.board?.[rr]?.[cc]?.unit;
+      const cellRef = nFinal.board?.[rr]?.[cc];
+      const u = cellRef?.unit;
       if (u && (u.currentHP ?? CARDS[u.tplId].hp) <= 0) {
-        deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null });
-        nFinal.board[rr][cc].unit = null;
+        deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: cellRef?.element || null });
+        if (cellRef) cellRef.unit = null;
       }
     }
 
@@ -567,6 +576,11 @@ export function stagedAttack(state, r, c, opts = {}) {
         }
         logLines.push(`${tplD.name}: союзники получают +${tplD.onDeathAddHPAll} HP`);
       }
+    }
+
+    const discardEffects = applyDeathDiscardEffects(nFinal, deaths, { cause: 'BATTLE' });
+    if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
+      logLines.push(...discardEffects.logs);
     }
 
     const releaseEvents = releasePossessionsAfterDeaths(nFinal, deaths);
@@ -852,10 +866,11 @@ export function magicAttack(state, fr, fc, tr, tc) {
 
   const deaths = [];
   for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
-    const u = n1.board[rr][cc].unit;
+    const cellRef = n1.board[rr][cc];
+    const u = cellRef.unit;
     if (u && (u.currentHP ?? CARDS[u.tplId].hp) <= 0) {
-      deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null });
-      n1.board[rr][cc].unit = null;
+      deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: cellRef?.element || null });
+      cellRef.unit = null;
     }
   }
   try {
@@ -865,6 +880,10 @@ export function magicAttack(state, fr, fc, tr, tc) {
       }
     }
   } catch {}
+  const discardEffects = applyDeathDiscardEffects(n1, deaths, { cause: 'MAGIC' });
+  if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
+    logLines.push(...discardEffects.logs);
+  }
   const releaseEvents = releasePossessionsAfterDeaths(n1, deaths);
   if (releaseEvents.releases.length) {
     for (const rel of releaseEvents.releases) {

--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,7 @@ import { createMetaObjects } from './scene/meta.js';
 import * as SummonLock from './ui/summonLock.js';
 import * as CancelButton from './ui/cancelButton.js';
 import { initDebugControls } from './ui/debugControls.js';
+import { initDiscardManager, syncWithState as syncDiscardManager } from './ui/discardManager.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -150,6 +151,7 @@ export function applyGameState(state) {
     // Сообщаем страницам с локальной переменной gameState о новом состоянии
     // (например, index.html держит собственную копию)
     window.setGameState?.(state);
+    try { syncDiscardManager(state); } catch {}
   } catch {}
 }
 try { if (typeof window !== 'undefined') window.applyGameState = applyGameState; } catch {}
@@ -198,6 +200,7 @@ try {
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
   window.__ui.deckSelect = DeckSelect;
+  window.__ui.discardManager = window.__ui.discardManager || { initDiscardManager, syncWithState: syncDiscardManager };
   window.__ui.deckBuilder = DeckBuilder;
   window.__ui.mainMenu = MainMenu;
   window.updateUI = updateUI;
@@ -220,4 +223,5 @@ import * as UISync from './ui/sync.js';
 try { UISync.attachSocketUIRefresh(); if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.sync = UISync; } } catch {}
 
 try { initDebugControls(); } catch {}
+try { initDiscardManager(); } catch {}
 

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -159,7 +159,8 @@ import { getServerBase } from './config.js';
           // фиксируем фактическое здоровье, а не базовое
           const hp = (typeof u?.currentHP === 'number') ? u.currentHP : u?.hp;
           return u ? { o: u.owner, h: hp, a: u.atk, f: u.facing, t: u.tplId } : null;
-        }))
+        })),
+        pendingDiscards: (state.pendingDiscards||[]).map(req => req ? ({ id: req.id, target: req.target, remaining: req.remaining, requested: req.requested }) : null)
       };
       return JSON.stringify(compact);
     } catch { return '';}
@@ -886,8 +887,25 @@ import { getServerBase } from './config.js';
     // Lock only when seat is known; otherwise do not block input
     if (!lock) return;
     const myKnown = (typeof MY_SEAT === 'number');
-    const shouldLock = (typeof NET_ON === 'function' ? NET_ON() : false) &&
+    let shouldLock = (typeof NET_ON === 'function' ? NET_ON() : false) &&
       gameState && myKnown && (gameState.active !== MY_SEAT);
+    if (shouldLock) {
+      try {
+        const seats = (typeof MY_SEAT === 'number') ? [MY_SEAT] : [0, 1];
+        const queue = Array.isArray(gameState?.pendingDiscards) ? gameState.pendingDiscards : [];
+        const hasLocalPending = queue.some(req => req && req.remaining > 0 && seats.includes(req.target));
+        if (hasLocalPending) {
+          shouldLock = false;
+        }
+      } catch {}
+    }
+    if (shouldLock) {
+      try {
+        if (typeof window !== 'undefined' && window.__ui?.discardManager?.hasActiveLocalRequest?.()) {
+          shouldLock = false;
+        }
+      } catch {}
+    }
     lock.classList.toggle('on', !!shouldLock);
   }
 

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -18,6 +18,7 @@ import {
   getPendingAbilityOrientation,
   clearPendingAbilityOrientation,
   showOracleDeathBuff,
+  hasPendingForcedDiscards,
 } from '../scene/interactions.js';
 
 export function rotateUnit(unitMesh, dir) {
@@ -358,6 +359,12 @@ export function confirmUnitAbilityOrientation(context, direction) {
       w.addLog?.(`${replacementName}: союзники получают +${amount} HP.`);
     }
 
+    if (Array.isArray(result.events?.discardLogs) && result.events.discardLogs.length) {
+      for (const text of result.events.discardLogs) {
+        if (text) w.addLog?.(text);
+      }
+    }
+
     if (result.summonEvents?.possessions?.length) {
       for (const ev of result.summonEvents.possessions) {
         const unitTaken = gameState.board?.[ev.r]?.[ev.c]?.unit;
@@ -419,6 +426,11 @@ export async function endTurn() {
     if (!gameState || gameState.winner !== null) return;
     const isInputLocked = w.isInputLocked || (() => false);
     if (isInputLocked()) return;
+    const forcedPending = hasPendingForcedDiscards();
+    if (forcedPending) {
+      w.showNotification?.('Нельзя завершить ход до окончания принудительного сброса.', 'error');
+      return;
+    }
     try {
       if (typeof w.MY_SEAT === 'number' && gameState.active !== w.MY_SEAT) {
         w.showNotification?.("Opponent's turn", 'error');

--- a/src/ui/discardManager.js
+++ b/src/ui/discardManager.js
@@ -1,0 +1,461 @@
+// Менеджер очереди принудительного сброса карт
+import { interactionState } from '../scene/interactions.js';
+import { discardHandCard } from '../scene/discard.js';
+
+const DEFAULT_AUTO_MS = 20000;
+
+const managerState = {
+  container: null,
+  titleEl: null,
+  timerEl: null,
+  subEl: null,
+  raf: null,
+  timeout: null,
+  active: null,
+  lastStateId: 0,
+  turnTimerPaused: false,
+};
+
+function getQueue(state) {
+  if (!state) return [];
+  return Array.isArray(state.pendingDiscards) ? state.pendingDiscards : [];
+}
+
+function notifyInputLockChanged() {
+  try {
+    if (typeof window !== 'undefined' && window.updateInputLock) {
+      window.updateInputLock();
+    }
+  } catch {}
+}
+
+// Останавливаем общий таймер хода, пока игрок выбирает карты для сброса
+function pauseTurnTimer() {
+  if (managerState.turnTimerPaused) return;
+  try {
+    if (typeof window !== 'undefined' && window.__ui?.turnTimer?.stop) {
+      window.__ui.turnTimer.stop();
+      managerState.turnTimerPaused = true;
+    }
+  } catch {}
+}
+
+// Возобновляем таймер, когда все запросы на сброс завершены
+function resumeTurnTimerIfIdle(state) {
+  if (!managerState.turnTimerPaused) return;
+  const gs = state || (typeof window !== 'undefined' ? window.gameState : null);
+  if (!gs) {
+    managerState.turnTimerPaused = false;
+    try { window.__ui?.turnTimer?.start?.(); } catch {}
+    return;
+  }
+  const queue = getQueue(gs);
+  const stillPending = queue.some(item => item && item.remaining > 0);
+  if (stillPending) return;
+  managerState.turnTimerPaused = false;
+  try { window.__ui?.turnTimer?.start?.(); } catch {}
+}
+
+function hasPendingRequests(state, { target = null, excludeId = null } = {}) {
+  if (!state) return false;
+  const queue = getQueue(state);
+  return queue.some((item) => {
+    if (!item || item.remaining <= 0) return false;
+    if (target !== null && item.target !== target) return false;
+    if (excludeId !== null && item.id === excludeId) return false;
+    return true;
+  });
+}
+
+function ensureAutoEndResume(state) {
+  const gs = state || (typeof window !== 'undefined' ? window.gameState : null);
+  if (!gs) return;
+  const pendingAuto = Math.max(0, Number(gs.pendingAutoEndRequests) || 0);
+  if (pendingAuto <= 0) return;
+  if (hasPendingRequests(gs)) return;
+  const activeSeat = typeof gs.active === 'number' ? gs.active : null;
+  if (activeSeat == null) return;
+  const mySeatKnown = (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number');
+  if (mySeatKnown && window.MY_SEAT !== activeSeat) return;
+  try {
+    if (typeof window !== 'undefined') {
+      window.__interactions?.requestAutoEndTurn?.({ resumeOnly: true });
+    }
+  } catch {}
+}
+
+function completeRequestAndSync(req, state) {
+  if (!req) return;
+  removeRequestFromState(req.id);
+  finishRequest();
+  const gs = (typeof window !== 'undefined' ? window.gameState : state) || state;
+  ensureAutoEndResume(gs);
+  if (typeof setTimeout === 'function') {
+    setTimeout(() => {
+      const latest = (typeof window !== 'undefined' ? window.gameState : gs) || gs;
+      syncWithState(latest);
+      ensureAutoEndResume(latest);
+    }, 0);
+  } else {
+    syncWithState(gs);
+    ensureAutoEndResume(gs);
+  }
+}
+
+function ensureContainer() {
+  if (managerState.container) return managerState.container;
+  if (typeof document === 'undefined') return null;
+
+  const wrap = document.createElement('div');
+  wrap.id = 'discard-overlay';
+  wrap.style.position = 'fixed';
+  wrap.style.inset = '0';
+  wrap.style.display = 'none';
+  wrap.style.alignItems = 'center';
+  wrap.style.justifyContent = 'center';
+  wrap.style.pointerEvents = 'none';
+  wrap.style.zIndex = '1300';
+
+  const card = document.createElement('div');
+  card.style.minWidth = '320px';
+  card.style.maxWidth = '420px';
+  card.style.padding = '18px 20px';
+  card.style.borderRadius = '12px';
+  card.style.background = 'rgba(15,23,42,0.92)';
+  card.style.border = '1px solid rgba(148,163,184,0.35)';
+  card.style.color = '#e2e8f0';
+  card.style.fontFamily = 'system-ui, -apple-system, "Segoe UI", sans-serif';
+  card.style.textAlign = 'center';
+  card.style.boxShadow = '0 18px 40px rgba(2,6,23,0.55)';
+  card.style.pointerEvents = 'auto';
+
+  const title = document.createElement('div');
+  title.style.fontSize = '18px';
+  title.style.fontWeight = '700';
+  title.style.marginBottom = '10px';
+
+  const timer = document.createElement('div');
+  timer.style.fontSize = '32px';
+  timer.style.fontWeight = '800';
+  timer.style.letterSpacing = '0.05em';
+  timer.style.marginBottom = '12px';
+
+  const sub = document.createElement('div');
+  sub.style.fontSize = '14px';
+  sub.style.color = '#cbd5f5';
+  sub.style.lineHeight = '1.4';
+
+  card.appendChild(title);
+  card.appendChild(timer);
+  card.appendChild(sub);
+  wrap.appendChild(card);
+  document.body.appendChild(wrap);
+
+  managerState.container = wrap;
+  managerState.titleEl = title;
+  managerState.timerEl = timer;
+  managerState.subEl = sub;
+  return wrap;
+}
+
+function hideOverlay() {
+  if (managerState.container) managerState.container.style.display = 'none';
+}
+
+function showOverlay() {
+  const node = ensureContainer();
+  if (node) node.style.display = 'flex';
+}
+
+function clearTimers() {
+  if (managerState.timeout) {
+    clearTimeout(managerState.timeout);
+    managerState.timeout = null;
+  }
+  if (managerState.raf) {
+    cancelAnimationFrame(managerState.raf);
+    managerState.raf = null;
+  }
+}
+
+function getLocalSeats() {
+  try {
+    const netOn = typeof window.NET_ON === 'function' ? window.NET_ON() : false;
+    if (!netOn) return [0, 1];
+    const seat = (typeof window.MY_SEAT === 'number') ? window.MY_SEAT : 0;
+    return [seat];
+  } catch {
+    return [0, 1];
+  }
+}
+
+function resolvePlayerName(state, idx) {
+  const player = state?.players?.[idx];
+  return player?.name || `Player ${idx + 1}`;
+}
+
+function formatCardName(tplId) {
+  try {
+    const tpl = window.CARDS?.[tplId];
+    return tpl?.name || tplId || 'Card';
+  } catch {
+    return tplId || 'Card';
+  }
+}
+
+function formatSource(req) {
+  if (!req?.source) return 'Способность';
+  const name = req.source.name || formatCardName(req.source.tplId);
+  return `${name}`;
+}
+
+function formatRemaining(n) {
+  const val = Math.max(0, Number(n) || 0);
+  if (val === 1) return '1 карту';
+  if (val >= 2 && val <= 4) return `${val} карты`;
+  return `${val} карт`;
+}
+
+function updateTimerDisplay() {
+  const req = managerState.active;
+  if (!req || !managerState.timerEl) return;
+  const now = Date.now();
+  const msLeft = Math.max(0, (req.deadline || 0) - now);
+  const seconds = Math.ceil(msLeft / 1000);
+  managerState.timerEl.textContent = `${seconds} с`;
+  if (msLeft <= 0) {
+    managerState.raf = null;
+    managerState.timerEl.textContent = '0 с';
+    managerState.timeout = null;
+    managerState.deadline = null;
+    triggerAutoDiscard();
+    return;
+  }
+  managerState.raf = requestAnimationFrame(updateTimerDisplay);
+}
+
+function scheduleCountdown() {
+  clearTimers();
+  const req = managerState.active;
+  if (!req) return;
+  const duration = req.autoRandomMs || DEFAULT_AUTO_MS;
+  const deadline = Date.now() + duration;
+  req.deadline = deadline;
+  managerState.timeout = setTimeout(triggerAutoDiscard, duration + 20);
+  managerState.raf = requestAnimationFrame(updateTimerDisplay);
+}
+
+function resetSelectionState() {
+  if (interactionState.pendingDiscardSelection?.requestId === managerState.active?.id) {
+    interactionState.pendingDiscardSelection = null;
+  }
+}
+
+function finishRequest() {
+  clearTimers();
+  resetSelectionState();
+  hideOverlay();
+  managerState.active = null;
+  notifyInputLockChanged();
+  resumeTurnTimerIfIdle(typeof window !== 'undefined' ? window.gameState : null);
+}
+
+function applyStateMutation(updater) {
+  try {
+    const gs = window.gameState;
+    if (!gs) return;
+    updater(gs);
+    if (typeof window.schedulePush === 'function') {
+      window.schedulePush('forced-discard', { force: true });
+    }
+    if (typeof window.updateHand === 'function') {
+      window.updateHand(gs);
+    }
+    if (typeof window.__ui?.handCount?.update === 'function') {
+      window.__ui.handCount.update(gs);
+    }
+  } catch {}
+}
+
+function removeRequestFromState(reqId) {
+  applyStateMutation((gs) => {
+    const queue = Array.isArray(gs.pendingDiscards) ? gs.pendingDiscards : (gs.pendingDiscards = []);
+    const idx = queue.findIndex(item => item && item.id === reqId);
+    if (idx >= 0) {
+      queue.splice(idx, 1);
+    }
+  });
+}
+
+function updateRequestRemaining(reqId, remaining) {
+  applyStateMutation((gs) => {
+    const queue = Array.isArray(gs.pendingDiscards) ? gs.pendingDiscards : (gs.pendingDiscards = []);
+    const item = queue.find(entry => entry && entry.id === reqId);
+    if (item) item.remaining = remaining;
+  });
+}
+
+function handleDiscard(handIdx, { auto = false } = {}) {
+  const req = managerState.active;
+  const state = window.gameState;
+  if (!req || !state) return;
+  const player = state.players?.[req.target];
+  if (!player || !Array.isArray(player.hand) || player.hand.length === 0) {
+    completeRequestAndSync(req, state);
+    return;
+  }
+  if (typeof handIdx !== 'number' || handIdx < 0 || handIdx >= player.hand.length) {
+    return;
+  }
+  const cardTpl = player.hand[handIdx];
+  discardHandCard(player, handIdx);
+  const tplName = cardTpl?.name || formatCardName(cardTpl?.id || cardTpl?.tplId);
+  const playerName = resolvePlayerName(state, req.target);
+  const sourceName = formatSource(req);
+  if (auto) {
+    window.addLog?.(`${sourceName}: ${playerName} сбрасывает ${tplName} автоматически (таймер).`);
+  } else {
+    window.addLog?.(`${sourceName}: ${playerName} сбрасывает ${tplName}.`);
+  }
+
+  const newRemaining = Math.max(0, (req.remaining || 1) - 1);
+  req.remaining = newRemaining;
+  if (newRemaining <= 0) {
+    completeRequestAndSync(req, state);
+    return;
+  }
+  updateRequestRemaining(req.id, newRemaining);
+  managerState.subEl.textContent = `${playerName}: сбросьте ${formatRemaining(newRemaining)}.`;
+  scheduleCountdown();
+  prepareSelection();
+}
+
+function triggerAutoDiscard() {
+  const req = managerState.active;
+  const state = window.gameState;
+  if (!req || !state) return;
+  const player = state.players?.[req.target];
+  const hand = Array.isArray(player?.hand) ? player.hand : [];
+  if (!hand.length) {
+    completeRequestAndSync(req, state);
+    return;
+  }
+  const idx = Math.floor(Math.random() * hand.length);
+  handleDiscard(idx, { auto: true });
+}
+
+function prepareSelection() {
+  const req = managerState.active;
+  const state = window.gameState;
+  if (!req || !state) return;
+  const player = state.players?.[req.target];
+  if (!player || !Array.isArray(player.hand) || player.hand.length === 0) {
+    completeRequestAndSync(req, state);
+    return;
+  }
+  interactionState.pendingDiscardSelection = {
+    forced: true,
+    keepAfterPick: true,
+    requestId: req.id,
+    onPicked: (handIdx) => {
+      handleDiscard(handIdx, { auto: false });
+    },
+  };
+}
+
+function beginRequest(state, req) {
+  const container = ensureContainer();
+  if (!container) return;
+  managerState.active = { ...req };
+  const playerName = resolvePlayerName(state, req.target);
+  const source = formatSource(req);
+  managerState.titleEl.textContent = `${source}: требуется сброс`;
+  managerState.subEl.textContent = `${playerName}: сбросьте ${formatRemaining(req.remaining)}.`;
+  pauseTurnTimer();
+  showOverlay();
+  prepareSelection();
+  scheduleCountdown();
+  notifyInputLockChanged();
+}
+
+function cancelIfStale(state) {
+  const req = managerState.active;
+  if (!req) return;
+  const queue = Array.isArray(state?.pendingDiscards) ? state.pendingDiscards : [];
+  const match = queue.find(item => item && item.id === req.id);
+  if (!match || match.remaining <= 0) {
+    finishRequest();
+  }
+}
+
+function findNextLocalRequest(state) {
+  const queue = Array.isArray(state?.pendingDiscards) ? state.pendingDiscards : [];
+  if (!queue.length) return null;
+  const seats = getLocalSeats();
+  for (const req of queue) {
+    if (!req || req.remaining <= 0) continue;
+    if (seats.includes(req.target)) return req;
+  }
+  return null;
+}
+
+export function syncWithState(state) {
+  if (state && hasPendingRequests(state)) {
+    pauseTurnTimer();
+  } else {
+    resumeTurnTimerIfIdle(state);
+  }
+  const seats = getLocalSeats();
+  if (!state || seats.length === 0) {
+    finishRequest();
+    ensureAutoEndResume(state);
+    return;
+  }
+  if (managerState.active) {
+    cancelIfStale(state);
+  }
+  const current = managerState.active;
+  if (current) {
+    const queue = Array.isArray(state.pendingDiscards) ? state.pendingDiscards : [];
+    const match = queue.find(item => item && item.id === current.id);
+    if (match && match.remaining !== current.remaining) {
+      current.remaining = match.remaining;
+      managerState.subEl.textContent = `${resolvePlayerName(state, match.target)}: сбросьте ${formatRemaining(match.remaining)}.`;
+      scheduleCountdown();
+      prepareSelection();
+    }
+    if (match && (!interactionState.pendingDiscardSelection || interactionState.pendingDiscardSelection.requestId !== match.id)) {
+      prepareSelection();
+    }
+    return;
+  }
+  const next = findNextLocalRequest(state);
+  if (!next) {
+    finishRequest();
+    ensureAutoEndResume(state);
+    return;
+  }
+  beginRequest(state, next);
+  ensureAutoEndResume(state);
+}
+
+export function initDiscardManager() {
+  ensureContainer();
+}
+
+export function hasActiveLocalRequest() {
+  if (!managerState.active) return false;
+  const seats = getLocalSeats();
+  return seats.includes(managerState.active.target);
+}
+
+const api = { initDiscardManager, syncWithState, hasActiveLocalRequest };
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.discardManager = api;
+  }
+} catch {}
+
+export default api;

--- a/tests/discard.test.js
+++ b/tests/discard.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { applyDeathDiscardEffects } from '../src/core/abilityHandlers/discard.js';
+
+function makePlayer(handIds = []) {
+  return {
+    hand: handIds.map(id => ({ id })),
+    deck: [],
+    discard: [],
+    graveyard: [],
+    mana: 0,
+    maxMana: 10,
+  };
+}
+
+function createBoard(elements) {
+  return elements.map(row => row.map(el => ({ element: el, unit: null })));
+}
+
+describe('discard ability handlers', () => {
+  it('adds discard request for Elven Rider on non-wood field', () => {
+    const elements = [
+      ['FOREST', 'FOREST', 'EARTH'],
+      ['FIRE', 'FOREST', 'FOREST'],
+      ['FOREST', 'WATER', 'FOREST'],
+    ];
+    const state = {
+      board: createBoard(elements),
+      players: [
+        makePlayer([]),
+        makePlayer([
+          'FIRE_FLAME_MAGUS',
+          'FIRE_HELLFIRE_SPITTER',
+          'FIRE_FLAME_ASCETIC',
+          'FIRE_PARTMOLE_FLAME_LIZARD',
+          'FIRE_PARTMOLE_FLAME_GUARD',
+        ]),
+      ],
+      pendingDiscards: [],
+      nextDiscardRequestId: 0,
+    };
+    const deaths = [
+      { r: 0, c: 0, owner: 0, tplId: 'FOREST_ELVEN_RIDER', element: 'EARTH' },
+    ];
+    const result = applyDeathDiscardEffects(state, deaths, { cause: 'TEST' });
+    expect(result.requests).toHaveLength(1);
+    expect(state.pendingDiscards).toHaveLength(1);
+    const request = state.pendingDiscards[0];
+    const forestCount = elements.flat().filter(el => el === 'FOREST').length;
+    expect(request.target).toBe(1);
+    const expectedCount = Math.min(forestCount, state.players[1].hand.length);
+    expect(request.remaining).toBe(expectedCount);
+    expect(result.logs.some(line => line.includes('оппонент'))).toBe(true);
+  });
+
+  it('creates discard for Zomba aura when allies die on forest', () => {
+    const elements = [
+      ['EARTH', 'FOREST', 'WATER'],
+      ['FIRE', 'FOREST', 'EARTH'],
+      ['FOREST', 'WATER', 'FIRE'],
+    ];
+    const state = {
+      board: createBoard(elements),
+      players: [
+        makePlayer([]),
+        makePlayer(['FIRE_FLAME_MAGUS', 'FIRE_HELLFIRE_SPITTER', 'FIRE_FLAME_ASCETIC']),
+      ],
+      pendingDiscards: [],
+      nextDiscardRequestId: 0,
+    };
+    state.board[1][1].unit = { tplId: 'FOREST_GREEN_ERLKING_ZOMBA', owner: 0 };
+    const deaths = [
+      { r: 0, c: 1, owner: 0, tplId: 'FOREST_GREEN_CUBIC', element: 'FOREST' },
+      { r: 0, c: 2, owner: 0, tplId: 'FOREST_SWALLOW_NINJA', element: 'WATER' },
+    ];
+    const result = applyDeathDiscardEffects(state, deaths, { cause: 'TEST_AURA' });
+    expect(result.requests).toHaveLength(1);
+    const request = state.pendingDiscards[0];
+    expect(request.target).toBe(1);
+    expect(request.remaining).toBe(2);
+  });
+});

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -165,6 +165,17 @@ describe('guards and hits', () => {
     expect(targetHit.dmg).toBe(CARDS.FIRE_HELLFIRE_SPITTER.atk + 1);
   });
 
+  it('Leapfrog Bandit получает бонус за атаку из blind spot через одну клетку', () => {
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][0].unit = { owner: 0, tplId: 'FOREST_LEAPFROG_BANDIT', facing: 'E' };
+    state.board[1][2].unit = { owner: 1, tplId: 'FIRE_PARTMOLE_FLAME_LIZARD', facing: 'E', currentHP: 3 };
+    const hits = computeHits(state, 1, 0);
+    const targetHit = hits.find(h => h.r === 1 && h.c === 2);
+    expect(targetHit).toBeTruthy();
+    expect(targetHit.backstab).toBe(true);
+    expect(targetHit.dmg).toBe(CARDS.FOREST_LEAPFROG_BANDIT.atk + 1);
+  });
+
   it('Biolith Battle Chariot поражает клетки впереди и справа одновременно', () => {
     const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
     state.board[1][1].unit = { owner: 0, tplId: 'BIOLITH_BATTLE_CHARIOT', facing: 'N' };


### PR DESCRIPTION
## Summary
- синхронизировал управление очередью принудительного сброса через общие хелперы и теперь глобальный таймер хода приостанавливается для всех игроков, пока остаются обязательные сбросы
- после очистки очереди дискарда автоматически возобновляется отложенное завершение хода, даже если сброс инициировал другой игрок
- принудительные сбросы отправляют на сервер мгновенный снапшот состояния, чтобы избежать повторного появления сброшенных карт и повторных запросов

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3e2a44f3c833091d214a7a8d4c84c