### PR TITLE
Add new forest and earth units with conditional abilities

### DIFF
--- a/src/core/abilityHandlers/dodgeEffects.js
+++ b/src/core/abilityHandlers/dodgeEffects.js
@@ -2,6 +2,7 @@
 // Позволяет повторно использовать логику как в браузере, так и при переносе в другие движки
 import { CARDS } from '../cards.js';
 import { getDodgeConfig, ensureDodgeState } from './dodge.js';
+import { computeSelfHpDodgeBonus } from './selfState.js';
 
 const DIRS = [
   { dr: -1, dc: 0 },
@@ -147,6 +148,14 @@ export function refreshBoardDodgeStates(state) {
             attempts: enemyGain.attemptsPerEnemy * enemies,
           });
         }
+      }
+
+      const selfHpBonus = computeSelfHpDodgeBonus(state, r, c, tpl);
+      if (selfHpBonus) {
+        addContribution(contributions, r, c, {
+          attempts: selfHpBonus.attempts,
+          chance: selfHpBonus.chance,
+        });
       }
     }
   }

--- a/src/core/abilityHandlers/dynamicAttack.js
+++ b/src/core/abilityHandlers/dynamicAttack.js
@@ -4,6 +4,133 @@ import { countUnits } from '../board.js';
 import { CARDS } from '../cards.js';
 import { normalizeElementName } from '../utils/elements.js';
 
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeTemplateList(raw) {
+  const ids = new Set();
+  const names = new Set();
+  for (const entry of toArray(raw)) {
+    if (!entry) continue;
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim();
+      if (!trimmed) continue;
+      if (trimmed === trimmed.toUpperCase()) ids.add(trimmed);
+      names.add(trimmed.toLowerCase());
+    }
+  }
+  return { ids, names };
+}
+
+function matchesTemplate(unit, tpl, ids, names) {
+  if (!unit || !tpl) return false;
+  if (ids.size) {
+    if (ids.has(unit.tplId)) return true;
+    if (tpl.id && ids.has(tpl.id)) return true;
+  }
+  if (names.size) {
+    const lower = tpl.name ? tpl.name.toLowerCase() : '';
+    if (lower && names.has(lower)) return true;
+  }
+  return false;
+}
+
+function countAlliedByTemplate(state, r, c, owner, ids, names, includeSelf) {
+  if (!state?.board) return 0;
+  let total = 0;
+  for (let rr = 0; rr < state.board.length; rr += 1) {
+    const row = state.board[rr];
+    if (!Array.isArray(row)) continue;
+    for (let cc = 0; cc < row.length; cc += 1) {
+      if (!includeSelf && rr === r && cc === c) continue;
+      const unit = row[cc]?.unit;
+      if (!unit) continue;
+      if (owner != null && unit.owner !== owner) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      if (matchesTemplate(unit, tpl, ids, names)) {
+        total += 1;
+      }
+    }
+  }
+  return total;
+}
+
+function normalizeTemplateConfig(raw) {
+  if (!raw) return null;
+  const typeRaw = String(raw.type || raw.mode || raw.kind || '').toUpperCase();
+  if (typeRaw && !['ALLY_TEMPLATE', 'ALLY_CARD', 'ALLY_TPL'].includes(typeRaw)) {
+    return null;
+  }
+  const list = raw.templates || raw.ids || raw.tplIds || raw.cards || raw.names;
+  const { ids, names } = normalizeTemplateList(list);
+  if (!ids.size && !names.size) return null;
+  const includeSelf = raw.includeSelf != null ? !!raw.includeSelf : false;
+  const per = Number.isFinite(raw.per) ? raw.per : (Number.isFinite(raw.amountPer) ? raw.amountPer : 1);
+  const max = Number.isFinite(raw.max) ? raw.max
+    : (Number.isFinite(raw.maxAmount) ? raw.maxAmount
+      : (Number.isFinite(raw.maxBonus) ? raw.maxBonus : null));
+  return {
+    type: 'ALLY_TEMPLATE',
+    ids,
+    names,
+    includeSelf,
+    per: Number.isFinite(per) ? per : 1,
+    max: Number.isFinite(max) ? max : null,
+  };
+}
+
+function normalizeDynamicConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const upper = raw.toUpperCase();
+    if (upper === 'OTHERS_ON_BOARD') {
+      return { type: 'OTHERS_ON_BOARD' };
+    }
+    const elementCfg = normalizeElementConfig(raw);
+    if (elementCfg?.type === 'ELEMENT_CREATURES' && elementCfg.element) {
+      return { type: 'ELEMENT_CREATURES', element: elementCfg.element };
+    }
+    const element = normalizeElementName(raw);
+    if (element) {
+      return { type: 'ELEMENT_CREATURES', element };
+    }
+    return null;
+  }
+  if (typeof raw === 'object') {
+    const typeRaw = String(raw.type || raw.mode || raw.kind || '').toUpperCase();
+    if (typeRaw === 'OTHERS_ON_BOARD') {
+      return { type: 'OTHERS_ON_BOARD' };
+    }
+    if (typeRaw === 'ALLY_TEMPLATE' || typeRaw === 'ALLY_CARD' || typeRaw === 'ALLY_TPL' || (!typeRaw && (raw.templates || raw.ids || raw.tplIds || raw.cards))) {
+      return normalizeTemplateConfig(raw);
+    }
+    if (typeRaw === 'ALLY_ELEMENT') {
+      const element = normalizeElementName(raw.element || raw.match || raw.elementType);
+      if (!element) return null;
+      const includeSelf = raw.includeSelf != null ? !!raw.includeSelf : false;
+      const per = Number.isFinite(raw.per) ? raw.per : (Number.isFinite(raw.amountPer) ? raw.amountPer : 1);
+      return {
+        type: 'ALLY_ELEMENT',
+        element,
+        includeSelf,
+        per: Number.isFinite(per) ? per : 1,
+      };
+    }
+    const elementCfg = normalizeElementConfig(raw);
+    if (elementCfg?.type === 'ELEMENT_CREATURES' && elementCfg.element) {
+      return { type: 'ELEMENT_CREATURES', element: elementCfg.element };
+    }
+    const element = normalizeElementName(raw.element || raw.match || raw.type);
+    if (element) {
+      return { type: 'ELEMENT_CREATURES', element };
+    }
+  }
+  return null;
+}
+
 function parseElementFromToken(token) {
   if (!token) return null;
   return normalizeElementName(token);
@@ -58,23 +185,77 @@ function countElementCreatures(state, element, opts = {}) {
   return count;
 }
 
+function countAlliedByElement(state, r, c, owner, element, includeSelf) {
+  if (!state?.board || !element) return 0;
+  let total = 0;
+  for (let rr = 0; rr < state.board.length; rr += 1) {
+    const row = state.board[rr];
+    if (!Array.isArray(row)) continue;
+    for (let cc = 0; cc < row.length; cc += 1) {
+      if (!includeSelf && rr === r && cc === c) continue;
+      const unit = row[cc]?.unit;
+      if (!unit) continue;
+      if (owner != null && unit.owner !== owner) continue;
+      const tplUnit = CARDS[unit.tplId];
+      if (tplUnit?.element === element) {
+        total += 1;
+      }
+    }
+  }
+  return total;
+}
+
 export function computeDynamicAttackBonus(state, r, c, tpl) {
   if (!tpl || !tpl.dynamicAtk) return null;
-  const cfg = tpl.dynamicAtk;
-  if (cfg === 'OTHERS_ON_BOARD') {
+  const cfg = normalizeDynamicConfig(tpl.dynamicAtk);
+  if (!cfg) return null;
+  if (cfg.type === 'OTHERS_ON_BOARD') {
     const total = countUnits(state);
     const others = Math.max(0, total - 1);
     if (others <= 0) return null;
     return { amount: others, type: 'OTHERS_ON_BOARD', count: others };
   }
-  const elementCfg = normalizeElementConfig(cfg);
-  if (elementCfg?.type === 'ELEMENT_CREATURES' && elementCfg.element) {
-    const count = countElementCreatures(state, elementCfg.element, { exclude: { r, c } });
+  if (cfg.type === 'ELEMENT_CREATURES' && cfg.element) {
+    const count = countElementCreatures(state, cfg.element, { exclude: { r, c } });
     if (count <= 0) return null;
     return {
       amount: count,
       type: 'ELEMENT_CREATURES',
-      element: elementCfg.element,
+      element: cfg.element,
+      count,
+    };
+  }
+  if (cfg.type === 'ALLY_TEMPLATE') {
+    const cell = state?.board?.[r]?.[c];
+    const unit = cell?.unit;
+    const owner = unit?.owner ?? null;
+    const count = countAlliedByTemplate(state, r, c, owner, cfg.ids, cfg.names, cfg.includeSelf);
+    if (count <= 0) return null;
+    const rawAmount = count * (cfg.per ?? 1);
+    const amount = cfg.max != null ? Math.min(rawAmount, cfg.max) : rawAmount;
+    if (!amount) return null;
+    return {
+      amount,
+      type: 'ALLY_TEMPLATE',
+      count,
+      templates: {
+        ids: Array.from(cfg.ids),
+        names: Array.from(cfg.names),
+      },
+    };
+  }
+  if (cfg.type === 'ALLY_ELEMENT' && cfg.element) {
+    const cell = state?.board?.[r]?.[c];
+    const unit = cell?.unit;
+    const owner = unit?.owner ?? null;
+    const count = countAlliedByElement(state, r, c, owner, cfg.element, cfg.includeSelf);
+    if (count <= 0) return null;
+    const amount = count * (cfg.per ?? 1);
+    if (!amount) return null;
+    return {
+      amount,
+      type: 'ALLY_ELEMENT',
+      element: cfg.element,
       count,
     };
   }

--- a/src/core/abilityHandlers/selfState.js
+++ b/src/core/abilityHandlers/selfState.js
@@ -1,0 +1,109 @@
+// Модуль для обработки эффектов, зависящих от текущего состояния самого существа
+// Держим логику изолированной от визуальной части для возможного переноса на другие движки
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function clampChance(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (num <= 0) return 0;
+  if (num >= 1) return 1;
+  return num;
+}
+
+function normalizeEffect(raw) {
+  if (!raw) return null;
+  if (typeof raw !== 'object') return null;
+  const equalsRaw = raw.hpEquals ?? raw.equals ?? raw.eq ?? raw.hp ?? raw.value;
+  const equals = Number.isFinite(equalsRaw) ? Math.floor(equalsRaw) : null;
+  if (equals == null) return null;
+  const atkBonusRaw = raw.atkBonus ?? raw.atk ?? raw.plusAtk ?? raw.attackBonus;
+  const dodgeAttemptsRaw = raw.dodgeAttempts ?? raw.dodge ?? raw.attempts ?? raw.dodgeAttempt;
+  const dodgeChanceRaw = raw.dodgeChance ?? raw.chance ?? raw.dodgeRate;
+
+  const effect = { hpEquals: equals };
+  if (Number.isFinite(atkBonusRaw) && atkBonusRaw !== 0) {
+    effect.atkBonus = Math.floor(atkBonusRaw);
+  }
+  if (Number.isFinite(dodgeAttemptsRaw) && dodgeAttemptsRaw > 0) {
+    effect.dodgeAttempts = Math.max(0, Math.floor(dodgeAttemptsRaw));
+  }
+  const chance = clampChance(dodgeChanceRaw);
+  if (chance != null) {
+    effect.dodgeChance = chance;
+  }
+  if (!effect.atkBonus && !effect.dodgeAttempts && effect.dodgeChance == null) {
+    return null;
+  }
+  return effect;
+}
+
+function collectEffects(tpl) {
+  const raw = tpl?.hpConditionalEffects || tpl?.selfHpConditionalEffects;
+  const list = [];
+  for (const item of toArray(raw)) {
+    const normalized = normalizeEffect(item);
+    if (normalized) list.push(normalized);
+  }
+  return list;
+}
+
+function getUnitCurrentHp(unit, tpl) {
+  if (!unit) return null;
+  if (typeof unit.currentHP === 'number' && Number.isFinite(unit.currentHP)) {
+    return unit.currentHP;
+  }
+  if (typeof tpl?.hp === 'number' && Number.isFinite(tpl.hp)) {
+    return tpl.hp;
+  }
+  return null;
+}
+
+export function computeSelfHpAttackBonus(state, r, c, tpl) {
+  if (!tpl) return null;
+  const effects = collectEffects(tpl);
+  if (!effects.length) return null;
+  const unit = state?.board?.[r]?.[c]?.unit;
+  if (!unit) return null;
+  const currentHp = getUnitCurrentHp(unit, tpl);
+  if (currentHp == null) return null;
+  let total = 0;
+  for (const effect of effects) {
+    if (effect.hpEquals === currentHp && effect.atkBonus) {
+      total += effect.atkBonus;
+    }
+  }
+  if (!total) return null;
+  return { amount: total, hp: currentHp };
+}
+
+export function computeSelfHpDodgeBonus(state, r, c, tpl) {
+  if (!tpl) return null;
+  const effects = collectEffects(tpl);
+  if (!effects.length) return null;
+  const unit = state?.board?.[r]?.[c]?.unit;
+  if (!unit) return null;
+  const currentHp = getUnitCurrentHp(unit, tpl);
+  if (currentHp == null) return null;
+  let attempts = 0;
+  let chance = null;
+  for (const effect of effects) {
+    if (effect.hpEquals !== currentHp) continue;
+    if (effect.dodgeAttempts) {
+      attempts += effect.dodgeAttempts;
+    }
+    if (effect.dodgeChance != null) {
+      chance = effect.dodgeChance;
+    }
+  }
+  if (attempts <= 0 && chance == null) return null;
+  return { attempts, chance, hp: currentHp };
+}
+
+export default {
+  computeSelfHpAttackBonus,
+  computeSelfHpDodgeBonus,
+};

--- a/src/core/abilityHandlers/summonBonuses.js
+++ b/src/core/abilityHandlers/summonBonuses.js
@@ -1,0 +1,82 @@
+// Обработка бонусов, которые срабатывают при призыве самого существа
+// Содержит только игровую логику без визуальных побочных эффектов
+import { CARDS } from '../cards.js';
+
+function clampChance(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0.5;
+  if (num <= 0) return 0;
+  if (num >= 1) return 1;
+  return num;
+}
+
+function normalizeRandomSelfBuff(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'object') {
+    const chance = clampChance(raw.chance ?? raw.rate ?? raw.probability ?? 0.5);
+    const hp = Number.isFinite(raw.hp) ? Math.floor(raw.hp) : Number.isFinite(raw.health) ? Math.floor(raw.health) : 0;
+    const atk = Number.isFinite(raw.atk) ? Math.floor(raw.atk) : Number.isFinite(raw.attack) ? Math.floor(raw.attack) : Number.isFinite(raw.atkBonus) ? Math.floor(raw.atkBonus) : 0;
+    if (!hp && !atk) return null;
+    return { chance, hp, atk };
+  }
+  return null;
+}
+
+function applyHpBonus(unit, tpl, amount) {
+  if (!unit || !tpl || !amount) return null;
+  const safeAmount = Math.max(0, Math.floor(amount));
+  if (!safeAmount) return null;
+  const baseHp = typeof tpl.hp === 'number' ? tpl.hp : 0;
+  const prevBonus = Math.max(0, Math.floor(unit.bonusHP || 0));
+  const prevMax = baseHp + prevBonus;
+  const before = Number.isFinite(unit.currentHP) ? unit.currentHP : baseHp;
+  unit.bonusHP = prevBonus + safeAmount;
+  const newMax = prevMax + safeAmount;
+  const after = Math.min(newMax, before + safeAmount);
+  unit.currentHP = after;
+  return { before, after, amount: safeAmount };
+}
+
+function applyAtkBonus(unit, amount) {
+  if (!unit || !amount) return null;
+  const safeAmount = Math.max(0, Math.floor(amount));
+  if (!safeAmount) return null;
+  const prev = Math.max(0, Math.floor(unit.bonusAtk || 0));
+  unit.bonusAtk = prev + safeAmount;
+  return { before: prev, after: unit.bonusAtk, amount: safeAmount };
+}
+
+export function applySummonSelfBuffs(state, r, c, opts = {}) {
+  const result = { logs: [] };
+  const cell = state?.board?.[r]?.[c];
+  const unit = cell?.unit;
+  if (!unit) return result;
+  const tpl = CARDS[unit.tplId];
+  if (!tpl) return result;
+
+  const config = normalizeRandomSelfBuff(tpl.randomSelfBuffOnSummon || tpl.randomBuffOnSummon);
+  if (!config) return result;
+
+  const rng = typeof opts?.rng === 'function' ? opts.rng : Math.random;
+  const roll = rng();
+  result.roll = roll;
+  if (roll >= config.chance) {
+    return result;
+  }
+
+  const hpChange = applyHpBonus(unit, tpl, config.hp);
+  const atkChange = applyAtkBonus(unit, config.atk);
+
+  if (hpChange) {
+    result.hp = hpChange.amount;
+    result.logs.push(`${tpl.name}: получает +${hpChange.amount} HP (текущее значение ${hpChange.after}).`);
+  }
+  if (atkChange) {
+    result.atk = atkChange.amount;
+    result.logs.push(`${tpl.name}: получает +${atkChange.amount} ATK.`);
+  }
+  result.applied = true;
+  return result;
+}
+
+export default { applySummonSelfBuffs };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -352,6 +352,15 @@ export const CARDS = {
     protectionEqualsAlliedTemplates: ['EARTH_GIANT_AXE_DWARF', 'Giant Axe Dwarf'],
     desc: 'Stone Wing Dwarf gains Protection equal to the number of allied Giant Axe Dwarves on the board.'
   },
+  EARTH_GIANT_AXE_DWARF: {
+    id: 'EARTH_GIANT_AXE_DWARF', name: 'Giant Axe Dwarf', type: 'UNIT', cost: 2, activation: 1,
+    element: 'EARTH', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    dynamicAtk: { type: 'ALLY_TEMPLATE', templates: ['EARTH_STONE_WING_DWARF', 'Stone Wing Dwarf'], per: 1 },
+    desc: 'Giant Axe Dwarf adds 1 to his Attack for every allied Stone Wing Dwarf on the board.'
+  },
 
   EARTH_BLACK_HOOD_DWARF_VULITRA: {
     id: 'EARTH_BLACK_HOOD_DWARF_VULITRA', name: 'Black Hood Dwarf Vulitra', type: 'UNIT', cost: 3, activation: 2,
@@ -376,6 +385,16 @@ export const CARDS = {
       { stat: 'PROTECTION', amount: 1, scope: 'ADJACENT', target: 'ALLY' },
     ],
     desc: 'Allied creatures on adjacent fields gain +1 Protection.'
+  },
+
+  EARTH_VERZAR_FOOT_SOLDIER: {
+    id: 'EARTH_VERZAR_FOOT_SOLDIER', name: 'Verzar Foot Soldier', type: 'UNIT', cost: 1, activation: 1,
+    element: 'EARTH', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    dynamicAtk: { type: 'ALLY_TEMPLATE', templates: ['EARTH_VERZAR_FOOT_SOLDIER', 'Verzar Foot Soldier'], per: 1, max: 1, includeSelf: false },
+    desc: 'Verzar Foot Soldier adds 1 to his Attack if at least one other allied Verzar Foot Soldier is on the board.'
   },
 
   BIOLITH_MORNING_STAR_WARRIOR: {
@@ -593,6 +612,33 @@ export const CARDS = {
     invisibilityAllies: ['FIRE_FIREFLY_NINJA'],
     rotateTargetOnDamage: true,
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
+  },
+  FOREST_GREEN_LYCANTHROPE: {
+    id: 'FOREST_GREEN_LYCANTHROPE', name: 'Green Lycanthrope', type: 'UNIT', cost: 1, activation: 1,
+    element: 'FOREST', atk: 0, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    randomSelfBuffOnSummon: { chance: 0.5, hp: 3, atk: 2 },
+    desc: 'When Green Lycanthrope is summoned, half the time add 3 to its HP and 2 to its Attack.'
+  },
+  FOREST_BEWITCHING_ELF_ARCHERESS: {
+    id: 'FOREST_BEWITCHING_ELF_ARCHERESS', name: 'Bewitching Elf Archeress', type: 'UNIT', cost: 1, activation: 1,
+    element: 'FOREST', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [2], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    rotateTargetOnDamage: true,
+    desc: 'When Archeress damages (but does not destroy) a creature, that creature is rotated 180° and cannot counterattack.'
+  },
+  FOREST_ELVEN_BERSERKER_MAIDEN: {
+    id: 'FOREST_ELVEN_BERSERKER_MAIDEN', name: 'Elven Berserker Maiden', type: 'UNIT', cost: 2, activation: 1,
+    element: 'FOREST', atk: 1, hp: 3,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY', ignoreAlliedBlocking: true } ],
+    blindspots: ['S'], ignoreAlliedBlocking: true,
+    hpConditionalEffects: [ { hpEquals: 1, atkBonus: 2, dodgeAttempts: 1 } ],
+    desc: 'While Elven Berserker Maiden has exactly 1 HP, she adds 2 to her Attack and gains a Dodge attempt.'
   },
   FOREST_JUNO_PRISONER_TRAP: {
     id: 'FOREST_JUNO_PRISONER_TRAP', name: 'Juno Prisoner Trap', type: 'UNIT', cost: 4, activation: 2,

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -932,6 +932,11 @@ export function placeUnitWithDirection(direction) {
     if (Array.isArray(summonEvents?.dodgeUpdates) && summonEvents.dodgeUpdates.length) {
       logDodgeUpdates(summonEvents.dodgeUpdates, gameState, cardData?.name || null);
     }
+    if (Array.isArray(summonEvents?.logLines) && summonEvents.logLines.length) {
+      for (const text of summonEvents.logLines) {
+        window.addLog?.(text);
+      }
+    }
     if (summonEvents?.possessions?.length) {
       try {
         const cards = window.CARDS || {};


### PR DESCRIPTION
## Summary
- add card data for Green Lycanthrope, Bewitching Elf Archeress, Elven Berserker Maiden, Giant Axe Dwarf and Verzar Foot Soldier with correct stats, attacks and descriptions
- extend core logic with self-HP conditional buffs, random summon bonuses, and richer dynamic attack/dodge handling; surface summon buff logs in the scene layer
- expand rules tests to cover the new cards and abilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5129657448330bf074384a9935a52