### PR TITLE
Синхронизация эффекта маны и панели

### DIFF
--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -11,6 +11,52 @@ function setAnim(v){ try { window.PENDING_MANA_ANIM = v; } catch {} }
 function getManaGainActive(){ try { return !!(typeof window !== 'undefined' && window.manaGainActive); } catch { return false; } }
 function setManaGainActive(v){ try { if (typeof window !== 'undefined') { window.manaGainActive = !!v; } } catch {} }
 
+// Очередь отложенных подсветок на панелях маны
+function getRevealQueueRoot(){
+  try {
+    if (typeof window === 'undefined') return [[], []];
+    if (!Array.isArray(window.__PENDING_MANA_REVEAL)) {
+      window.__PENDING_MANA_REVEAL = [[], []];
+    }
+    const root = window.__PENDING_MANA_REVEAL;
+    if (!Array.isArray(root[0])) root[0] = [];
+    if (!Array.isArray(root[1])) root[1] = [];
+    return root;
+  } catch {
+    return [[], []];
+  }
+}
+
+function enqueueReveal(ownerIndex, info){
+  if (!Number.isFinite(ownerIndex)) return;
+  try {
+    if (typeof window === 'undefined') return;
+    const root = getRevealQueueRoot();
+    root[ownerIndex] = Array.isArray(root[ownerIndex]) ? root[ownerIndex] : [];
+    root[ownerIndex].push(info);
+  } catch {}
+}
+
+function peekReveal(ownerIndex){
+  try {
+    const root = getRevealQueueRoot();
+    if (!Array.isArray(root[ownerIndex]) || !root[ownerIndex].length) return null;
+    return root[ownerIndex][0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function shiftReveal(ownerIndex){
+  try {
+    const root = getRevealQueueRoot();
+    if (!Array.isArray(root[ownerIndex]) || !root[ownerIndex].length) return null;
+    return root[ownerIndex].shift();
+  } catch {
+    return null;
+  }
+}
+
 export function renderBars(gameState) {
   if (!gameState) return;
   const total = 10;
@@ -43,174 +89,404 @@ export function renderBars(gameState) {
     
     // Сохраняем текущие видимые орбы, чтобы избежать мерцания
     const existingOrbs = Array.from(manaDisplay.querySelectorAll('.mana-orb, .mana-slot'));
-    
+
     manaDisplay.innerHTML = '';
     const mySeat = (typeof window !== 'undefined' && typeof window.MY_SEAT === 'number') ? window.MY_SEAT : null;
     const activeSeat = (typeof window !== 'undefined' && window.gameState && typeof window.gameState.active === 'number')
       ? window.gameState.active : (gameState?.active ?? null);
     const animateAllowed = (typeof mySeat === 'number') ? (mySeat === p) : (typeof activeSeat === 'number' ? activeSeat === p : true);
+
+    const revealCandidate = peekReveal(p);
+    let revealRange = null;
+    if (revealCandidate && Number.isFinite(revealCandidate.from) && Number.isFinite(revealCandidate.to)) {
+      const from = Math.max(0, Math.floor(revealCandidate.from));
+      const to = Math.max(from, Math.floor(revealCandidate.to));
+      if (to > from) {
+        revealRange = { from, to };
+      }
+    }
+    let revealMatched = false;
+
     for (let i = 0; i < total; i++) {
       const orb = document.createElement('div');
       const filled = i < renderMana;
       const isBlockedForAnim = !!(pending && i >= pending.startIdx && i <= pending.endIdx);
       orb.className = filled ? 'mana-orb' : 'mana-slot';
-      
-      // Избегаем мерцания: если орб уже был видим, начинаем с opacity: 1
-      const wasVisible = existingOrbs[i] && existingOrbs[i].classList.contains('mana-orb');
-      orb.style.opacity = (!animateAllowed) ? '1' : ((filled && wasVisible) ? '1' : (filled ? '0' : '1'));
-      
+
+      const wasVisible = existingOrbs[i] && existingOrbs[i].classList && existingOrbs[i].classList.contains('mana-orb');
+      const isRevealOrb = !!(revealRange && filled && i >= revealRange.from && i < revealRange.to);
+      // Сброс трансформации по умолчанию, чтобы орбы не «зависали» уменьшенными
+      if (!isRevealOrb || !animateAllowed) {
+        try {
+          orb.style.transform = 'scale(1)';
+        } catch {}
+      }
+      if (isRevealOrb) {
+        revealMatched = true;
+        if (animateAllowed) {
+          try {
+            orb.style.opacity = '0';
+            orb.style.transform = 'scale(0.6)';
+          } catch {}
+        }
+      }
+
+      const baseOpacity = (!animateAllowed)
+        ? '1'
+        : ((filled && wasVisible) ? '1' : (filled ? '0' : '1'));
+      orb.style.opacity = baseOpacity;
       manaDisplay.appendChild(orb);
-      if (animateAllowed && filled && !isBlockedForAnim && !wasVisible) {
+
+      if (animateAllowed && filled && !isBlockedForAnim && !wasVisible && !isRevealOrb) {
         const delay = 0.06 * Math.max(0, i - prev);
-        setTimeout(()=>{
+        setTimeout(() => {
           try {
             orb.style.transform = 'translateX(16px) scale(0.6)';
             orb.style.transition = 'transform 220ms ease, opacity 220ms ease';
-            requestAnimationFrame(()=>{
+            requestAnimationFrame(() => {
               orb.style.opacity = '1';
               orb.style.transform = 'translateX(0) scale(1)';
             });
           } catch {}
-        }, delay*1000);
+        }, delay * 1000);
       }
+    }
+
+    if (revealRange && revealMatched) {
+      if (animateAllowed) {
+        const hasTimeline = (typeof window !== 'undefined') && !!window.gsap?.timeline;
+        if (!hasTimeline) {
+          try {
+            manaDisplay.style.transition = 'filter 260ms ease';
+            manaDisplay.style.filter = 'brightness(2.05)';
+            setTimeout(() => { try { manaDisplay.style.filter = 'none'; } catch {} }, 360);
+          } catch {}
+        }
+      }
+      shiftReveal(p);
     }
   }
 }
 
-export function animateManaGainFromWorld(pos, ownerIndex, visualOnly = true, targetSlotMaybe = null, optionsMaybe = {}) {
-  try {
-    let opts = (optionsMaybe && typeof optionsMaybe === 'object') ? optionsMaybe : {};
-    let targetSlot = targetSlotMaybe;
-    if (targetSlotMaybe && typeof targetSlotMaybe === 'object' && (!optionsMaybe || Object.keys(optionsMaybe).length === 0)) {
-      opts = targetSlotMaybe;
-      targetSlot = opts.targetSlot ?? null;
-      if (opts.visualOnly != null) visualOnly = !!opts.visualOnly;
+// Вспомогательный генератор эффектов раскрытия орбов на панели
+function populatePanelBurst(tl, bar, indices, sparks, { highlight = true } = {}) {
+  if (!tl || !bar || !Array.isArray(indices) || !indices.length) return;
+  const perOrbDelay = 0.12;
+
+  for (const [order, idx] of indices.entries()) {
+    const el = bar.children?.[idx];
+    if (!el) continue;
+
+    const revealAt = Math.max(0, order * perOrbDelay);
+
+    // Подготавливаем элемент перед включением эффекта
+    tl.call(() => {
+      try {
+        el.style.willChange = 'transform, box-shadow, filter, opacity';
+        el.style.transformOrigin = '50% 50%';
+        if (el.className !== 'mana-orb') {
+          el.className = 'mana-orb';
+        }
+        el.style.opacity = '0';
+        el.style.transform = 'scale(0.58)';
+      } catch {}
+    }, null, revealAt);
+
+    if (highlight && order === 0) {
+      tl.to(bar, {
+        filter: 'brightness(2.05) drop-shadow(0 0 18px rgba(96,165,250,0.95))',
+        duration: 0.18,
+        ease: 'power2.out',
+      }, revealAt).to(bar, {
+        filter: 'none',
+        duration: 0.32,
+        ease: 'power2.inOut',
+      }, revealAt + 0.18);
     }
 
-    const count = Math.max(1, Math.floor(opts.count ?? 1));
-    const startDelayMs = Math.max(0, Number.isFinite(opts.startDelayMs) ? Number(opts.startDelayMs) : 0);
-    const delayBetweenMs = Math.max(0, Number.isFinite(opts.delayBetweenMs) ? Number(opts.delayBetweenMs) : 140);
-    const flightDuration = Math.max(0.45, Number.isFinite(opts.flightDuration) ? Number(opts.flightDuration) : 1.35);
-    const flightEase = typeof opts.flightEase === 'string' ? opts.flightEase : 'power3.in';
-    const arrivalScale = Number.isFinite(opts.arrivalScale) ? Number(opts.arrivalScale) : 1.1;
+    tl.to(el, {
+      duration: 0.196,
+      ease: 'back.out(2.2)',
+      onStart: () => {
+        try {
+          el.style.boxShadow = '0 0 22px rgba(96,165,250,0.95), 0 0 44px rgba(56,189,248,0.85)';
+          el.style.opacity = '1';
+        } catch {}
+      },
+      onComplete: () => {
+        try { el.style.boxShadow = '0 0 12px rgba(30,160,255,0.85)'; } catch {}
+      },
+    }, revealAt)
+      .to(el, { scale: 2.5, duration: 0.196, ease: 'back.out(2.2)' }, revealAt)
+      .to(el, { scale: 1.0, duration: 0.42, ease: 'power2.inOut' }, revealAt + 0.196)
+      .call(() => {
+        try {
+          el.style.transform = 'scale(1)';
+          el.style.opacity = '1';
+        } catch {}
+      }, null, revealAt + 0.72);
+
+    const rect = el.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+    const sparkCount = 16;
+
+    for (let i = 0; i < sparkCount; i++) {
+      const spark = document.createElement('div');
+      spark.style.position = 'fixed';
+      spark.style.left = `${centerX}px`;
+      spark.style.top = `${centerY}px`;
+      spark.style.width = '4px';
+      spark.style.height = '4px';
+      spark.style.borderRadius = '50%';
+      spark.style.pointerEvents = 'none';
+      spark.style.background = 'radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(125,211,252,1) 60%, rgba(14,165,233,0.8) 100%)';
+      spark.style.boxShadow = '0 0 10px rgba(59,130,246,0.95)';
+      spark.style.opacity = '0';
+      spark.style.zIndex = '70';
+      document.body.appendChild(spark);
+      sparks.push(spark);
+
+      const angle = (Math.PI * 2) * (i / sparkCount) + Math.random() * 0.8;
+      const dist = 40 + Math.random() * 40;
+      const dx = Math.cos(angle) * dist;
+      const dy = Math.sin(angle) * dist;
+      const t0 = revealAt + 0.04;
+
+      tl.fromTo(spark,
+        { x: 0, y: 0, opacity: 0, scale: 0.6 },
+        { x: dx, y: dy, opacity: 1, scale: 1.2, duration: 0.154, ease: 'power2.out' },
+        t0)
+        .to(spark, {
+          opacity: 0,
+          scale: 0.3,
+          duration: 0.35,
+          ease: 'power1.in',
+          delay: 0.105,
+        }, `>-0.1`);
+    }
+  }
+
+  const totalDuration = (indices.length - 1) * perOrbDelay + 0.72;
+  tl.to({}, { duration: Math.max(0, totalDuration - tl.duration()) });
+}
+
+function cleanupSparks(sparks) {
+  if (!Array.isArray(sparks)) return;
+  for (const s of sparks) {
+    try { if (s && s.parentNode) s.parentNode.removeChild(s); } catch {}
+  }
+}
+
+export function animateManaGainFromWorld(pos, ownerIndex, visualOnlyMaybe = true, legacyArg = null, legacyOpts = {}) {
+  try {
+    let visualOnly = true;
+    let opts = {};
+    if (typeof visualOnlyMaybe === 'object' && visualOnlyMaybe !== null) {
+      opts = visualOnlyMaybe;
+      visualOnly = (visualOnlyMaybe.visualOnly != null) ? !!visualOnlyMaybe.visualOnly : true;
+    } else {
+      visualOnly = !!visualOnlyMaybe;
+      if (legacyArg && typeof legacyArg === 'object' && (!legacyOpts || Object.keys(legacyOpts).length === 0)) {
+        opts = legacyArg;
+      } else if (legacyOpts && typeof legacyOpts === 'object') {
+        opts = legacyOpts;
+      }
+    }
+    if (opts.visualOnly != null) {
+      visualOnly = !!opts.visualOnly;
+    }
+
+    const amountRaw = opts.amount ?? opts.count ?? 1;
+    const amount = Math.max(0, Math.floor(Number.isFinite(amountRaw) ? amountRaw : Number(amountRaw) || 0));
+    if (amount <= 0) return;
+
+    const startDelayMs = Math.max(0, Number.isFinite(opts.startDelayMs)
+      ? Number(opts.startDelayMs)
+      : (Number.isFinite(opts.delayMs) ? Number(opts.delayMs) : 0));
+    const floatDuration = Math.max(0.6, Number.isFinite(opts.floatDuration) ? Number(opts.floatDuration) : 1.05);
+    const floatDistance = Number.isFinite(opts.floatDistance) ? Number(opts.floatDistance) : 170;
+    const labelHoldMs = Math.max(0, Number.isFinite(opts.labelHoldMs) ? Number(opts.labelHoldMs) : 680);
+    const fadeOutMs = Math.max(180, Number.isFinite(opts.fadeOutMs) ? Number(opts.fadeOutMs) : 320);
+    const labelText = typeof opts.label === 'string' ? opts.label : `+${amount}`;
+    const flashScale = Number.isFinite(opts.flashScale) ? Math.max(1.5, Number(opts.flashScale)) : 3.6;
 
     const gameState = (typeof window !== 'undefined') ? window.gameState : null;
 
-    const scheduleSingle = (slotIndex, extraDelayMs) => {
-      setTimeout(() => {
-        try {
-          const source = pos && typeof pos.clone === 'function'
-            ? pos.clone()
-            : (pos ? { x: pos.x, y: pos.y, z: pos.z } : null);
-          if (!source) return;
-          const start = worldToScreen(source);
-          const barEl = document.getElementById(`mana-display-${ownerIndex}`);
-          if (!barEl) return;
+    if (visualOnly && Number.isFinite(ownerIndex)) {
+      const blocks = getBlocks();
+      if (Array.isArray(blocks)) {
+        blocks[ownerIndex] = Math.max(0, Number(blocks[ownerIndex] || 0)) + amount;
+        setBlocks(blocks);
+        try { if (typeof window.updateUI === 'function') window.updateUI(); } catch {}
+      }
+    }
 
-          const barRect = barEl.getBoundingClientRect();
-          let currentMana = Math.max(0, (gameState?.players?.[ownerIndex]?.mana) || 0);
-          const currentBlocks = Math.max(0, Number(getBlocks()?.[ownerIndex]) || 0);
+    setTimeout(() => {
+      let container = null;
+      let cleanupTriggered = false;
+      let revealTriggered = false;
+      const cleanup = () => {
+        if (cleanupTriggered) return;
+        cleanupTriggered = true;
+        try { if (container && container.parentNode) container.parentNode.removeChild(container); } catch {}
+        triggerReveal();
+      };
 
-          let targetIdx;
-          if (typeof slotIndex === 'number') {
-            targetIdx = Math.max(0, Math.min(9, slotIndex));
-          } else if (visualOnly) {
+      const triggerReveal = () => {
+        if (revealTriggered) return;
+        revealTriggered = true;
+        if (visualOnly && Number.isFinite(ownerIndex)) {
+          const blocks = getBlocks();
+          const beforeBlock = Array.isArray(blocks)
+            ? Math.max(0, Number(blocks[ownerIndex] || 0))
+            : 0;
+          const afterBlock = Math.max(0, beforeBlock - amount);
+          if (Array.isArray(blocks)) {
+            blocks[ownerIndex] = afterBlock;
+            setBlocks(blocks);
+          }
+          const targetMana = Math.max(0, Number(gameState?.players?.[ownerIndex]?.mana) || 0);
+          const prevVisible = Math.max(0, targetMana - beforeBlock);
+          const visibleNow = Math.max(0, targetMana - afterBlock);
+          const revealCount = Math.max(0, visibleNow - prevVisible);
+          if (revealCount > 0) {
+            enqueueReveal(ownerIndex, { from: prevVisible, to: visibleNow, amount: revealCount });
+          }
+          const indices = [];
+          for (let idx = prevVisible; idx < visibleNow; idx++) indices.push(idx);
+          try { if (typeof window.updateUI === 'function') window.updateUI(); } catch {}
+
+          const scheduleEffect = () => {
             try {
-              const filledNow = Array.from(barEl.children)
-                .filter(el => el && el.classList && el.classList.contains('mana-orb')).length;
-              targetIdx = Math.min(9, Math.max(0, filledNow));
-            } catch {
-              const visibleMana = Math.max(0, currentMana - currentBlocks);
-              targetIdx = Math.min(9, visibleMana);
-            }
-          } else {
-            targetIdx = Math.max(0, Math.min(9, currentMana - 1));
-          }
-
-          let child = barEl.children && barEl.children[targetIdx];
-          if (!child && barEl.children && barEl.children.length > 0) {
-            const lastIdx = Math.min(targetIdx, barEl.children.length - 1);
-            child = barEl.children[lastIdx];
-          }
-
-          let tx;
-          let ty;
-          if (child) {
-            const srect = child.getBoundingClientRect();
-            tx = srect.left + srect.width / 2;
-            ty = srect.top + srect.height / 2;
-          } else {
-            tx = barRect.left + barRect.width / 2;
-            ty = barRect.top + barRect.height / 2;
-          }
-
-          if (visualOnly && typeof ownerIndex === 'number') {
-            const b = getBlocks();
-            b[ownerIndex] = Math.max(0, (b[ownerIndex] || 0) + 1);
-            setBlocks(b);
-            try { if (typeof window.updateUI === 'function') window.updateUI(); } catch {}
-          }
-
-          const orb = document.createElement('div');
-          orb.className = 'mana-orb';
-          orb.style.position = 'fixed';
-          orb.style.left = `${start.x}px`;
-          orb.style.top = `${start.y}px`;
-          orb.style.transform = 'translate(-50%, -50%) scale(0.35)';
-          orb.style.opacity = '0';
-          orb.style.zIndex = '60';
-          document.body.appendChild(orb);
-
-          const cleanup = () => {
-            try { if (orb && orb.parentNode) orb.parentNode.removeChild(orb); } catch {}
-            if (visualOnly && typeof ownerIndex === 'number') {
-              const b2 = getBlocks();
-              b2[ownerIndex] = Math.max(0, (b2[ownerIndex] || 0) - 1);
-              setBlocks(b2);
-              try { if (typeof window.updateUI === 'function') window.updateUI(); } catch {}
-            }
+              const bar = document.getElementById(`mana-display-${ownerIndex}`);
+              if (bar && typeof window !== 'undefined' && window.gsap?.timeline) {
+                const sparks = [];
+                const tl = window.gsap.timeline({ onComplete: () => cleanupSparks(sparks) });
+                populatePanelBurst(tl, bar, indices, sparks, { highlight: true });
+              }
+            } catch {}
           };
 
-          const tl = (typeof window !== 'undefined')
-            ? window.gsap?.timeline?.({ onComplete: cleanup })
-            : null;
-          if (tl) {
-            tl.to(orb, {
-              duration: 0.22,
-              ease: 'back.out(1.6)',
-              opacity: 1,
-              transform: 'translate(-50%, -50%) scale(1)'
-            })
-              .to(orb, {
-                duration: flightDuration,
-                ease: flightEase,
-                left: tx,
-                top: ty
-              }, '>-0.06')
-              .to(orb, {
-                duration: 0.16,
-                ease: 'power1.out',
-                transform: `translate(-50%, -50%) scale(${arrivalScale})`
-              }, `>-0.08`)
-              .to(orb, {
-                duration: 0.16,
-                ease: 'power1.inOut',
-                transform: 'translate(-50%, -50%) scale(1)'
-              });
+          if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(scheduleEffect);
           } else {
-            setTimeout(cleanup, Math.max(600, (flightDuration * 1000) + 200));
+            setTimeout(scheduleEffect, 16);
           }
-        } catch (err) {
-          console.error('[mana] Ошибка анимации орба маны:', err);
         }
-      }, extraDelayMs);
-    };
+      };
 
-    for (let i = 0; i < count; i += 1) {
-      const slotIndex = (typeof targetSlot === 'number') ? (targetSlot + i) : null;
-      const extraDelayMs = startDelayMs + delayBetweenMs * i;
-      scheduleSingle(slotIndex, extraDelayMs);
-    }
+      try {
+        const source = pos && typeof pos?.clone === 'function'
+          ? pos.clone()
+          : (pos ? { x: pos.x, y: pos.y, z: pos.z } : null);
+        if (!source) return;
+        const start = worldToScreen(source);
+        container = document.createElement('div');
+        container.style.position = 'fixed';
+        container.style.left = `${start.x}px`;
+        container.style.top = `${start.y}px`;
+        container.style.transform = 'translate(-50%, -50%) scale(0.72)';
+        container.style.pointerEvents = 'none';
+        container.style.zIndex = '120';
+        container.style.opacity = '0';
+        document.body.appendChild(container);
+
+        const orb = document.createElement('div');
+        orb.style.width = '28px';
+        orb.style.height = '28px';
+        orb.style.borderRadius = '50%';
+        orb.style.background = 'radial-gradient(circle, rgba(255,255,255,0.95) 0%, rgba(125,211,252,0.95) 55%, rgba(14,165,233,0.55) 100%)';
+        orb.style.boxShadow = '0 0 26px rgba(56,189,248,0.9)';
+        orb.style.opacity = '0.9';
+        orb.style.transform = 'scale(0.42)';
+        container.appendChild(orb);
+
+        const labelWrapper = document.createElement('div');
+        labelWrapper.style.position = 'absolute';
+        labelWrapper.style.left = '50%';
+        labelWrapper.style.top = '50%';
+        labelWrapper.style.transform = 'translate(-50%, -50%) translate(34px, -6px)';
+        labelWrapper.style.opacity = '0';
+        container.appendChild(labelWrapper);
+
+        const label = document.createElement('span');
+        label.textContent = labelText;
+        label.style.fontFamily = 'var(--ui-font, "Montserrat", "Roboto", sans-serif)';
+        label.style.fontWeight = '700';
+        label.style.fontSize = '20px';
+        label.style.color = '#a5f3fc';
+        label.style.textShadow = '0 0 16px rgba(56,189,248,0.9), 0 0 32px rgba(14,165,233,0.75)';
+        labelWrapper.appendChild(label);
+
+        const flash = document.createElement('div');
+        flash.style.position = 'absolute';
+        flash.style.left = '50%';
+        flash.style.top = '50%';
+        flash.style.width = '18px';
+        flash.style.height = '18px';
+        flash.style.borderRadius = '50%';
+        flash.style.background = 'radial-gradient(circle, rgba(255,255,255,0.9) 0%, rgba(125,211,252,0.35) 55%, rgba(14,165,233,0) 100%)';
+        flash.style.transform = 'translate(-50%, -50%) scale(0.24)';
+        flash.style.opacity = '0';
+        container.appendChild(flash);
+
+        const tl = (typeof window !== 'undefined')
+          ? window.gsap?.timeline?.({ onComplete: cleanup })
+          : null;
+        if (tl) {
+          const floatSeconds = floatDuration;
+          const holdSeconds = labelHoldMs / 1000;
+          const fadeSeconds = fadeOutMs / 1000;
+          tl.to(container, { opacity: 1, scale: 1, duration: 0.22, ease: 'back.out(1.8)' })
+            .to(container, { y: -floatDistance, duration: floatSeconds, ease: 'power1.out' }, '<')
+            .to(orb, { scale: 1, duration: 0.28, ease: 'back.out(2.1)' }, '<')
+            .to(labelWrapper, { opacity: 1, duration: 0.26, ease: 'power2.out' }, '<+0.05')
+            .to(labelWrapper, { y: -18, duration: Math.max(0.14, floatSeconds), ease: 'power1.out' }, '<')
+            .add('reveal', Math.max(0.22, floatSeconds - 0.28))
+            .call(triggerReveal, null, 'reveal')
+            .to(orb, { opacity: 0, scale: 1.45, duration: Math.max(0.2, fadeSeconds), ease: 'power1.in' }, 'reveal')
+            .to(flash, { opacity: 1, scale: flashScale, duration: 0.34, ease: 'power2.out' }, 'reveal')
+            .to(flash, { opacity: 0, scale: flashScale * 1.08, duration: 0.32, ease: 'power2.in' }, 'reveal+0.18')
+            .to(labelWrapper, { y: -46, duration: holdSeconds, ease: 'power1.out' }, 'reveal')
+            .to(labelWrapper, { opacity: 0, duration: 0.32, ease: 'power1.in' }, `reveal+=${Math.max(0.16, holdSeconds - 0.12)}`)
+            .to(container, { opacity: 0, duration: 0.34, ease: 'power1.inOut' });
+        } else {
+          container.style.opacity = '1';
+          const raf = (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function')
+            ? window.requestAnimationFrame.bind(window)
+            : (fn => setTimeout(() => fn(Date.now()), 16));
+          const startTime = (typeof performance !== 'undefined' && typeof performance.now === 'function')
+            ? performance.now()
+            : Date.now();
+          const floatMs = floatDuration * 1000;
+          const totalDuration = floatMs + labelHoldMs + fadeOutMs;
+          const tick = (time) => {
+            const current = (typeof time === 'number')
+              ? time
+              : ((typeof performance !== 'undefined' && typeof performance.now === 'function') ? performance.now() : Date.now());
+            const elapsed = Math.min(totalDuration, current - startTime);
+            const progress = elapsed / (totalDuration || 1);
+            const y = -floatDistance * progress;
+            container.style.transform = `translate(-50%, -50%) translateY(${y}px)`;
+            if (elapsed < totalDuration) {
+              raf(tick);
+            } else {
+              cleanup();
+            }
+          };
+          raf(tick);
+          setTimeout(() => { try { labelWrapper.style.opacity = '1'; } catch {} }, 90);
+          setTimeout(() => { try { flash.style.opacity = '1'; } catch {} }, Math.max(0, floatMs - 160));
+          setTimeout(() => { triggerReveal(); }, Math.max(0, floatMs * 0.6));
+          setTimeout(() => { try { labelWrapper.style.opacity = '0'; } catch {} }, floatMs + labelHoldMs);
+          setTimeout(() => { cleanup(); }, totalDuration + 32);
+        }
+      } catch (err) {
+        console.error('[mana] Ошибка анимации орба маны:', err);
+        try { cleanup(); } catch {}
+      }
+    }, startDelayMs);
   } catch (err) {
     console.error('[mana] animateManaGainFromWorld error:', err);
   }
@@ -253,10 +529,7 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
       
       const cleanup = () => {
         console.log(`[MANA] Cleaning up animation for player ${ownerIndex}`);
-        // Убираем все блестки
-        for (const s of sparks) { 
-          try { if (s.parentNode) s.parentNode.removeChild(s); } catch {} 
-        }
+        cleanupSparks(sparks);
         // Сбрасываем флаги и состояние
         setManaGainActive(false);
         try { if (typeof window !== 'undefined' && typeof window.refreshInputLockUI === 'function') window.refreshInputLockUI(); } catch {}
@@ -286,108 +559,13 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
         return;
       }
       
-      // Красивая анимация с вспышками и блестками для каждого нового орба
       const tl = (typeof window !== 'undefined') ? window.gsap?.timeline?.({ onComplete: cleanup }) : null;
       if (!tl) {
         setTimeout(cleanup, durationMs);
         return;
       }
-      
-      const perOrbDelay = 0.12;
-      for (const idx of indices) {
-        const el = bar.children[idx];
-        if (!el) continue;
 
-        // Подготавливаем элемент для анимации
-        el.style.willChange = 'transform, box-shadow, filter, opacity';
-        el.style.transformOrigin = '50% 50%';
-        el.style.opacity = '0';
-        el.style.transform = 'scale(0.6)';
-
-        const revealAt = Math.max(0, (idx - startIdx) * perOrbDelay);
-        if (idx === startIdx) {
-          tl.to(bar, {
-            filter: 'brightness(2.05) drop-shadow(0 0 18px rgba(96,165,250,0.95))',
-            duration: 0.18,
-            ease: 'power2.out'
-          }, revealAt)
-            .to(bar, {
-              filter: 'none',
-              duration: 0.32,
-              ease: 'power2.inOut'
-            }, revealAt + 0.18);
-        }
-
-        // На старте убеждаемся что элемент существует как пустая ячейка, затем превращаем в орб + вспышка
-        tl.call(() => {
-          try {
-            if (el.className !== 'mana-orb') {
-              el.className = 'mana-orb';
-              el.style.opacity = '0';
-            }
-          } catch {}
-        }, null, revealAt)
-          // Анимация масштабирования и свечения орба
-          .to(el, {
-            duration: 0.196,
-            ease: 'back.out(2.2)',
-            onStart: () => {
-              el.style.boxShadow = '0 0 22px rgba(96,165,250,0.95), 0 0 44px rgba(56,189,248,0.85)';
-              el.style.opacity = '1';
-            },
-            onComplete: () => {
-              el.style.boxShadow = '0 0 12px rgba(30,160,255,0.85)';
-            }
-          }, revealAt)
-          .to(el, { scale: 2.5, duration: 0.196, ease: 'back.out(2.2)' }, revealAt)
-          .to(el, { scale: 1.0, duration: 0.42, ease: 'power2.inOut' }, revealAt + 0.196);
-
-        // Создаем блестки вокруг каждого орба
-        const rect = el.getBoundingClientRect();
-        const centerX = rect.left + rect.width / 2;
-        const centerY = rect.top + rect.height / 2;
-        const sparkCount = 16; // 16 блесток на каждый орб
-        
-        for (let i = 0; i < sparkCount; i++) {
-          const spark = document.createElement('div');
-          spark.style.position = 'fixed';
-          spark.style.left = `${centerX}px`;
-          spark.style.top = `${centerY}px`;
-          spark.style.width = '4px'; 
-          spark.style.height = '4px';
-          spark.style.borderRadius = '50%';
-          spark.style.pointerEvents = 'none';
-          spark.style.background = 'radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(125,211,252,1) 60%, rgba(14,165,233,0.8) 100%)';
-          spark.style.boxShadow = '0 0 10px rgba(59,130,246,0.95)';
-          spark.style.opacity = '0';
-          spark.style.zIndex = '70';
-          document.body.appendChild(spark);
-          sparks.push(spark);
-          
-          // Случайный угол и расстояние для блестки
-          const angle = (Math.PI * 2) * (i / sparkCount) + Math.random() * 0.8;
-          const dist = 40 + Math.random() * 40;
-          const dx = Math.cos(angle) * dist;
-          const dy = Math.sin(angle) * dist;
-          const t0 = revealAt + 0.04;
-
-          // Анимация блестки: появление -> разлет -> исчезновение
-          tl.fromTo(spark,
-            { x: 0, y: 0, opacity: 0, scale: 0.6 },
-            { x: dx, y: dy, opacity: 1, scale: 1.2, duration: 0.154, ease: 'power2.out' },
-            t0)
-            .to(spark, { 
-              opacity: 0, 
-              scale: 0.3, 
-              duration: 0.35, 
-              ease: 'power1.in', 
-              delay: 0.105 
-            }, `>-0.1`);
-        }
-      }
-      
-      // Добавляем паузу если анимация короче требуемой длительности
-      tl.to({}, { duration: Math.max(0, (durationMs/1000) - tl.duration()) });
+      populatePanelBurst(tl, bar, indices, sparks, { highlight: true });
       
     } catch (e) {
       console.error('Error in animateTurnManaGain:', e);


### PR DESCRIPTION
## Summary
- Вынесена общая логика вспышек панелей в отдельный генератор и переиспользована для прироста хода и мгновенного получения маны.
- Анимация орба маны теперь вызывает появление орбов на панели в момент растворения и синхронно запускает полный набор эффектов.
- Подпись количества маны перемещается вместе с орбом и дольше удерживается в зоне видимости для читаемости.
- Орбы от смерти существа появляются на панели раньше и фиксируются в полном масштабе, чтобы исключить зависание уменьшенных элементов после смены хода.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d66e71471083309ac248f00ff6dd2e