### PR TITLE
Добавить Dancing Temptress и улучшить обработку смерти

### DIFF
--- a/src/core/abilityHandlers/deathReposition.js
+++ b/src/core/abilityHandlers/deathReposition.js
@@ -1,0 +1,72 @@
+// Перемещения существ, срабатывающие при смерти других юнитов
+// Чистая логика, не зависящая от визуальных компонентов
+import { CARDS } from '../cards.js';
+import { DIR_VECTORS, inBounds } from '../constants.js';
+import { applyFieldTransitionToUnit } from '../fieldEffects.js';
+import { applyFieldFatalityCheck, describeFieldFatality } from './fieldHazards.js';
+
+function describeShift(shift, name) {
+  if (!shift) return null;
+  const fieldLabel = shift.nextElement ? `поле ${shift.nextElement}` : 'нейтральное поле';
+  if (shift.deltaHp > 0) {
+    return `${name} усиливается на ${fieldLabel}: HP ${shift.beforeHp}→${shift.afterHp}.`;
+  }
+  if (shift.deltaHp < 0) {
+    return `${name} теряет силу на ${fieldLabel}: HP ${shift.beforeHp}→${shift.afterHp}.`;
+  }
+  return null;
+}
+
+export function applyDeathRepositionEffects(state, deaths = []) {
+  const logs = [];
+  if (!state?.board || !Array.isArray(deaths) || !deaths.length) {
+    return { logs };
+  }
+
+  for (const death of deaths) {
+    if (!death) continue;
+    const tpl = CARDS[death.tplId];
+    if (!tpl?.deathPullFrontToSelf) continue;
+
+    const facing = typeof death.facing === 'string' ? death.facing : 'N';
+    const vec = DIR_VECTORS[facing] || DIR_VECTORS.N;
+    const frontR = death.r + vec[0];
+    const frontC = death.c + vec[1];
+    if (!inBounds(frontR, frontC)) continue;
+
+    const frontCell = state.board?.[frontR]?.[frontC];
+    const targetUnit = frontCell?.unit;
+    if (!targetUnit) continue;
+    const targetTpl = CARDS[targetUnit.tplId];
+    if (!targetTpl) continue;
+    const targetHp = typeof targetUnit.currentHP === 'number' ? targetUnit.currentHP : targetTpl.hp || 0;
+    if (targetHp <= 0) continue;
+
+    const destCell = state.board?.[death.r]?.[death.c];
+    if (!destCell || destCell.unit) continue;
+
+    frontCell.unit = null;
+    destCell.unit = targetUnit;
+
+    const sourceName = tpl?.name || 'Существо';
+    const targetName = targetTpl?.name || 'Существо';
+    logs.push(`${sourceName}: ${targetName} перемещается на её прежнее поле.`);
+
+    const fromElement = frontCell?.element || null;
+    const toElement = destCell?.element || null;
+
+    const shift = applyFieldTransitionToUnit(targetUnit, targetTpl, fromElement, toElement);
+    const shiftLog = describeShift(shift, targetName);
+    if (shiftLog) logs.push(shiftLog);
+
+    const hazard = applyFieldFatalityCheck(targetUnit, targetTpl, toElement);
+    const fatalLog = describeFieldFatality(targetTpl, hazard, { name: targetName });
+    if (fatalLog) logs.push(fatalLog);
+  }
+
+  return { logs };
+}
+
+export default {
+  applyDeathRepositionEffects,
+};

