### PR TITLE
feat: add mana steal mechanic and Kadena water units

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -47,6 +47,7 @@ import {
   describeFieldFatality as describeFieldFatalityInternal,
   evaluateFieldFatality as evaluateFieldFatalityInternal,
 } from './abilityHandlers/fieldHazards.js';
+import { applySummonManaSteal } from './abilityHandlers/manaSteal.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -677,6 +678,16 @@ export function applySummonAbilities(state, r, c) {
     events.draws = [...(events.draws || []), ...extraDraws];
     if (!events.draw) {
       events.draw = extraDraws[0];
+    }
+  }
+
+  const manaSteals = applySummonManaSteal(state, { r, c, unit, tpl, cell });
+  if (Array.isArray(manaSteals) && manaSteals.length) {
+    events.manaSteals = [...manaSteals];
+    for (const steal of manaSteals) {
+      if (steal?.log) {
+        events.logs = [...(events.logs || []), steal.log];
+      }
     }
   }
 

--- a/src/core/abilityHandlers/discard.js
+++ b/src/core/abilityHandlers/discard.js
@@ -1,5 +1,6 @@
 // Логика эффектов принудительного сброса карт
 import { CARDS } from '../cards.js';
+import { applyDeathManaSteal } from './manaSteal.js';
 
 const DEFAULT_TIMER_MS = 20000;
 
