### PR TITLE
Fix Biolith field buffs and perfect dodge retaliation handling

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -41,6 +41,11 @@ import {
   computeAuraProtection as computeAuraProtectionInternal,
 } from './abilityHandlers/protection.js';
 import { normalizeElementName } from './utils/elements.js';
+import {
+  applyFieldFatalityCheck as applyFieldFatalityCheckInternal,
+  describeFieldFatality as describeFieldFatalityInternal,
+  evaluateFieldFatality as evaluateFieldFatalityInternal,
+} from './abilityHandlers/fieldHazards.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -293,8 +298,14 @@ export function collectDamageInteractions(state, context = {}) {
   const processed = [];
   for (const h of hits) {
     if (!h) continue;
+    if (h.sameOwner) continue;
     const dealt = h.dealt ?? h.dmg ?? 0;
-    if (dealt <= 0) continue;
+    const allowZero = !!tpl.swapOnDamageAllowZero;
+    const contactHit = !h.invisible && !h.dodge;
+    if (!contactHit && dealt <= 0) continue;
+    if (dealt <= 0) {
+      if (!allowZero || !contactHit) continue;
+    }
     const cell = state.board?.[h.r]?.[h.c];
     const target = cell?.unit;
     if (!target) continue;
@@ -406,6 +417,12 @@ export function applyDamageInteractionResults(state, effects = {}) {
       if (attackerLog) logs.push(attackerLog);
       const targetLog = describeShift(shiftTarget, targetName);
       if (targetLog) logs.push(targetLog);
+      const attackerHazard = applyFieldFatalityCheckInternal(attackerUnit, tplAttacker, targetPrevElement);
+      const targetHazard = applyFieldFatalityCheckInternal(targetUnit, tplTarget, attackerPrevElement);
+      const attackerFatalLog = describeFieldFatalityInternal(tplAttacker, attackerHazard, { name: attackerName });
+      if (attackerFatalLog) logs.push(attackerFatalLog);
+      const targetFatalLog = describeFieldFatalityInternal(tplTarget, targetHazard, { name: targetName });
+      if (targetFatalLog) logs.push(targetFatalLog);
     } else if (ev?.type === 'ROTATE_TARGET') {
       const target = findUnitRef(state, ev.target);
       if (!target.unit) continue;
@@ -456,6 +473,9 @@ export function applyDamageInteractionResults(state, effects = {}) {
           logs.push(`${targetName} теряет силу на ${fieldLabel}: HP ${prev}→${next}.`);
         }
       }
+      const hazard = applyFieldFatalityCheckInternal(state.board[to.r][to.c]?.unit, tplTarget, toElement);
+      const fatalLog = describeFieldFatalityInternal(tplTarget, hazard, { name: targetName });
+      if (fatalLog) logs.push(fatalLog);
     }
   }
 
@@ -794,6 +814,9 @@ export const attemptUnitDodge = attemptDodgeInternal;
 export const refreshContinuousPossessions = refreshContinuousPossessionsInternal;
 export { refreshBoardDodgeStates };
 export const applyTurnStartManaEffects = applyTurnStartManaEffectsInternal;
+export const evaluateFieldFatality = evaluateFieldFatalityInternal;
+export const applyFieldFatalityCheck = applyFieldFatalityCheckInternal;
+export const describeFieldFatality = describeFieldFatalityInternal;
 
 export function collectUnitActions(state, r, c) {
   const actions = [];

--- a/src/core/abilityHandlers/fieldHazards.js
+++ b/src/core/abilityHandlers/fieldHazards.js
@@ -1,0 +1,56 @@
+// Модуль обработки мгновенных смертей от неподходящих полей
+// Содержит только игровую логику без привязки к визуальной части
+import { normalizeElementName } from '../utils/elements.js';
+
+function resolveRequiredElement(tpl) {
+  if (!tpl) return null;
+  const direct = tpl.diesOffNonElement != null ? tpl.diesOffNonElement : tpl.diesOffElement;
+  const normalized = normalizeElementName(direct);
+  return normalized || null;
+}
+
+function resolveForbiddenElement(tpl) {
+  if (!tpl) return null;
+  const normalized = normalizeElementName(tpl.diesOnElement);
+  return normalized || null;
+}
+
+export function evaluateFieldFatality(tpl, cellElement) {
+  const cell = normalizeElementName(cellElement);
+  const required = resolveRequiredElement(tpl);
+  if (required && cell !== required) {
+    return { dies: true, reason: 'OFF_ELEMENT', element: required };
+  }
+  const forbidden = resolveForbiddenElement(tpl);
+  if (forbidden && cell === forbidden) {
+    return { dies: true, reason: 'ON_ELEMENT', element: forbidden };
+  }
+  return { dies: false, reason: null, element: null };
+}
+
+export function applyFieldFatalityCheck(unit, tpl, cellElement) {
+  const verdict = evaluateFieldFatality(tpl, cellElement);
+  if (verdict.dies && unit) {
+    unit.currentHP = 0;
+  }
+  return verdict;
+}
+
+export function describeFieldFatality(tpl, verdict, opts = {}) {
+  if (!verdict?.dies) return null;
+  const name = opts.name || tpl?.name || 'Существо';
+  const element = verdict.element || 'UNKNOWN';
+  if (verdict.reason === 'OFF_ELEMENT') {
+    return `${name} погибает вдали от стихии ${element}!`;
+  }
+  if (verdict.reason === 'ON_ELEMENT') {
+    return `${name} не переносит стихию ${element} и погибает!`;
+  }
+  return `${name} погибает из-за несовместимого поля ${element}.`;
+}
+
+export default {
+  evaluateFieldFatality,
+  applyFieldFatalityCheck,
+  describeFieldFatality,
+};

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -391,6 +391,22 @@ export const CARDS = {
     ],
     desc: 'Morning Star Warrior adds 2 to its Attack if the target creature has 5 or more HPs.\nMorning Star Warrior gains Protection equal to the number of allied Biolith creatures.'
   },
