### PR TITLE
Обновить анимации прироста маны и синхронизацию

### DIFF
--- a/src/net/client.js
+++ b/src/net/client.js
@@ -605,11 +605,7 @@ import { getServerBase } from './config.js';
         // Показать вспышку +2 маны у панели by (только визуально; фактическое значение придёт со снапшотом)
         const barEl = document.getElementById(`mana-display-${by}`);
         if (barEl) {
-          const rect = barEl.getBoundingClientRect();
-          const center = { x: rect.left + rect.width/2, y: rect.top + rect.height/2 };
-          // Две искры в панель — символически
-          animateManaGainFromWorld(new THREE.Vector3(0,0,0), by, true);
-          setTimeout(()=> animateManaGainFromWorld(new THREE.Vector3(0,0,0), by, true), 120);
+          animateManaGainFromWorld(new THREE.Vector3(0,0,0), by, true, null, { count: 2 });
         }
         // Принудительно обновляем UI для полного сброса состояний
         try { updateHand(); } catch {}

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -16,6 +16,7 @@ import {
 } from '../core/abilities.js';
 import { capMana } from '../core/constants.js';
 import { applyDeathDiscardEffects } from '../core/abilityHandlers/discard.js';
+import { applyManaGainOnDeaths } from '../core/abilityHandlers/manaGain.js';
 
 // Centralized interaction state
 export const interactionState = {
@@ -881,16 +882,30 @@ export function placeUnitWithDirection(direction) {
     const owner = unit.owner;
     const deathElement = gameState.board?.[row]?.[col]?.element || null;
     const deathInfo = [{ r: row, c: col, owner, tplId: unit.tplId, uid: unit.uid ?? null, element: deathElement }];
-    const slotBeforeGain = gameState.players?.[owner]?.mana || 0;
+    const playersBefore = Array.isArray(gameState.players)
+      ? gameState.players.map(pl => ({ mana: Math.max(0, Number(pl?.mana) || 0) }))
+      : [];
     try { gameState.players[owner].graveyard.push(window.CARDS[unit.tplId]); } catch {}
     const ownerPlayer = gameState.players?.[owner];
     if (ownerPlayer) {
       ownerPlayer.mana = capMana((ownerPlayer.mana || 0) + 1);
     }
+    const manaAbilityResult = applyManaGainOnDeaths(gameState, deathInfo, { boardState: gameState });
+    if (Array.isArray(manaAbilityResult?.logs) && manaAbilityResult.logs.length) {
+      for (const text of manaAbilityResult.logs) {
+        if (text) window.addLog(text);
+      }
+    }
     const ctx = getCtx();
     const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
-    const pos = ctx.tileMeshes[row][col].position.clone().add(new THREE.Vector3(0, 1.2, 0));
-    window.animateManaGainFromWorld(pos, owner, true, slotBeforeGain);
+    const manaPlan = buildManaGainPlan({
+      playersBefore,
+      deaths: deathInfo,
+      manaGainEntries: Array.isArray(manaAbilityResult?.entries) ? manaAbilityResult.entries : [],
+      tileMeshes: ctx.tileMeshes,
+      THREE,
+    });
+    try { manaPlan?.schedule?.(); } catch (err) { console.error('[interactions] Не удалось запустить анимацию маны:', err); }
     gameState.board[row][col].unit = null;
     const discardEffects = applyDeathDiscardEffects(gameState, deathInfo, { cause: 'SUMMON' });
     if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {


### PR DESCRIPTION
## Summary
- переработал анимацию получения маны из существ: один орб с текстом и вспышкой на панели
- добавил очередь и агрегирование прироста маны, чтобы панель синхронизировалась с визуальными эффектами
- исправил обработку мгновенной смерти и эффектов заклинаний, чтобы дополнительные способности (например, у Skeleton Soldier) давали верное количество маны

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d66e71471083309ac248f00ff6dd2e