@@ -101,6 +102,14 @@ export function applyDeathDiscardEffects(state, deaths = [], context = {}) {
 
   const queue = ensureQueue(state);
   if (!queue) return events;
+
+  const manaSteals = applyDeathManaSteal(state, deaths, context);
+  if (Array.isArray(manaSteals) && manaSteals.length) {
+    events.manaSteals = [...manaSteals];
+    for (const steal of manaSteals) {
+      if (steal?.log) events.logs.push(steal.log);
+    }
+  }
 
   for (const death of deaths) {
     if (!death) continue;

--- a/src/core/abilityHandlers/manaSteal.js
+++ b/src/core/abilityHandlers/manaSteal.js
@@ -1,0 +1,335 @@
+// Логика способности "mana steal" (кража маны)
+import { CARDS } from '../cards.js';
+
+const capMana = (value) => {
+  const num = Math.floor(Number(value) || 0);
+  if (!Number.isFinite(num)) return 0;
+  if (num < 0) return 0;
+  if (num > 10) return 10;
+  return num;
+};
+
+function ensureQueue(state) {
+  if (!state) return null;
+  if (!Array.isArray(state.manaStealEvents)) {
+    state.manaStealEvents = [];
+  }
+  return state.manaStealEvents;
+}
+
+function nextEventId(state) {
+  if (!state) return Date.now();
+  const current = Number(state.__manaStealSeq) || 0;
+  const next = current + 1;
+  state.__manaStealSeq = next;
+  return next;
+}
+
+function registerEvent(state, baseEvent) {
+  const queue = ensureQueue(state);
+  const event = {
+    ...baseEvent,
+    id: nextEventId(state),
+    ts: Date.now(),
+  };
+  if (queue) {
+    queue.push(event);
+    if (queue.length > 20) {
+      queue.splice(0, queue.length - 20);
+    }
+  }
+  return event;
+}
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
+function normalizeTrigger(raw) {
+  if (!raw) return null;
+  const code = String(raw).toUpperCase();
+  if (code === 'SUMMON' || code === 'ON_SUMMON') return 'SUMMON';
+  if (code === 'DEATH' || code === 'ON_DEATH' || code === 'DESTROYED') return 'DEATH';
+  return null;
+}
+
+function normalizeAmountSpec(raw) {
+  if (raw == null) return null;
+  if (typeof raw === 'number') {
+    const value = Math.max(0, Math.floor(raw));
+    if (!Number.isFinite(value) || value <= 0) return null;
+    return { kind: 'FIXED', value };
+  }
+  if (typeof raw === 'object') {
+    if (typeof raw.value === 'number') {
+      const value = Math.max(0, Math.floor(raw.value));
+      if (!Number.isFinite(value) || value <= 0) return null;
+      return { kind: 'FIXED', value };
+    }
+    const type = String(raw.type || raw.mode || '').toUpperCase();
+    if (type === 'FIELD_COUNT' || type === 'FIELDS') {
+      const element = String(raw.element || raw.field || '').toUpperCase();
+      if (!element) return null;
+      return { kind: 'FIELD_COUNT', element };
+    }
+    if (raw.countFieldsOfElement) {
+      const element = String(raw.countFieldsOfElement || '').toUpperCase();
+      if (!element) return null;
+      return { kind: 'FIELD_COUNT', element };
+    }
+    if (raw.amountByFieldCount) {
+      const element = String(raw.amountByFieldCount || '').toUpperCase();
+      if (!element) return null;
+      return { kind: 'FIELD_COUNT', element };
+    }
+  }
+  return null;
+}
+
+function countFields(state, element) {
+  if (!state?.board || !element) return 0;
+  let total = 0;
+  for (let r = 0; r < state.board.length; r += 1) {
+    for (let c = 0; c < state.board[r].length; c += 1) {
+      if (state.board?.[r]?.[c]?.element === element) total += 1;
+    }
+  }
+  return total;
+}
+
+function resolveAmount(state, spec, ctx) {
+  if (!spec) return 0;
+  if (spec.kind === 'FIXED') {
+    return Math.max(0, Math.floor(spec.value || 0));
+  }
+  if (spec.kind === 'FIELD_COUNT') {
+    return countFields(state, spec.element);
+  }
+  return 0;
+}
+
+function normalizeEntry(raw, trigger) {
+  if (!raw) return null;
+  if (typeof raw === 'number') {
+    const amount = Math.max(0, Math.floor(raw));
+    if (amount <= 0) return null;
+    return { trigger, amountSpec: { kind: 'FIXED', value: amount } };
+  }
+  if (typeof raw !== 'object') return null;
+  const entry = { trigger };
+  const cloned = { ...raw };
+  if (typeof cloned.amount === 'number') {
+    entry.amountSpec = normalizeAmountSpec(cloned.amount);
+  } else {
+    entry.amountSpec = normalizeAmountSpec(cloned.amount)
+      || normalizeAmountSpec(cloned.amountSpec)
+      || normalizeAmountSpec(cloned.countFieldsOfElement)
+      || normalizeAmountSpec(cloned.amountByFieldCount);
+  }
+  if (!entry.amountSpec && typeof cloned.countFieldsOfElement === 'string') {
+    entry.amountSpec = { kind: 'FIELD_COUNT', element: String(cloned.countFieldsOfElement).toUpperCase() };
+  }
+  if (!entry.amountSpec && typeof cloned.amountByFieldCount === 'string') {
+    entry.amountSpec = { kind: 'FIELD_COUNT', element: String(cloned.amountByFieldCount).toUpperCase() };
+  }
+  if (!entry.amountSpec && typeof cloned.amount === 'object') {
+    entry.amountSpec = normalizeAmountSpec(cloned.amount);
+  }
+  if (!entry.amountSpec) {
+    entry.amountSpec = normalizeAmountSpec(cloned.value);
+  }
+  if (cloned.max != null) entry.max = Math.max(0, Math.floor(cloned.max));
+  if (cloned.min != null) entry.min = Math.max(0, Math.floor(cloned.min));
+
+  const requireField = cloned.requireFieldElement || cloned.requireElement || cloned.requireField;
+  if (requireField) {
+    entry.requireFieldElement = String(requireField).toUpperCase();
+  }
+  const forbidField = cloned.forbidFieldElement || cloned.forbidElement || cloned.forbidField || cloned.excludeFieldElement;
+  if (forbidField) {
+    entry.forbidFieldElement = String(forbidField).toUpperCase();
+  }
+
+  const fromRaw = cloned.from ?? cloned.stealFrom ?? cloned.target ?? cloned.fromPlayer;
+  const toRaw = cloned.to ?? cloned.recipient ?? cloned.giveTo ?? cloned.toPlayer;
+
+  const mapRole = (value, fallback) => {
+    if (value == null) return fallback;
+    if (typeof value === 'number') return value;
+    const txt = String(value).toUpperCase();
+    if (txt === 'SELF' || txt === 'ALLY' || txt === 'OWNER') return 'OWNER';
+    if (txt === 'OPPONENT' || txt === 'ENEMY') return 'OPPONENT';
+    return fallback;
+  };
+
+  entry.from = mapRole(fromRaw, 'OPPONENT');
+  entry.to = mapRole(toRaw, 'OWNER');
+  if (cloned.reason) entry.reason = String(cloned.reason);
+  if (cloned.log === false) entry.skipLog = true;
+
+  return entry.amountSpec ? entry : null;
+}
+
+function gatherEntries(tpl, trigger) {
+  if (!tpl?.manaSteal) return [];
+  const data = tpl.manaSteal;
+  const list = [];
+  const pickKeys = [];
+  if (trigger === 'SUMMON') pickKeys.push('onSummon', 'summon');
+  if (trigger === 'DEATH') pickKeys.push('onDeath', 'death', 'onDestroy', 'destroyed');
+  for (const key of pickKeys) {
+    const raw = data[key];
+    for (const item of toArray(raw)) {
+      const entry = normalizeEntry(item, trigger);
+      if (entry) list.push(entry);
+    }
+  }
+  return list;
+}
+
+function resolveRoleIndex(owner, role) {
+  if (typeof role === 'number') return role;
+  if (role === 'OWNER') return owner;
+  if (role === 'OPPONENT') return owner === 0 ? 1 : 0;
+  return owner;
+}
+
+function applyEntry(state, entry, ctx) {
+  if (!state || !entry) return null;
+  const owner = (ctx.owner != null) ? ctx.owner : (ctx.unit?.owner ?? null);
+  if (owner == null) return null;
+  const cellElement = ctx.element || ctx.cellElement || ctx.cell?.element || null;
+  if (entry.requireFieldElement && cellElement !== entry.requireFieldElement) {
+    return null;
+  }
+  if (entry.forbidFieldElement && cellElement === entry.forbidFieldElement) {
+    return null;
+  }
+
+  const amountRaw = resolveAmount(state, entry.amountSpec, ctx);
+  if (!Number.isFinite(amountRaw) || amountRaw <= 0) return null;
+
+  let amount = Math.max(0, Math.floor(amountRaw));
+  if (entry.max != null) amount = Math.min(amount, entry.max);
+  if (entry.min != null) amount = Math.max(amount, entry.min);
+  if (amount <= 0) return null;
+
+  const fromIndex = resolveRoleIndex(owner, entry.from);
+  const toIndex = resolveRoleIndex(owner, entry.to);
+  if (fromIndex == null || toIndex == null || fromIndex === toIndex) return null;
+
+  const fromPlayer = state.players?.[fromIndex];
+  const toPlayer = state.players?.[toIndex];
+  if (!fromPlayer || !toPlayer) return null;
+
+  const fromBefore = capMana(fromPlayer.mana);
+  const toBefore = capMana(toPlayer.mana);
+  if (fromBefore <= 0) return null;
+
+  const capacity = Math.max(0, 10 - toBefore);
+  if (capacity <= 0) return null;
+
+  const transfer = Math.min(amount, fromBefore, capacity);
+  if (transfer <= 0) return null;
+
+  const fromAfter = capMana(fromBefore - transfer);
+  const toAfter = capMana(toBefore + transfer);
+
+  fromPlayer.mana = fromAfter;
+  toPlayer.mana = toAfter;
+
+  const sourceTpl = ctx.tpl || (ctx.tplId ? CARDS[ctx.tplId] : null) || (ctx.unit ? CARDS[ctx.unit.tplId] : null);
+  const sourceInfo = ctx.source || {
+    tplId: sourceTpl?.id || ctx.tplId || null,
+    name: sourceTpl?.name || ctx.sourceName || 'Unit',
+    owner,
+  };
+
+  const baseEvent = {
+    trigger: entry.trigger,
+    amount: transfer,
+    from: fromIndex,
+    to: toIndex,
+    before: { fromMana: fromBefore, toMana: toBefore },
+    after: { fromMana: fromAfter, toMana: toAfter },
+    source: sourceInfo,
+    reason: entry.reason || ctx.reason || entry.trigger,
+    element: cellElement || null,
+    position: ctx.position ? { ...ctx.position } : null,
+  };
+
+  const event = registerEvent(state, baseEvent);
+  if (!entry.skipLog) {
+    const name = event.source?.name || 'Существо';
+    const victim = (event.from != null) ? event.from + 1 : '?';
+    event.log = `${name}: крадет ${transfer} маны у игрока ${victim}.`;
+  }
+  return event;
+}
+
+export function applySummonManaSteal(state, context = {}) {
+  const { tpl, unit, cell, r, c } = context;
+  const entries = gatherEntries(tpl, 'SUMMON');
+  if (!entries.length) return [];
+  const events = [];
+  for (const entry of entries) {
+    const ev = applyEntry(state, entry, {
+      owner: unit?.owner,
+      unit,
+      tpl,
+      cell,
+      cellElement: cell?.element || null,
+      element: cell?.element || null,
+      position: (typeof r === 'number' && typeof c === 'number') ? { r, c } : null,
+      reason: 'SUMMON',
+    });
+    if (ev) events.push(ev);
+  }
+  return events;
+}
+
+export function applyDeathManaSteal(state, deaths = [], context = {}) {
+  if (!Array.isArray(deaths) || deaths.length === 0) return [];
+  const events = [];
+  for (const death of deaths) {
+    if (!death) continue;
+    const tpl = CARDS[death.tplId];
+    if (!tpl) continue;
+    const entries = gatherEntries(tpl, 'DEATH');
+    if (!entries.length) continue;
+    for (const entry of entries) {
+      const ev = applyEntry(state, entry, {
+        owner: death.owner,
+        tpl,
+        tplId: tpl.id,
+        element: death.element || null,
+        cellElement: death.element || null,
+        position: (typeof death.r === 'number' && typeof death.c === 'number') ? { r: death.r, c: death.c } : null,
+        reason: context?.cause || 'DEATH',
+      });
+      if (ev) events.push(ev);
+    }
+  }
+  return events;
+}
+
+export function hasManaStealKeyword(tpl) {
+  if (!tpl?.manaSteal) return false;
+  const onSummon = gatherEntries(tpl, 'SUMMON');
+  if (onSummon.length) return true;
+  const onDeath = gatherEntries(tpl, 'DEATH');
+  return onDeath.length > 0;
+}
+
+export function listManaStealEvents(state) {
+  if (!state || !Array.isArray(state.manaStealEvents)) return [];
+  return state.manaStealEvents.slice();
+}
+
+export default {
+  applySummonManaSteal,
+  applyDeathManaSteal,
+  hasManaStealKeyword,
+  listManaStealEvents,
+};

--- a/src/core/abilityHandlers/sacrifice.js
+++ b/src/core/abilityHandlers/sacrifice.js
@@ -221,6 +221,9 @@ export function executeSacrificeAction(state, action = {}, payload = {}) {
   if (discardEvents && Array.isArray(discardEvents.logs) && discardEvents.logs.length) {
     result.events.discardLogs = discardEvents.logs.slice();
   }
+  if (Array.isArray(discardEvents?.manaSteals) && discardEvents.manaSteals.length) {
+    result.events.manaSteals = [...(result.events.manaSteals || []), ...discardEvents.manaSteals];
+  }
 
   const cellElement = cell.element || null;
   const buff = computeCellBuff(cellElement, summonTpl.element);
@@ -281,6 +284,9 @@ export function executeSacrificeAction(state, action = {}, payload = {}) {
     const discardReplacement = applyDeathDiscardEffects(state, replacementDeath, { cause: 'SACRIFICE_REPLACEMENT' });
     if (discardReplacement && Array.isArray(discardReplacement.logs) && discardReplacement.logs.length) {
       result.events.discardLogs = (result.events.discardLogs || []).concat(discardReplacement.logs);
+    }
+    if (Array.isArray(discardReplacement?.manaSteals) && discardReplacement.manaSteals.length) {
+      result.events.manaSteals = [...(result.events.manaSteals || []), ...discardReplacement.manaSteals];
     }
   }
 

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -288,6 +288,39 @@ export const CARDS = {
     desc: 'Magic Attack. While on a Water field, Aluhja Priestess gains Dodge attempt.'
   },
 
+  WATER_MOVING_ISLE_OF_KADENA: {
+    id: 'WATER_MOVING_ISLE_OF_KADENA', name: 'Moving Isle of Kadena', type: 'UNIT', cost: 4, activation: 2,
+    element: 'WATER', atk: 1, hp: 4,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1], ignoreAlliedBlocking: true },
+      { dir: 'E', ranges: [1], ignoreAlliedBlocking: true },
+      { dir: 'S', ranges: [1], ignoreAlliedBlocking: true },
+      { dir: 'W', ranges: [1], ignoreAlliedBlocking: true },
+    ],
+    blindspots: [], fortress: true, ignoreAlliedBlocking: true,
+    diesOnElement: 'FIRE',
+    manaSteal: {
+      onSummon: {
+        amount: { type: 'FIELD_COUNT', element: 'WATER' },
+        forbidFieldElement: 'WATER',
+      },
+    },
+    desc: 'Fortress. If Moving Isle of Kadena is summoned to a non-Water field, steal mana from your opponent equal to the number of Water fields. Destroy Moving Isle of Kadena if it is on a Fire field.'
+  },
+
+  WATER_QUEENS_SERVANT: {
+    id: 'WATER_QUEENS_SERVANT', name: "Queen's Servant", type: 'UNIT', cost: 4, activation: 2,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'MAGIC',
+    targetAllEnemies: true,
+    blindspots: ['S'], perfectDodge: true, ignoreAlliedBlocking: true,
+    manaSteal: {
+      onDeath: { amount: 1 },
+    },
+    desc: "Magic Attack. Perfect Dodge. If Queen's Servant is destroyed, steal 1 mana from your opponent."
+  },
+
   EARTH_ARELAI_THE_PROTECTOR: {
     id: 'EARTH_ARELAI_THE_PROTECTOR', name: 'Arelai the Protector', type: 'UNIT', cost: 3, activation: 2,
     element: 'EARTH', atk: 2, hp: 3,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -556,6 +556,7 @@ export function stagedAttack(state, r, c, opts = {}) {
     ensureStep1();
     const nFinal = JSON.parse(JSON.stringify(n1));
     const ret = step2();
+    const manaStealEvents = [];
 
     const applied = applyDamageInteractionResults(nFinal, damageEffects);
     const attackerPosUpdate = applied?.attackerPosUpdate || null;
@@ -617,6 +618,9 @@ export function stagedAttack(state, r, c, opts = {}) {
     if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
       logLines.push(...discardEffects.logs);
     }
+    if (Array.isArray(discardEffects?.manaSteals) && discardEffects.manaSteals.length) {
+      manaStealEvents.push(...discardEffects.manaSteals);
+    }
 
     const releaseEvents = releasePossessionsAfterDeaths(nFinal, deaths);
     if (releaseEvents.releases.length) {
@@ -671,6 +675,7 @@ export function stagedAttack(state, r, c, opts = {}) {
       attackType,
       schemeKey,
       attackProfile: profile,
+      manaSteals: manaStealEvents,
     };
   }
 
@@ -739,6 +744,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
   if (!allowFriendly && (!mainTarget || mainTarget.owner === attacker.owner)) return null;
 
   const logLines = [];
+  const manaStealEvents = [];
   const targets = [];
   const damageEffects = { preventRetaliation: new Set(), events: [] };
   const dodgeUpdates = [];
@@ -919,6 +925,9 @@ export function magicAttack(state, fr, fc, tr, tc) {
   if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
     logLines.push(...discardEffects.logs);
   }
+  if (Array.isArray(discardEffects?.manaSteals) && discardEffects.manaSteals.length) {
+    manaStealEvents.push(...discardEffects.manaSteals);
+  }
   const releaseEvents = releasePossessionsAfterDeaths(n1, deaths);
   if (releaseEvents.releases.length) {
     for (const rel of releaseEvents.releases) {
@@ -975,6 +984,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
     schemeKey,
     attackProfile: profile,
     dmg,
+    manaSteals: manaStealEvents,
   };
 }
 

--- a/src/scene/delta.js
+++ b/src/scene/delta.js
@@ -182,6 +182,17 @@ export function playDeltaAnimations(prevState, nextState, opts = {}) {
         window.__fx?.scheduleHpPopup(change.r, change.c, change.delta, 1600);
       }
     }
+
+    const prevSteals = Array.isArray(prevState?.manaStealEvents) ? prevState.manaStealEvents : [];
+    const nextSteals = Array.isArray(nextState?.manaStealEvents) ? nextState.manaStealEvents : [];
+    const seenIds = new Set(prevSteals.map(ev => ev?.id));
+    const fresh = nextSteals.filter(ev => ev && !seenIds.has(ev.id));
+    const animateSteal = window.__ui?.mana?.animateManaSteal;
+    if (typeof animateSteal === 'function' && fresh.length) {
+      for (const ev of fresh) {
+        try { animateSteal(ev); } catch (err) { console.warn('[delta] mana steal animation failed', err); }
+      }
+    }
   } catch {}
 }
 

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -52,6 +52,17 @@ function adjustPendingAutoEnd(delta) {
   gs.pendingAutoEndRequests = next > 0 ? next : 0;
 }
 
