### PR TITLE
Переработка анимаций получения маны

### DIFF
--- a/src/net/client.js
+++ b/src/net/client.js
@@ -605,11 +605,9 @@ import { getServerBase } from './config.js';
         // Показать вспышку +2 маны у панели by (только визуально; фактическое значение придёт со снапшотом)
         const barEl = document.getElementById(`mana-display-${by}`);
         if (barEl) {
-          const rect = barEl.getBoundingClientRect();
-          const center = { x: rect.left + rect.width/2, y: rect.top + rect.height/2 };
-          // Две искры в панель — символически
-          animateManaGainFromWorld(new THREE.Vector3(0,0,0), by, true);
-          setTimeout(()=> animateManaGainFromWorld(new THREE.Vector3(0,0,0), by, true), 120);
+          // Две символические вспышки без изменения панелей
+          animateManaGainFromWorld(new THREE.Vector3(0,0,0), by, true, null, { skipPanelUpdate: true, floatDurationMs: 720 });
+          setTimeout(() => animateManaGainFromWorld(new THREE.Vector3(0,0,0), by, true, null, { skipPanelUpdate: true, floatDurationMs: 720 }), 140);
         }
         // Принудительно обновляем UI для полного сброса состояний
         try { updateHand(); } catch {}

--- a/styles/main.css
+++ b/styles/main.css
@@ -10,11 +10,46 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
   background: radial-gradient(circle at 30% 30%, #fff, #8bd5ff 30%, #1ea0ff 70%, #0a67b7); 
   box-shadow: 0 0 10px rgba(30,160,255,0.8); 
 }
-.mana-slot { 
-  width: 18px; height: 18px; border-radius: 50%; 
-  border: 1px solid rgba(255,255,255,0.25); 
-  background: rgba(255,255,255,0.06); 
-  box-shadow: inset 0 2px 6px rgba(0,0,0,0.5); 
+.mana-slot {
+  width: 18px; height: 18px; border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.06);
+  box-shadow: inset 0 2px 6px rgba(0,0,0,0.5);
+}
+/* Эффект вылетающей души маны */
+.mana-soul-wrapper { filter: drop-shadow(0 0 16px rgba(59,130,246,0.55)); }
+.mana-soul-orb {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, rgba(255,255,255,0.95), rgba(125,211,252,0.85) 45%, rgba(14,165,233,0.8) 70%, rgba(15,118,110,0) 100%);
+  box-shadow: 0 0 24px rgba(59,130,246,0.85), 0 0 48px rgba(56,189,248,0.65);
+  mix-blend-mode: screen;
+}
+.mana-soul-flash {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(191,219,254,0.65) 0%, rgba(56,189,248,0.45) 55%, rgba(59,130,246,0) 100%);
+  pointer-events: none;
+}
+.mana-soul-label {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  color: #f8fafc;
+  font-weight: 700;
+  font-size: 18px;
+  text-shadow: 0 0 10px rgba(59,130,246,0.95), 0 0 20px rgba(37,99,235,0.65);
+  pointer-events: none;
+  white-space: nowrap;
 }
 /* Кнопка завершения хода с круговым таймером **/ 
 .end-turn-btn { 


### PR DESCRIPTION
## Summary
- объединён расчёт вылетающих орбов маны в общий план, чтобы синхронизировать итоговое пополнение панелей
- переработана визуализация маны: душа маны поднимается вверх с подсветкой и синхронным появлением орбов на панелях
- исправлен ранний триггер Skeleton Warrior и других мгновенных смертей за счёт применения логики gainManaOnDeath и общего плана анимаций

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d66e71471083309ac248f00ff6dd2e