--- a/src/core/abilityHandlers/deathUtils.js
+++ b/src/core/abilityHandlers/deathUtils.js
@@ -1,0 +1,62 @@
+// Вспомогательные функции для описания событий смерти существ
+// Модуль содержит только чистую игровую логику, без привязки к визуализации
+import { CARDS } from '../cards.js';
+import { DIR_VECTORS, inBounds } from '../constants.js';
+
+const FACING_ORDER = ['N', 'E', 'S', 'W'];
+
+function normalizeFacing(value, tpl) {
+  if (typeof value === 'string') {
+    const token = value.trim().toUpperCase();
+    if (FACING_ORDER.includes(token)) return token;
+  }
+  if (tpl && typeof tpl.facing === 'string') {
+    const token = tpl.facing.trim().toUpperCase();
+    if (FACING_ORDER.includes(token)) return token;
+  }
+  if (tpl && typeof tpl.defaultFacing === 'string') {
+    const token = tpl.defaultFacing.trim().toUpperCase();
+    if (FACING_ORDER.includes(token)) return token;
+  }
+  return 'N';
+}
+
+export function computeFrontOwner(state, r, c, facing) {
+  if (!state?.board) return null;
+  const vec = DIR_VECTORS[facing] || DIR_VECTORS.N;
+  const fr = r + vec[0];
+  const fc = c + vec[1];
+  if (!inBounds(fr, fc)) return null;
+  const cell = state.board?.[fr]?.[fc];
+  const unit = cell?.unit;
+  if (!unit) return null;
+  const tpl = CARDS[unit.tplId];
+  if (!tpl) return null;
+  const currentHp = typeof unit.currentHP === 'number' ? unit.currentHP : tpl.hp || 0;
+  if (currentHp <= 0) return null;
+  return unit.owner;
+}
+
+export function createDeathEntry(state, unit, r, c) {
+  if (!state || !unit) return null;
+  const tpl = CARDS[unit.tplId];
+  if (!tpl) return null;
+  const facing = normalizeFacing(unit.facing, tpl);
+  const element = state.board?.[r]?.[c]?.element || null;
+  const frontOwner = computeFrontOwner(state, r, c, facing);
+  return {
+    r,
+    c,
+    owner: unit.owner,
+    tplId: unit.tplId,
+    uid: unit.uid ?? null,
+    element,
+    facing,
+    frontOwner,
+  };
+}
+
+export default {
+  computeFrontOwner,
+  createDeathEntry,
+};

--- a/src/core/abilityHandlers/incarnation.js
+++ b/src/core/abilityHandlers/incarnation.js
@@ -1,5 +1,6 @@
 // Модуль обработки механики "Инкарнация"
 import { CARDS } from '../cards.js';
+import { createDeathEntry } from './deathUtils.js';
 
 function getTemplate(tplOrId) {
   if (!tplOrId) return null;
@@ -69,9 +70,8 @@ export function applyIncarnationSummon(state, context = {}) {
   const cell = board?.[r]?.[c];
   const removedUnit = cell?.unit || null;
   const removedTpl = getTemplate(removedUnit?.tplId);
-  const deathInfo = removedUnit
-    ? [{ r, c, owner: removedUnit.owner, tplId: removedUnit.tplId, uid: removedUnit.uid ?? null, element: cell?.element || null }]
-    : null;
+  const deathEntry = removedUnit ? createDeathEntry(state, removedUnit, r, c) : null;
+  const deathInfo = deathEntry ? [deathEntry] : null;
   if (cell) cell.unit = null;
   return {
     ok: true,

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -313,7 +313,7 @@ export const CARDS = {
     id: 'WATER_QUEENS_SERVANT', name: "Queen's Servant", type: 'UNIT', cost: 4, activation: 2,
     element: 'WATER', atk: 1, hp: 1,
     attackType: 'MAGIC',
-    targetAllEnemies: true,
+    attacks: [ { dir: 'N', ranges: [1, 2, 3], mode: 'ANY' } ],
     blindspots: ['S'], perfectDodge: true, ignoreAlliedBlocking: true,
     manaSteal: {
       onDeath: { amount: 1 },
@@ -805,6 +805,18 @@ export const CARDS = {
     blindspots: ['S'], ignoreAlliedBlocking: true,
     deathDiscardOnElement: { element: 'FOREST', count: 1 },
     desc: 'If Samurai Nagirashu is destroyed on a Wood field, your opponent must discard 1 card.'
+  },
+  NEUTRAL_DANCING_TEMPTRESS: {
+    id: 'NEUTRAL_DANCING_TEMPTRESS', name: 'Dancing Temptress', type: 'UNIT', cost: 3, activation: 2,
+    element: 'NEUTRAL', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    deathPullFrontToSelf: true,
+    manaSteal: {
+      onDeath: { amount: 1, from: 'FRONT_OWNER' },
+    },
+    desc: 'Если Dancing Temptress уничтожена, владелец существа перед ней теряет 1 ману, а само существо перемещается на её поле.'
   },
   NEUTRAL_WHITE_CUBIC: {
     id: 'NEUTRAL_WHITE_CUBIC', name: 'White Cubic', type: 'UNIT', cost: 1, activation: 1,


### PR DESCRIPTION
## Summary
- добавить карту Dancing Temptress с кражей маны и перемещением цели после её уничтожения
- исправить атаку Queen's Servant, чтобы она выбирала одну цель, а не всех противников
- вынести служебные функции для обработки смерти и перемещений существ, обновив связанные обработчики

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d72e5ec31483308fedda97cd9b7ad5