+function handleManaStealAnimations(list) {
+  if (typeof window === 'undefined') return;
+  if (!Array.isArray(list) || list.length === 0) return;
+  const animate = window.__ui?.mana?.animateManaSteal;
+  if (typeof animate !== 'function') return;
+  for (const steal of list) {
+    if (!steal) continue;
+    try { animate(steal); } catch (err) { console.warn('[interactions] mana steal animation failed', err); }
+  }
+}
+
 export function hasPendingForcedDiscards() {
   if (typeof window === 'undefined') return false;
   const state = window.gameState;
@@ -799,6 +810,7 @@ export function placeUnitWithDirection(direction) {
           window.addLog(text);
         }
       }
+      handleManaStealAnimations(discardInfo?.manaSteals);
     }
   }
   const unit = {
@@ -892,6 +904,7 @@ export function placeUnitWithDirection(direction) {
         window.addLog(text);
       }
     }
+    handleManaStealAnimations(discardEffects?.manaSteals);
     // При мгновенной смерти существо считается призванным, поэтому передаём ход оппоненту
     endTurnAfterSummon();
     // очищаем возможные состояния выбора цели, чтобы не блокировать интерфейс после мгновенной смерти
@@ -935,6 +948,7 @@ export function placeUnitWithDirection(direction) {
         window.addLog?.(text);
       }
     }