+  BIOLITH_BIOLITH_STINGER: {
+    id: 'BIOLITH_BIOLITH_STINGER', name: 'Biolith Stinger', type: 'UNIT', cost: 3, activation: 2,
+    element: 'BIOLITH', atk: 0, hp: 1,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1] },
+      { dir: 'E', ranges: [1] },
+      { dir: 'S', ranges: [1] },
+      { dir: 'W', ranges: [1] }
+    ],
+    blindspots: [],
+    dodge: { chance: 0.5, attempts: 1 },
+    swapOnDamage: true,
+    swapOnDamageAllowZero: true,
+    desc: 'Dodge attempt. If Biolith Stinger attacks a creature and does not destroy it, it switches locations with that creature (which cannot counterattack).'
+  },
 
   EARTH_NOVOGUS_GRAVEKEEPER: {
     id: 'EARTH_NOVOGUS_GRAVEKEEPER', name: 'Novogus Gravekeeper', type: 'UNIT', cost: 9, activation: 5,
@@ -593,6 +609,18 @@ export const CARDS = {
     onEnemySummonAdjacentHealAllies: 1,
     diesOnElement: 'EARTH',
     desc: 'Fortress: cannot attack unless counterattacking. When an enemy creature is summoned adjacent to it, all other allied creatures gain 1 HP. Destroy if on an Earth field.'
+  },
+  WOOD_JUNO_TREE_HAUNT: {
+    id: 'WOOD_JUNO_TREE_HAUNT', name: 'Juno Tree Haunt', type: 'UNIT', cost: 3, activation: 1,
+    element: 'FOREST', atk: 2, hp: 1,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1, 2], mode: 'ANY', ignoreBlocking: true },
+    ],
+    blindspots: ['S'],
+    perfectDodge: true,
+    diesOffNonElement: 'FOREST',
+    desc: 'Perfect Dodge. Destroy if on a non‑Wood field.'
   },
   FOREST_EDIN_THE_PERSECUTED: {
     id: 'FOREST_EDIN_THE_PERSECUTED', name: 'Edin the Persecuted', type: 'UNIT', cost: 3, activation: 2,

--- a/src/core/fieldEffects.js
+++ b/src/core/fieldEffects.js
@@ -14,8 +14,8 @@ const OPPOSITES = {
 
 export function computeCellBuff(cellElement, unitElement) {
   if (!cellElement || !unitElement) return { atk: 0, hp: 0 };
-  if (cellElement === unitElement) return { atk: 0, hp: 2 };
   if (cellElement === 'BIOLITH') return { atk: 0, hp: 0 };
+  if (cellElement === unitElement) return { atk: 0, hp: 2 };
   const opposite = OPPOSITES[unitElement];
   if (opposite && cellElement === opposite) return { atk: 0, hp: -2 };
   return { atk: 0, hp: 0 };


### PR DESCRIPTION
## Summary
- добавлена карта Juno Tree Haunt со способностями Perfect Dodge и гибелью на чужих полях
- добавлена карта Biolith Stinger с попыткой уворота и обменом позиций при уроне
- вынесена логика моментальной гибели от неподходящих полей в отдельный модуль и подключена к призыву и перемещениям
- исправлены эффекты поля Биолита, чтобы оно не давало бонусов существам
- расширена защита Perfect Dodge на физические контратаки и исправлена работа магов, погибающих от поля

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4fbf7d7788330aca289c23981417c