### PR TITLE
Add authentication system and per-user decks

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,6 @@
         // Привязка обработчиков взаимодействия теперь в модуле interactions
         window.__interactions.setupInteractions();
         try { window.attachUIEvents && window.attachUIEvents(); } catch {}
-        try { window.__ui?.mainMenu?.open?.(true); } catch {}
       }
     try { window.init = init; window.initThreeJS = initThreeJS; window.initGame = initGame; window.animate = animate; } catch {}
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,109 @@
+import { Router } from 'express';
+import { hashPassword, verifyPassword } from '../server/services/authService.js';
+import { createAuthPayload, toClientProfile } from '../server/services/sessionService.js';
+import {
+  createUser,
+  findUserByEmail,
+  updateLastLogin,
+  ensureUserTable,
+} from '../server/repositories/usersRepository.js';
+import { requireAuth } from '../server/middleware/authMiddleware.js';
+
+const router = Router();
+let storageReady = false;
+
+function sanitizeEmail(raw) {
+  if (typeof raw !== 'string') return '';
+  return raw.trim().toLowerCase();
+}
+
+function sanitizeNickname(raw, fallback) {
+  const base = typeof raw === 'string' && raw.trim() ? raw.trim() : fallback;
+  const safe = base || 'Player';
+  return safe.length > 32 ? safe.slice(0, 32) : safe;
+}
+
+function validatePassword(password) {
+  if (typeof password !== 'string' || !password.trim()) {
+    throw new Error('Пароль обязателен');
+  }
+  if (password.length < 6) {
+    throw new Error('Пароль должен содержать не менее 6 символов');
+  }
+}
+
+async function ensureStorage() {
+  if (storageReady) return true;
+  const ok = await ensureUserTable();
+  storageReady = ok;
+  return ok;
+}
+
+router.post('/register', async (req, res) => {
+  try {
+    const ready = await ensureStorage();
+    if (!ready) {
+      return res.status(503).json({ error: 'Хранилище пользователей недоступно' });
+    }
+    const email = sanitizeEmail(req.body?.email);
+    const password = req.body?.password ?? '';
+    const confirm = req.body?.confirm ?? req.body?.passwordConfirm ?? '';
+    try {
+      validatePassword(password);
+    } catch (err) {
+      return res.status(400).json({ error: err?.message || 'Пароль не подходит требованиям' });
+    }
+    if (password !== confirm) {
+      return res.status(400).json({ error: 'Пароли не совпадают' });
+    }
+    if (!email) {
+      return res.status(400).json({ error: 'Email обязателен' });
+    }
+    const existing = await findUserByEmail(email);
+    if (existing) {
+      return res.status(409).json({ error: 'Пользователь с таким email уже существует' });
+    }
+    const nickname = sanitizeNickname(req.body?.nickname, email.split('@')[0] || 'Player');
+    const { hash, salt } = await hashPassword(password);
+    const user = await createUser({ email, passwordHash: hash, passwordSalt: salt, nickname });
+    const payload = createAuthPayload(user);
+    res.status(201).json(payload);
+  } catch (err) {
+    console.error('[auth] Регистрация завершилась ошибкой', err);
+    res.status(500).json({ error: 'Не удалось создать пользователя' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const ready = await ensureStorage();
+    if (!ready) {
+      return res.status(503).json({ error: 'Хранилище пользователей недоступно' });
+    }
+    const email = sanitizeEmail(req.body?.email);
+    const password = req.body?.password ?? '';
+    if (!email || !password) {
+      return res.status(400).json({ error: 'Неверные учетные данные' });
+    }
+    const user = await findUserByEmail(email);
+    if (!user) {
+      return res.status(401).json({ error: 'Неверный email или пароль' });
+    }
+    const valid = await verifyPassword(password, user.passwordHash, user.passwordSalt);
+    if (!valid) {
+      return res.status(401).json({ error: 'Неверный email или пароль' });
+    }
+    await updateLastLogin(user.id);
+    const payload = createAuthPayload(user);
+    res.json(payload);
+  } catch (err) {
+    console.error('[auth] Ошибка входа', err);
+    res.status(500).json({ error: 'Не удалось выполнить вход' });
+  }
+});
+
+router.get('/profile', requireAuth, (req, res) => {
+  res.json({ user: toClientProfile(req.user) });
+});
+
+export default router;

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -1,0 +1,36 @@
+import { resolveUserFromToken, toClientProfile } from '../services/sessionService.js';
+
+function pickToken(req) {
+  const header = req.headers?.authorization || req.headers?.Authorization;
+  const xAuth = req.headers?.['x-auth-token'] || req.headers?.['x-access-token'];
+  const queryToken = req.query?.token || req.query?.authToken;
+  return header || xAuth || queryToken || null;
+}
+
+export async function attachUser(req, _res, next) {
+  if (req.__authAttached) return next();
+  req.__authAttached = true;
+  const rawToken = pickToken(req);
+  const resolved = await resolveUserFromToken(rawToken);
+  if (resolved?.user) {
+    req.user = toClientProfile(resolved.user);
+    req.authToken = resolved.token;
+  } else {
+    req.user = null;
+    req.authToken = null;
+  }
+  next();
+}
+
+export async function requireAuth(req, res, next) {
+  await attachUser(req, res, () => {});
+  if (!req.user) {
+    return res.status(401).json({ error: 'Требуется авторизация' });
+  }
+  return next();
+}
+
+export default {
+  attachUser,
+  requireAuth,
+};

--- a/server/repositories/usersRepository.js
+++ b/server/repositories/usersRepository.js
@@ -1,0 +1,107 @@
+import { randomUUID } from 'crypto';
+import { isDbReady, query } from '../db.js';
+
+function mapRow(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    email: row.email,
+    passwordHash: row.password_hash,
+    passwordSalt: row.password_salt,
+    nickname: row.nickname,
+    createdAt: row.created_at ? new Date(row.created_at).toISOString() : null,
+    updatedAt: row.updated_at ? new Date(row.updated_at).toISOString() : null,
+    lastLoginAt: row.last_login_at ? new Date(row.last_login_at).toISOString() : null,
+  };
+}
+
+export function toPublicUser(user) {
+  if (!user) return null;
+  const { id, email, nickname, createdAt, updatedAt, lastLoginAt } = user;
+  return { id, email, nickname, createdAt, updatedAt, lastLoginAt };
+}
+
+export async function ensureUserTable() {
+  if (!isDbReady()) return false;
+  await query(`
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      password_salt TEXT NOT NULL,
+      nickname TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_login_at TIMESTAMPTZ
+    );
+  `);
+  await query(`
+    CREATE INDEX IF NOT EXISTS idx_users_email ON users (LOWER(email));
+  `);
+  await query(`
+    CREATE INDEX IF NOT EXISTS idx_users_nickname ON users (LOWER(nickname));
+  `);
+  return true;
+}
+
+export async function createUser({ email, passwordHash, passwordSalt, nickname }) {
+  if (!isDbReady()) throw new Error('Хранилище пользователей недоступно');
+  const id = randomUUID();
+  const result = await query(`
+    INSERT INTO users (id, email, password_hash, password_salt, nickname)
+    VALUES ($1, LOWER($2), $3, $4, $5)
+    RETURNING id, email, password_hash, password_salt, nickname, created_at, updated_at, last_login_at;
+  `, [id, email, passwordHash, passwordSalt, nickname]);
+  return mapRow(result.rows?.[0]);
+}
+
+export async function findUserByEmail(email) {
+  if (!isDbReady()) throw new Error('Хранилище пользователей недоступно');
+  const result = await query(`
+    SELECT id, email, password_hash, password_salt, nickname, created_at, updated_at, last_login_at
+    FROM users
+    WHERE LOWER(email) = LOWER($1)
+    LIMIT 1;
+  `, [email]);
+  return mapRow(result.rows?.[0]);
+}
+
+export async function getUserById(id) {
+  if (!isDbReady()) throw new Error('Хранилище пользователей недоступно');
+  const result = await query(`
+    SELECT id, email, password_hash, password_salt, nickname, created_at, updated_at, last_login_at
+    FROM users
+    WHERE id = $1
+    LIMIT 1;
+  `, [id]);
+  return mapRow(result.rows?.[0]);
+}
+
+export async function updateLastLogin(id) {
+  if (!isDbReady()) throw new Error('Хранилище пользователей недоступно');
+  await query(`
+    UPDATE users
+    SET last_login_at = NOW(), updated_at = NOW()
+    WHERE id = $1;
+  `, [id]);
+}
+
+export async function touchProfile(id, patch = {}) {
+  if (!isDbReady()) throw new Error('Хранилище пользователей недоступно');
+  const fields = [];
+  const values = [];
+  let idx = 1;
+  if (patch.nickname) {
+    fields.push(`nickname = $${idx += 1}`);
+    values.push(patch.nickname);
+  }
+  if (!fields.length) return null;
+  values.unshift(id);
+  const result = await query(`
+    UPDATE users
+    SET ${fields.join(', ')}, updated_at = NOW()
+    WHERE id = $1
+    RETURNING id, email, password_hash, password_salt, nickname, created_at, updated_at, last_login_at;
+  `, values);
+  return mapRow(result.rows?.[0]);
+}

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -1,0 +1,112 @@
+import { createHmac, randomBytes, scrypt as scryptCb, timingSafeEqual } from 'crypto';
+
+const TOKEN_TTL_MS = Math.max(1000 * 60 * 60 * 24, Number(process.env.AUTH_TOKEN_TTL_MS) || 1000 * 60 * 60 * 24 * 30);
+const KEY_LENGTH = 64;
+let secretCache = null;
+let warnedAboutSecret = false;
+
+function getSecret() {
+  if (secretCache) return secretCache;
+  const candidate = process.env.AUTH_SECRET || process.env.JWT_SECRET || process.env.SECRET_KEY;
+  if (!candidate && !warnedAboutSecret) {
+    console.warn('[authService] AUTH_SECRET не задан, используется небезопасный dev-secret');
+    warnedAboutSecret = true;
+  }
+  secretCache = candidate || 'dev-secret-change-me';
+  return secretCache;
+}
+
+function scrypt(password, salt) {
+  return new Promise((resolve, reject) => {
+    scryptCb(password, salt, KEY_LENGTH, (err, derivedKey) => {
+      if (err) return reject(err);
+      resolve(derivedKey);
+    });
+  });
+}
+
+function toBase64Url(data) {
+  if (typeof data === 'string') {
+    return Buffer.from(data, 'utf8').toString('base64url');
+  }
+  return Buffer.from(data).toString('base64url');
+}
+
+function parseBase64Url(str) {
+  return Buffer.from(str, 'base64url').toString('utf8');
+}
+
+export async function hashPassword(password) {
+  if (typeof password !== 'string' || !password) {
+    throw new Error('Пароль не может быть пустым');
+  }
+  const salt = randomBytes(16);
+  const derived = await scrypt(password, salt);
+  return {
+    hash: derived.toString('hex'),
+    salt: salt.toString('hex'),
+  };
+}
+
+export async function verifyPassword(password, hash, salt) {
+  if (typeof password !== 'string' || !password) return false;
+  if (!hash || !salt) return false;
+  const derived = await scrypt(password, Buffer.from(salt, 'hex'));
+  const stored = Buffer.from(hash, 'hex');
+  if (stored.length !== derived.length) return false;
+  return timingSafeEqual(stored, derived);
+}
+
+export function issueToken(user, { expiresInMs } = {}) {
+  if (!user?.id) throw new Error('Невозможно выдать токен без пользователя');
+  const now = Date.now();
+  const ttl = Number.isFinite(expiresInMs) && expiresInMs > 0 ? expiresInMs : TOKEN_TTL_MS;
+  const payload = {
+    sub: user.id,
+    email: user.email,
+    nickname: user.nickname,
+    iat: now,
+    exp: now + ttl,
+    v: 1,
+  };
+  const header = {
+    alg: 'HS256',
+    typ: 'EOGJWT',
+    v: 1,
+  };
+  const unsigned = `${toBase64Url(JSON.stringify(header))}.${toBase64Url(JSON.stringify(payload))}`;
+  const signature = createHmac('sha256', getSecret()).update(unsigned).digest('base64url');
+  return `${unsigned}.${signature}`;
+}
+
+export function verifyToken(token) {
+  if (!token || typeof token !== 'string') {
+    throw new Error('Токен не задан');
+  }
+  const cleaned = token.trim();
+  const parts = cleaned.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Некорректный формат токена');
+  }
+  const [headerPart, payloadPart, signaturePart] = parts;
+  const unsigned = `${headerPart}.${payloadPart}`;
+  const expectedSignature = createHmac('sha256', getSecret()).update(unsigned).digest();
+  const providedSignature = Buffer.from(signaturePart, 'base64url');
+  if (providedSignature.length !== expectedSignature.length || !timingSafeEqual(providedSignature, expectedSignature)) {
+    throw new Error('Подпись токена недействительна');
+  }
+  let payload;
+  try {
+    payload = JSON.parse(parseBase64Url(payloadPart));
+  } catch {
+    throw new Error('Невозможно разобрать нагрузку токена');
+  }
+  if (payload.exp && Date.now() > Number(payload.exp)) {
+    throw new Error('Срок действия токена истёк');
+  }
+  return payload;
+}
+
+export function getDefaultTokenTtl() {
+  return TOKEN_TTL_MS;
+}