+    handleManaStealAnimations(summonEvents?.manaSteals);
     if (Array.isArray(summonEvents?.statBuffs) && summonEvents.statBuffs.length) {
       for (const buff of summonEvents.statBuffs) {
         if (!buff) continue;

--- a/src/scene/unitTooltip.js
+++ b/src/scene/unitTooltip.js
@@ -11,6 +11,7 @@ import {
 } from '../core/abilities.js';
 import { effectiveStats } from '../core/rules.js';
 import { showTooltip, hideTooltip } from '../ui/tooltip.js';
+import { hasManaStealKeyword } from '../core/abilityHandlers/manaSteal.js';
 
 const SOURCE = 'unit-hover';
 const DELAY_MS = 1000;
@@ -117,6 +118,9 @@ function collectStatuses(state, unit, tpl, { r, c, cell }) {
   }
   if (tpl?.fieldquakeLock) {
     statuses.push({ key: 'fieldquake', text: 'Fieldquake lock aura' });
+  }
+  if (hasManaStealKeyword(tpl)) {
+    statuses.push({ key: 'mana-steal', text: 'Mana steal' });
   }
   const protection = getUnitProtection(state, r, c, { unit, tpl });
   if (protection > 0) {

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -11,6 +11,17 @@ import { computeFieldquakeLockedCells } from '../core/fieldLocks.js';
 import { refreshPossessionsUI } from '../ui/possessions.js';
 import { applyDeathDiscardEffects } from '../core/abilityHandlers/discard.js';
 
+function animateManaStealEvents(list) {
+  if (typeof window === 'undefined') return;
+  if (!Array.isArray(list) || list.length === 0) return;
+  const animate = window.__ui?.mana?.animateManaSteal;
+  if (typeof animate !== 'function') return;
+  for (const steal of list) {
+    if (!steal) continue;
+    try { animate(steal); } catch (err) { console.warn('[spells] mana steal animation failed', err); }
+  }
+}
+
 // Общая реализация ритуала Holy Feast
 function runHolyFeast({ tpl, pl, idx, cardMesh, tileMesh }) {
   const handIndices = pl.hand
@@ -289,6 +300,7 @@ export const handlers = {
               addLog(text);
             }
           }
+          animateManaStealEvents(discardEffects?.manaSteals);
           setTimeout(() => {
             refreshPossessionsUI(gameState);
             updateUnits();
@@ -403,6 +415,7 @@ export const handlers = {
               if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
                 for (const text of discardEffects.logs) addLog(text);
               }
+              animateManaStealEvents(discardEffects?.manaSteals);
               setTimeout(() => {
                 refreshPossessionsUI(gameState);
                 updateUnits();

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -365,6 +365,20 @@ export function confirmUnitAbilityOrientation(context, direction) {
       }
     }
 
+    const animateManaSteal = w.__ui?.mana?.animateManaSteal;
+    if (typeof animateManaSteal === 'function') {
+      if (Array.isArray(result.events?.manaSteals) && result.events.manaSteals.length) {
+        for (const steal of result.events.manaSteals) {
+          try { animateManaSteal(steal); } catch (err) { console.warn('[unitAbility] mana steal animation failed', err); }
+        }
+      }
+      if (Array.isArray(result.summonEvents?.manaSteals) && result.summonEvents.manaSteals.length) {
+        for (const steal of result.summonEvents.manaSteals) {
+          try { animateManaSteal(steal); } catch (err) { console.warn('[unitAbility] mana steal animation failed', err); }
+        }
+      }
+    }
+
     if (result.summonEvents?.possessions?.length) {
       for (const ev of result.summonEvents.possessions) {
         const unitTaken = gameState.board?.[ev.r]?.[ev.c]?.unit;

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -157,6 +157,152 @@ export function animateManaGainFromWorld(pos, ownerIndex, visualOnly = true, tar
   } catch {}
 }
 
+export function animateManaSteal(event) {
+  try {
+    if (!event) return;
+    const amountRaw = Number(event.amount || event.count || 0);
+    const amount = Math.max(0, Math.floor(amountRaw));
+    const fromIndex = Number.isInteger(event.from) ? event.from : null;
+    const toIndex = Number.isInteger(event.to) ? event.to : null;
+    if (amount <= 0 || fromIndex == null || toIndex == null) return;
+    const fromBar = document.getElementById(`mana-display-${fromIndex}`);
+    const toBar = document.getElementById(`mana-display-${toIndex}`);
+    if (!fromBar || !toBar) return;
+
+    const beforeFrom = Number.isFinite(event?.before?.fromMana)
+      ? event.before.fromMana
+      : (Number(event?.after?.fromMana) || 0) + amount;
+    const beforeTo = Number.isFinite(event?.before?.toMana)
+      ? event.before.toMana
+      : Math.max(0, (Number(event?.after?.toMana) || 0) - amount);
+    const afterTo = Number.isFinite(event?.after?.toMana)
+      ? event.after.toMana
+      : Math.min(10, beforeTo + amount);
+
+    const fromSlots = [];
+    for (let i = 0; i < amount; i += 1) {
+      fromSlots.push(Math.max(0, Math.min(9, beforeFrom - 1 - i)));
+    }
+    const newSlots = [];
+    for (let idx = beforeTo; idx < afterTo; idx += 1) {
+      newSlots.push(Math.max(0, Math.min(9, idx)));
+    }
+    while (newSlots.length < amount) {
+      const fallback = newSlots.length ? newSlots[newSlots.length - 1] : Math.max(0, Math.min(9, afterTo - 1));
+      newSlots.push(fallback);
+    }
+
+    const getSlotRect = (barEl, idx) => {
+      if (!barEl) return null;
+      const child = barEl.children?.[idx];
+      if (child) return child.getBoundingClientRect();
+      if (barEl.children && barEl.children.length) {
+        const last = barEl.children[Math.min(idx, barEl.children.length - 1)];
+        if (last) return last.getBoundingClientRect();
+      }
+      return barEl.getBoundingClientRect();
+    };
+
+    const spawnSteal = (fromIdx, toIdx, delayMs) => {
+      const fromRect = getSlotRect(fromBar, fromIdx);
+      if (!fromRect) return;
+      const orb = document.createElement('div');
+      orb.className = 'mana-orb--steal-fx';
+      orb.style.position = 'fixed';
+      orb.style.left = `${fromRect.left + fromRect.width / 2}px`;
+      orb.style.top = `${fromRect.top + fromRect.height / 2}px`;
+      orb.style.transform = 'translate(-50%, -50%) scale(0.9)';
+      orb.style.opacity = '0';
+      orb.style.zIndex = '90';
+      document.body.appendChild(orb);
+
+      const ensureTargetVisible = () => {
+        const targetEl = toBar.children?.[toIdx];
+        if (targetEl) {
+          targetEl.style.transition = 'opacity 220ms ease';
+          targetEl.style.opacity = '1';
+        }
+      };
+
+      const playArrival = () => {
+        const targetRect = getSlotRect(toBar, toIdx);
+        if (!targetRect) { ensureTargetVisible(); return; }
+        const spark = document.createElement('div');
+        spark.className = 'mana-orb--steal-gain';
+        spark.style.position = 'fixed';
+        spark.style.left = `${targetRect.left + targetRect.width / 2}px`;
+        spark.style.top = `${targetRect.top + targetRect.height / 2}px`;
+        spark.style.transform = 'translate(-50%, -50%) scale(0.4)';
+        spark.style.opacity = '0';
+        spark.style.zIndex = '92';
+        document.body.appendChild(spark);
+        const tlGain = window.gsap?.timeline({
+          onComplete: () => {
+            try { if (spark.parentNode) spark.parentNode.removeChild(spark); } catch {}
+            ensureTargetVisible();
+          },
+        });
+        if (tlGain) {
+          tlGain.to(spark, { duration: 0.15, opacity: 1, scale: 0.9, ease: 'power1.out' })
+            .to(spark, { duration: 0.32, opacity: 0, scale: 1.2, ease: 'power2.in' }, '>-0.05');
+        } else {
+          spark.style.transition = 'opacity 180ms ease, transform 180ms ease';
+          requestAnimationFrame(() => {
+            spark.style.opacity = '1';
+            spark.style.transform = 'translate(-50%, -50%) scale(0.9)';
+            setTimeout(() => {
+              spark.style.opacity = '0';
+              spark.style.transform = 'translate(-50%, -50%) scale(1.2)';
+              setTimeout(() => {
+                try { if (spark.parentNode) spark.parentNode.removeChild(spark); } catch {}
+                ensureTargetVisible();
+              }, 200);
+            }, 200);
+          });
+        }
+      };
+
+      const targetEl = toBar.children?.[toIdx];
+      if (targetEl) {
+        targetEl.style.opacity = '0';
+      }
+
+      const cleanup = () => {
+        try { if (orb.parentNode) orb.parentNode.removeChild(orb); } catch {}
+        playArrival();
+      };
+
+      const tl = window.gsap?.timeline({ delay: Math.max(0, delayMs) / 1000, onComplete: cleanup });
+      if (tl) {
+        tl.to(orb, { duration: 0.2, opacity: 1, scale: 1.05, ease: 'power2.out' })
+          .to(orb, { duration: 0.36, y: '-32', ease: 'power1.out' }, '>-0.06')
+          .to(orb, { duration: 0.28, opacity: 0, scale: 0.6, ease: 'power2.in' }, '>-0.2');
+      } else {
+        setTimeout(() => {
+          orb.style.transition = 'transform 260ms ease, opacity 260ms ease';
+          requestAnimationFrame(() => {
+            orb.style.opacity = '1';
+            orb.style.transform = 'translate(-50%, -80%) scale(1.05)';
+            setTimeout(() => {
+              orb.style.opacity = '0';
+              orb.style.transform = 'translate(-50%, -110%) scale(0.6)';
+              setTimeout(cleanup, 260);
+            }, 200);
+          });
+        }, Math.max(0, delayMs));
+      }
+    };
+
+    for (let i = 0; i < amount; i += 1) {
+      const fromIdx = fromSlots[i] ?? fromSlots[fromSlots.length - 1] ?? 0;
+      const toIdx = newSlots[i] ?? newSlots[newSlots.length - 1] ?? 0;
+      spawnSteal(fromIdx, toIdx, i * 140);
+    }
+  } catch (err) {
+    console.warn('[mana] animateManaSteal failed', err);
+  }
+}
+
 export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationMs = 900) {
   return new Promise(resolve => {
     try {
@@ -321,7 +467,7 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
   });
 }
 
-const api = { renderBars, animateManaGainFromWorld, animateTurnManaGain };
+const api = { renderBars, animateManaGainFromWorld, animateManaSteal, animateTurnManaGain };
 try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.mana = api; } } catch {}
 export default api;
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -10,11 +10,27 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
   background: radial-gradient(circle at 30% 30%, #fff, #8bd5ff 30%, #1ea0ff 70%, #0a67b7); 
   box-shadow: 0 0 10px rgba(30,160,255,0.8); 
 }
-.mana-slot { 
-  width: 18px; height: 18px; border-radius: 50%; 
-  border: 1px solid rgba(255,255,255,0.25); 
-  background: rgba(255,255,255,0.06); 
-  box-shadow: inset 0 2px 6px rgba(0,0,0,0.5); 
+.mana-slot {
+  width: 18px; height: 18px; border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.06);
+  box-shadow: inset 0 2px 6px rgba(0,0,0,0.5);
+}
+.mana-orb--steal-fx {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #ffffff, #c084fc 32%, #6366f1 70%, #312e81);
+  box-shadow: 0 0 14px rgba(99, 102, 241, 0.75);
+  pointer-events: none;
+}
+.mana-orb--steal-gain {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #ffffff, #bbf7d0 32%, #4ade80 70%, #166534);
+  box-shadow: 0 0 16px rgba(45, 212, 191, 0.9);
+  pointer-events: none;
 }
 /* Кнопка завершения хода с круговым таймером **/ 
 .end-turn-btn { 


### PR DESCRIPTION
## Summary
- add reusable mana steal handler wired into summon and death pipelines
- implement Moving Isle of Kadena and Queen's Servant with the new mechanic and proper combat layouts
- create UI handling and animations for mana stealing events, including action/log plumbing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d6888235b88330a5119db71eab5530