--- a/server/services/sessionService.js
+++ b/server/services/sessionService.js
@@ -1,0 +1,37 @@
+import { issueToken, verifyToken } from './authService.js';
+import { getUserById, toPublicUser } from '../repositories/usersRepository.js';
+
+function extractToken(rawToken) {
+  if (!rawToken || typeof rawToken !== 'string') return null;
+  const trimmed = rawToken.trim();
+  if (!trimmed) return null;
+  if (trimmed.toLowerCase().startsWith('bearer ')) {
+    return trimmed.slice(7).trim();
+  }
+  return trimmed;
+}
+
+export async function resolveUserFromToken(rawToken) {
+  const token = extractToken(rawToken);
+  if (!token) return null;
+  try {
+    const payload = verifyToken(token);
+    const user = await getUserById(payload.sub);
+    if (!user) return null;
+    return { user, token, payload };
+  } catch (err) {
+    console.warn('[sessionService] Токен отклонён', err?.message || err);
+    return null;
+  }
+}
+
+export function createAuthPayload(user, options = {}) {
+  if (!user) throw new Error('Пользователь не найден');
+  const token = issueToken(user, options);
+  const profile = toPublicUser(user);
+  return { token, user: profile };
+}
+
+export function toClientProfile(user) {
+  return toPublicUser(user);
+}

--- a/src/auth/sessionStore.js
+++ b/src/auth/sessionStore.js
@@ -1,0 +1,266 @@
+// Хранилище авторизационных данных на фронтенде
+// Держим модуль чистым: только управление токеном, профилями и уведомления слушателей
+
+const STORAGE_KEY_PROFILES = 'eog.auth.profiles';
+const STORAGE_KEY_DEFAULT = 'eog.auth.defaultProfile';
+const SESSION_KEY_ACTIVE = 'eog.auth.session.activeProfile';
+
+let profiles = new Map();
+let activeProfileId = null;
+let activeToken = null;
+let activeUser = null;
+let initialized = false;
+
+const listeners = new Set();
+
+function notify() {
+  const snapshot = {
+    profiles: getStoredProfiles(),
+    activeProfileId,
+    token: activeToken,
+    user: activeUser,
+    authenticated: !!activeToken,
+  };
+  listeners.forEach(cb => {
+    try { cb(snapshot); } catch (err) { console.warn('[sessionStore] Ошибка слушателя', err); }
+  });
+}
+
+function readLocalStorage(key) {
+  if (typeof localStorage === 'undefined') return null;
+  try { return localStorage.getItem(key); } catch { return null; }
+}
+
+function writeLocalStorage(key, value) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    if (value === null || value === undefined) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, value);
+    }
+  } catch {}
+}
+
+function readSessionStorage(key) {
+  if (typeof sessionStorage === 'undefined') return null;
+  try { return sessionStorage.getItem(key); } catch { return null; }
+}
+
+function writeSessionStorage(key, value) {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    if (value === null || value === undefined) {
+      sessionStorage.removeItem(key);
+    } else {
+      sessionStorage.setItem(key, value);
+    }
+  } catch {}
+}
+
+function loadProfiles() {
+  const raw = readLocalStorage(STORAGE_KEY_PROFILES);
+  if (!raw) return new Map();
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return new Map();
+    const map = new Map();
+    for (const [id, entry] of Object.entries(parsed)) {
+      if (!id || !entry) continue;
+      if (!entry.token || !entry.user || entry.user.id !== id) continue;
+      map.set(id, {
+        token: String(entry.token),
+        user: entry.user,
+        updatedAt: Number(entry.updatedAt) || Date.now(),
+      });
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+function persistProfiles() {
+  const obj = {};
+  profiles.forEach((value, key) => {
+    obj[key] = {
+      token: value.token,
+      user: value.user,
+      updatedAt: value.updatedAt,
+    };
+  });
+  writeLocalStorage(STORAGE_KEY_PROFILES, JSON.stringify(obj));
+}
+
+function pickInitialProfileId() {
+  const sessionId = readSessionStorage(SESSION_KEY_ACTIVE);
+  if (sessionId && profiles.has(sessionId)) return sessionId;
+  const defaultId = readLocalStorage(STORAGE_KEY_DEFAULT);
+  if (defaultId && profiles.has(defaultId)) return defaultId;
+  let latestId = null;
+  let latestTs = -Infinity;
+  profiles.forEach((value, key) => {
+    if (value.updatedAt > latestTs) {
+      latestId = key;
+      latestTs = value.updatedAt;
+    }
+  });
+  return latestId;
+}
+
+function applyActiveProfile(id, { silent = false } = {}) {
+  if (id && !profiles.has(id)) {
+    id = null;
+  }
+  activeProfileId = id;
+  if (id) {
+    const entry = profiles.get(id);
+    activeToken = entry?.token || null;
+    activeUser = entry?.user || null;
+    writeSessionStorage(SESSION_KEY_ACTIVE, id);
+    writeLocalStorage(STORAGE_KEY_DEFAULT, id);
+  } else {
+    activeToken = null;
+    activeUser = null;
+    writeSessionStorage(SESSION_KEY_ACTIVE, null);
+    writeLocalStorage(STORAGE_KEY_DEFAULT, null);
+  }
+  if (!silent) notify();
+}
+
+export function initSessionStore() {
+  if (initialized) return {
+    profiles: getStoredProfiles(),
+    activeProfileId,
+    token: activeToken,
+    user: activeUser,
+    authenticated: !!activeToken,
+  };
+  profiles = loadProfiles();
+  const initialId = pickInitialProfileId();
+  applyActiveProfile(initialId, { silent: true });
+  initialized = true;
+  notify();
+  return {
+    profiles: getStoredProfiles(),
+    activeProfileId,
+    token: activeToken,
+    user: activeUser,
+    authenticated: !!activeToken,
+  };
+}
+
+export function getSessionToken() {
+  return activeToken;
+}
+
+export function getActiveUser() {
+  return activeUser;
+}
+
+export function isAuthenticated() {
+  return !!activeToken;
+}
+
+export function getStoredProfiles() {
+  const arr = [];
+  profiles.forEach((value, key) => {
+    arr.push({ id: key, user: value.user, updatedAt: value.updatedAt });
+  });
+  arr.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+  return arr;
+}
+
+export function onSessionChange(listener) {
+  if (typeof listener !== 'function') return () => {};
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function setActiveSession({ token, user, remember = true }) {
+  if (!user?.id || !token) return;
+  const entry = {
+    token,
+    user,
+    updatedAt: Date.now(),
+  };
+  if (remember) {
+    profiles.set(user.id, entry);
+    persistProfiles();
+  }
+  applyActiveProfile(user.id);
+}
+
+export function setActiveProfile(profileId) {
+  applyActiveProfile(profileId || null);
+}
+
+export function clearActiveSession({ keepProfiles = true, dropActiveProfile = false } = {}) {
+  if (dropActiveProfile && activeProfileId) {
+    profiles.delete(activeProfileId);
+    persistProfiles();
+  }
+  if (!keepProfiles) {
+    profiles.clear();
+    persistProfiles();
+    writeLocalStorage(STORAGE_KEY_DEFAULT, null);
+  }
+  applyActiveProfile(null);
+}
+
+export function removeStoredProfile(profileId) {
+  if (!profileId) return;
+  profiles.delete(profileId);
+  persistProfiles();
+  if (activeProfileId === profileId) {
+    applyActiveProfile(pickInitialProfileId());
+  } else {
+    notify();
+  }
+}
+
+export function handleUnauthorized({ dropProfile = true } = {}) {
+  if (!activeProfileId) {
+    clearActiveSession({ keepProfiles: !dropProfile });
+    return;
+  }
+  if (dropProfile) {
+    profiles.delete(activeProfileId);
+    persistProfiles();
+  }
+  applyActiveProfile(dropProfile ? pickInitialProfileId() : null);
+}
+
+export function getStateSnapshot() {
+  return {
+    profiles: getStoredProfiles(),
+    activeProfileId,
+    token: activeToken,
+    user: activeUser,
+    authenticated: !!activeToken,
+  };
+}
+
+const api = {
+  initSessionStore,
+  getSessionToken,
+  getActiveUser,
+  isAuthenticated,
+  getStoredProfiles,
+  onSessionChange,
+  setActiveSession,
+  setActiveProfile,
+  clearActiveSession,
+  removeStoredProfile,
+  handleUnauthorized,
+  getStateSnapshot,
+};
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__auth = window.__auth || {};
+    Object.assign(window.__auth, api);
+  }
+} catch {}
+
+export default api;

--- a/src/net/auth.js
+++ b/src/net/auth.js
@@ -1,0 +1,61 @@
+// HTTP-клиент для регистрации и входа
+// Оставляем модуль без зависимостей от DOM
+
+import { getServerBase } from './config.js';
+
+function buildUrl(path = '') {
+  const base = getServerBase().replace(/\/+$/, '');
+  const suffix = path ? (path.startsWith('/') ? path : `/${path}`) : '';
+  return `${base}/auth${suffix}`;
+}
+
+async function requestJson(url, options = {}) {
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+  const contentType = response.headers.get('content-type') || '';
+  const isJson = contentType.includes('application/json');
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`;
+    if (isJson) {
+      try {
+        const payload = await response.json();
+        if (payload?.error) message = payload.error;
+      } catch {}
+    }
+    const err = new Error(message);
+    err.status = response.status;
+    throw err;
+  }
+  if (!isJson) return {};
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}
+
+export async function login({ email, password } = {}) {
+  const body = JSON.stringify({ email, password });
+  const data = await requestJson(buildUrl('/login'), { method: 'POST', body });
+  return data;
+}
+
+export async function register({ email, password, confirm, nickname } = {}) {
+  const body = JSON.stringify({ email, password, confirm, nickname });
+  const data = await requestJson(buildUrl('/register'), { method: 'POST', body });
+  return data;
+}
+
+export async function fetchProfile(token) {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const data = await requestJson(buildUrl('/profile'), { method: 'GET', headers });
+  return data;
+}
+
+export default { login, register, fetchProfile };

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -1,4 +1,5 @@
 import { getServerBase } from './config.js';
+import { initSessionStore, getSessionToken, onSessionChange, handleUnauthorized } from '../auth/sessionStore.js';
 
   /* MODULE: network/multiplayer
      Purpose: handle server connection, matchmaking, state sync,
@@ -6,6 +7,7 @@ import { getServerBase } from './config.js';
 (() => {
   // ===== 0) Config =====
   const SERVER_URL = getServerBase();
+  initSessionStore();
   try {
     if (typeof window !== 'undefined') {
       const cfg = window.__netConfig = window.__netConfig || {};
@@ -73,14 +75,52 @@ import { getServerBase } from './config.js';
   function hideStartCountdown(){ startModal?.remove(); startModal=null; }
 
   // ===== 4) Socket + sync =====
-  const socket = io(SERVER_URL, { 
+  const socket = io(SERVER_URL, {
     transports: ['websocket', 'polling'],
     upgrade: true,
     rememberUpgrade: true,
     timeout: 20000,
-    forceNew: true
+    forceNew: true,
+    autoConnect: false,
+    auth: {},
   });
   try { window.socket = socket; } catch {}
+  function getCurrentToken() {
+    try { return getSessionToken(); } catch { return null; }
+  }
+  function connectWithCurrentToken({ refresh = false } = {}) {
+    const token = getCurrentToken();
+    if (!token) {
+      if (socket.connected) {
+        try { socket.emit('authenticate', { token: null }); } catch {}
+      }
+      socket.disconnect();
+      socket.auth = socket.auth && typeof socket.auth === 'object' ? socket.auth : {};
+      delete socket.auth.token;
+      return false;
+    }
+    socket.auth = { ...(socket.auth || {}), token };
+    if (socket.connected) {
+      if (refresh) {
+        try { socket.emit('authenticate', { token }); } catch {}
+      }
+      return true;
+    }
+    try { socket.connect(); } catch {}
+    return true;
+  }
+  function disconnectSocket() {
+    try { socket.emit('authenticate', { token: null }); } catch {}
+    try { socket.disconnect(); } catch {}
+  }
+  onSessionChange(state => {
+    if (state?.token) {
+      connectWithCurrentToken({ refresh: true });
+    } else {
+      disconnectSocket();
+    }
+  });
+  connectWithCurrentToken();
   // NET_ACTIVE, MY_SEAT, APPLYING уже объявлены выше в глобальной области
 
   // --- SENDING: «обёртки» + DIGEST-пуллер ---
@@ -698,10 +738,18 @@ import { getServerBase } from './config.js';
 
   // ===== 5) Queue / start =====
   function onFindMatchClick(deckId){
+    const hasToken = connectWithCurrentToken({ refresh: true });
+    if (!hasToken) {
+      try { window.__ui?.notifications?.show?.('Необходимо войти в аккаунт', 'error'); } catch {}
+      return;
+    }
+    if (!deckId) {
+      try { window.__ui?.notifications?.show?.('Выберите колоду перед поиском матча', 'error'); } catch {}
+      return;
+    }
     console.log('[QUEUE] Attempting to join queue, socket connected:', socket.connected, 'deck:', deckId);
     showQueueModal();
     try {
-      if (!socket.connected) socket.connect();
       (window.socket || socket).emit('joinQueue', { deckId });
       (window.socket || socket).emit('debugLog', { event: 'joinQueue_sent', connected: socket.connected, deckId });
     } catch(err) {
@@ -714,6 +762,31 @@ import { getServerBase } from './config.js';
       window.__net.findMatch = onFindMatchClick;
     }
   } catch {}
+  socket.on('authError', (payload = {}) => {
+    const reason = payload?.reason || 'UNKNOWN';
+    console.warn('[QUEUE] authError', reason, payload);
+    if (reason === 'AUTH_REQUIRED') {
+      try { window.__ui?.notifications?.show?.('Сессия истекла, войдите заново', 'error'); } catch {}
+      try { handleUnauthorized({ dropProfile: true }); } catch {}
+      hideQueueModal();
+      disconnectSocket();
+      return;
+    }
+    if (reason === 'DECK_NOT_FOUND' || reason === 'DECK_REQUIRED') {
+      try { window.__ui?.notifications?.show?.('Колода недоступна для сетевой игры', 'error'); } catch {}
+      hideQueueModal();
+      return;
+    }
+    if (reason === 'DECK_LOOKUP_FAILED') {
+      try { window.__ui?.notifications?.show?.('Не удалось проверить колоду на сервере', 'error'); } catch {}
+      hideQueueModal();
+    }
+  });
+  socket.on('authState', ({ ok }) => {
+    if (!ok) {
+      hideQueueModal();
+    }
+  });
   socket.on('matchFound', ({ matchId, seat, decks })=>{
     hideQueueModal();
     try {

--- a/src/ui/authScreen.js
+++ b/src/ui/authScreen.js
@@ -1,0 +1,306 @@
+// Экран авторизации: регистрация, вход и выбор сохранённых профилей
+// Вся логика отделена от визуальных эффектов, чтобы её можно было переносить в другие движки
+
+import { login, register } from '../net/auth.js';
+import { refreshDecks } from '../net/decks.js';
+import {
+  initSessionStore,
+  onSessionChange,
+  getStateSnapshot,
+  getStoredProfiles,
+  setActiveSession,
+  setActiveProfile,
+  clearActiveSession,
+  removeStoredProfile,
+} from '../auth/sessionStore.js';
+import { setDeckStorageNamespace } from '../core/decks.js';
+
+let root = null;
+let mode = 'login';
+let pending = false;
+let errorMessage = '';
+let initialized = false;
+let unsubscribe = null;
+let lastUserId = null;
+let lastNotifiedUserId = null;
+let optionsRef = {};
+let syncingDecks = false;
+
+function ensureRoot() {
+  if (root || typeof document === 'undefined') return;
+  root = document.createElement('div');
+  root.id = 'auth-overlay';
+  root.className = 'fixed inset-0 z-[9999] flex items-center justify-center bg-slate-900 bg-opacity-95 text-slate-100 hidden';
+  document.body.appendChild(root);
+}
+
+function renderSavedProfiles(container) {
+  const profiles = getStoredProfiles();
+  if (!profiles.length) {
+    container.innerHTML = '';
+    return;
+  }
+  const list = document.createElement('div');
+  list.className = 'mt-6 space-y-3';
+  const title = document.createElement('div');
+  title.className = 'text-sm text-slate-300 uppercase tracking-wide';
+  title.textContent = 'Saved profiles';
+  list.appendChild(title);
+  profiles.forEach(({ id, user, updatedAt }) => {
+    const item = document.createElement('div');
+    item.className = 'flex items-center justify-between gap-3 bg-slate-800/70 border border-slate-700 rounded-lg px-3 py-2';
+    const info = document.createElement('div');
+    info.className = 'flex flex-col';
+    const nickname = document.createElement('span');
+    nickname.className = 'text-sm font-semibold';
+    nickname.textContent = user?.nickname || 'Player';
+    const email = document.createElement('span');
+    email.className = 'text-xs text-slate-400';
+    email.textContent = user?.email || id;
+    const time = document.createElement('span');
+    time.className = 'text-[10px] text-slate-500';
+    try {
+      const date = new Date(updatedAt || Date.now());
+      time.textContent = `Last used: ${date.toLocaleString()}`;
+    } catch {
+      time.textContent = '';
+    }
+    info.appendChild(nickname);
+    info.appendChild(email);
+    if (time.textContent) info.appendChild(time);
+    item.appendChild(info);
+
+    const actions = document.createElement('div');
+    actions.className = 'flex items-center gap-2';
+
+    const useBtn = document.createElement('button');
+    useBtn.className = 'px-3 py-1 bg-emerald-600 hover:bg-emerald-500 text-xs rounded';
+    useBtn.textContent = 'Use';
+    useBtn.addEventListener('click', (evt) => {
+      evt.preventDefault();
+      setActiveProfile(id);
+    });
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'px-2 py-1 bg-slate-700 hover:bg-slate-600 text-xs rounded';
+    removeBtn.textContent = '×';
+    removeBtn.title = 'Remove';
+    removeBtn.addEventListener('click', (evt) => {
+      evt.preventDefault();
+      removeStoredProfile(id);
+      render();
+    });
+
+    actions.appendChild(useBtn);
+    actions.appendChild(removeBtn);
+    item.appendChild(actions);
+    list.appendChild(item);
+  });
+  container.innerHTML = '';
+  container.appendChild(list);
+}
+
+function render() {
+  if (!root) return;
+  const savedProfilesPlaceholder = '<div id="auth-saved"></div>';
+  const buttonLabel = mode === 'login' ? 'Sign In' : 'Create an Account';
+  const toggleLabel = mode === 'login'
+    ? 'Create an Account'
+    : 'Return to Sign In Screen';
+  const heading = mode === 'login' ? 'Welcome back' : 'Create account';
+  const errorBlock = errorMessage ? `<div class="text-sm text-red-400 mt-3">${errorMessage}</div>` : '';
+  const pendingHint = pending ? '<div class="text-xs text-slate-400 mt-2">Processing…</div>' : '';
+  const confirmField = mode === 'register'
+    ? `<div class="flex flex-col gap-1">
+        <label class="text-xs uppercase tracking-wide text-slate-300">Confirm password</label>
+        <input type="password" name="confirm" class="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm" required />
+      </div>`
+    : '';
+  const nicknameField = mode === 'register'
+    ? `<div class="flex flex-col gap-1">
+        <label class="text-xs uppercase tracking-wide text-slate-300">Nickname</label>
+        <input type="text" name="nickname" maxlength="32" class="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm" placeholder="Optional" />
+      </div>`
+    : '';
+
+  root.innerHTML = `
+    <div class="w-full max-w-sm bg-slate-900 border border-slate-700 rounded-2xl px-6 py-8 shadow-xl">
+      <h2 class="text-xl font-semibold mb-6 text-center">${heading}</h2>
+      <form id="auth-form" class="flex flex-col gap-4">
+        <div class="flex flex-col gap-1">
+          <label class="text-xs uppercase tracking-wide text-slate-300">Email</label>
+          <input type="email" name="email" class="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm" required />
+        </div>
+        <div class="flex flex-col gap-1">
+          <label class="text-xs uppercase tracking-wide text-slate-300">Password</label>
+          <input type="password" name="password" class="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm" required minlength="6" />
+        </div>
+        ${confirmField}
+        ${nicknameField}
+        <button type="submit" class="mt-2 bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800 text-sm font-semibold rounded px-4 py-2" ${pending ? 'disabled' : ''}>${buttonLabel}</button>
+      </form>
+      <button id="auth-toggle" class="mt-4 w-full text-xs text-slate-400 hover:text-slate-200">${toggleLabel}</button>
+      ${errorBlock}
+      ${pendingHint}
+      ${savedProfilesPlaceholder}
+    </div>
+  `;
+
+  const form = root.querySelector('#auth-form');
+  form.addEventListener('submit', handleSubmit);
+  const toggleBtn = root.querySelector('#auth-toggle');
+  toggleBtn.addEventListener('click', (evt) => {
+    evt.preventDefault();
+    mode = mode === 'login' ? 'register' : 'login';
+    errorMessage = '';
+    render();
+  });
+
+  renderSavedProfiles(root.querySelector('#auth-saved'));
+}
+
+async function syncDecksForUser(user) {
+  if (!user?.id) return;
+  if (syncingDecks) return;
+  syncingDecks = true;
+  try {
+    setDeckStorageNamespace(user.id, { fallbackToDefaults: false });
+    await refreshDecks({ persistLocal: true });
+    if (typeof optionsRef.onAuthenticated === 'function' && lastNotifiedUserId !== user.id) {
+      try { optionsRef.onAuthenticated(user); } catch {}
+      lastNotifiedUserId = user.id;
+    }
+  } catch (err) {
+    errorMessage = err?.message || 'Failed to sync decks';
+    console.warn('[authScreen] Не удалось синхронизировать колоды', err);
+  } finally {
+    syncingDecks = false;
+    render();
+  }
+}
+
+function show() {
+  if (!root) return;
+  root.classList.remove('hidden');
+  render();
+}
+
+function hide() {
+  if (!root) return;
+  root.classList.add('hidden');
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  if (pending) return;
+  const formData = new FormData(event.currentTarget);
+  const email = String(formData.get('email') || '').trim();
+  const password = String(formData.get('password') || '');
+  const confirm = String(formData.get('confirm') || '');
+  const nickname = String(formData.get('nickname') || '').trim();
+  if (!email || !password) {
+    errorMessage = 'Email и пароль обязательны';
+    render();
+    return;
+  }
+  if (mode === 'register' && password !== confirm) {
+    errorMessage = 'Пароли не совпадают';
+    render();
+    return;
+  }
+  pending = true;
+  errorMessage = '';
+  render();
+  try {
+    const payload = mode === 'login'
+      ? await login({ email, password })
+      : await register({ email, password, confirm, nickname });
+    if (!payload?.token || !payload?.user) {
+      throw new Error('Некорректный ответ сервера');
+    }
+    setActiveSession({ token: payload.token, user: payload.user, remember: true });
+    // дальнейшие действия выполнит handleSessionChange
+  } catch (err) {
+    console.error('[authScreen] Ошибка авторизации', err);
+    errorMessage = err?.message || 'Не удалось выполнить действие';
+  } finally {
+    pending = false;
+    render();
+  }
+}
+
+function handleSessionChange(state) {
+  if (!state) return;
+  const authenticated = !!state.authenticated && !!state.user;
+  if (authenticated) {
+    if (state.user.id !== lastUserId) {
+      lastUserId = state.user.id;
+      syncDecksForUser(state.user);
+    }
+    hide();
+  } else {
+    if (lastUserId) {
+      try { setDeckStorageNamespace(null, { fallbackToDefaults: true }); } catch {}
+    }
+    lastUserId = null;
+    lastNotifiedUserId = null;
+    show();
+  }
+  if (!pending) {
+    render();
+  }
+}
+
+export function initAuthScreen(options = {}) {
+  if (initialized) {
+    optionsRef = options;
+    return;
+  }
+  optionsRef = options;
+  initSessionStore();
+  ensureRoot();
+  render();
+  unsubscribe = onSessionChange(handleSessionChange);
+  handleSessionChange(getStateSnapshot());
+  initialized = true;
+}
+
+export function disposeAuthScreen() {
+  if (typeof unsubscribe === 'function') {
+    unsubscribe();
+    unsubscribe = null;
+  }
+  initialized = false;
+}
+
+export function showAuthScreen() {
+  ensureRoot();
+  show();
+}
+
+export function hideAuthScreen() {
+  hide();
+}
+
+export function logout() {
+  clearActiveSession({ keepProfiles: true });
+  try { setDeckStorageNamespace(null, { fallbackToDefaults: true }); } catch {}
+  show();
+}
+
+const api = {
+  initAuthScreen,
+  disposeAuthScreen,
+  showAuthScreen,
+  hideAuthScreen,
+  logout,
+};
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.auth = api;
+  }
+} catch {}
+
+export default api;

--- a/src/ui/mainMenu.js
+++ b/src/ui/mainMenu.js
@@ -1,4 +1,7 @@
 // Главное меню игры
+import { getActiveUser } from '../auth/sessionStore.js';
+import { logout as authLogout } from './authScreen.js';
+
 let firstOpen = true;
 
 export function open(initial = false) {
@@ -13,6 +16,29 @@ export function open(initial = false) {
   const panel = document.createElement('div');
   panel.className = 'overlay-panel p-6 w-60 flex flex-col items-center gap-3';
   overlay.appendChild(panel);
+
+  const user = getActiveUser();
+  if (user) {
+    const userRow = document.createElement('div');
+    userRow.className = 'w-full flex justify-end';
+    const badge = document.createElement('div');
+    badge.className = 'flex items-center gap-2 bg-slate-800/80 border border-slate-700 rounded-full px-3 py-1 text-xs text-slate-200';
+    const name = document.createElement('span');
+    name.className = 'font-semibold text-slate-100';
+    name.textContent = user.nickname || user.email || 'Player';
+    const logoutBtn = document.createElement('button');
+    logoutBtn.className = 'text-red-300 hover:text-red-200';
+    logoutBtn.textContent = 'Log Out';
+    logoutBtn.addEventListener('click', (evt) => {
+      evt.preventDefault();
+      close();
+      authLogout();
+    });
+    badge.appendChild(name);
+    badge.appendChild(logoutBtn);
+    userRow.appendChild(badge);
+    panel.appendChild(userRow);
+  }
 
   if (firstOpen) {
     const logo = document.createElement('img');


### PR DESCRIPTION
## Summary
- add PostgreSQL-backed user repository, auth service, and /auth API for registration/login
- require bearer tokens on deck routes, enforce deck ownership, and associate sockets/matches with authenticated users
- implement frontend session store, login/register UI, token-aware networking, and main menu logout/user badge

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d714d0de588330a74e715ccae1af3e