### PR TITLE
Add Dancing Temptress card and refine death effects

### DIFF
--- a/src/core/abilityHandlers/deathReposition.js
+++ b/src/core/abilityHandlers/deathReposition.js
@@ -1,0 +1,70 @@
+// Перемещение существ после смерти источника (логика без привязки к визуализации)
+import { CARDS } from '../cards.js';
+import { inBounds } from '../constants.js';
+import { applyFieldTransitionToUnit } from '../fieldEffects.js';
+import { applyFieldFatalityCheck, describeFieldFatality } from '../abilities.js';
+
+function getCell(state, r, c) {
+  if (!state?.board) return null;
+  if (!inBounds(r, c)) return null;
+  return state.board[r]?.[c] || null;
+}
+
+export function applyDeathRepositionEffects(state, deaths = []) {
+  const logs = [];
+  if (!state || !Array.isArray(deaths) || deaths.length === 0) {
+    return { logs };
+  }
+
+  for (const death of deaths) {
+    if (!death) continue;
+    const tplDead = CARDS[death.tplId];
+    if (!tplDead?.deathPullFrontToSelf) continue;
+
+    const front = death.front;
+    if (!front || !inBounds(front.r, front.c)) continue;
+
+    const destCell = getCell(state, death.r, death.c);
+    const srcCell = getCell(state, front.r, front.c);
+    if (!destCell || !srcCell) continue;
+    if (destCell.unit) continue; // клетка должна быть пустой после смерти
+
+    const unit = srcCell.unit;
+    if (!unit) continue;
+    if (front.uid != null && unit.uid != null && unit.uid !== front.uid) continue;
+
+    const tplUnit = CARDS[unit.tplId];
+    if (!tplUnit) continue;
+    const currentHp = unit.currentHP ?? tplUnit.hp ?? 0;
+    if (currentHp <= 0) continue;
+
+    const moverName = tplUnit.name || 'Существо';
+    const sourceName = tplDead?.name || 'существо';
+
+    srcCell.unit = null;
+    destCell.unit = unit;
+    logs.push(`${moverName} занимает поле ${sourceName} после её гибели.`);
+
+    const fromElement = srcCell.element || front.element || null;
+    const toElement = destCell.element || death.element || null;
+    const shift = applyFieldTransitionToUnit(unit, tplUnit, fromElement, toElement);
+    if (shift) {
+      const fieldLabel = shift.nextElement ? `поле ${shift.nextElement}` : 'нейтральное поле';
+      if (shift.deltaHp > 0) {
+        logs.push(`${moverName} усиливается, перейдя на ${fieldLabel}: HP ${shift.beforeHp}→${shift.afterHp}.`);
+      } else if (shift.deltaHp < 0) {
+        logs.push(`${moverName} слабеет на ${fieldLabel}: HP ${shift.beforeHp}→${shift.afterHp}.`);
+      }
+    }
+
+    const hazard = applyFieldFatalityCheck(unit, tplUnit, toElement);
+    const fatalLog = describeFieldFatality(tplUnit, hazard, { name: moverName });
+    if (fatalLog) {
+      logs.push(fatalLog);
+    }
+  }
+
+  return { logs };
+}
+
+export default { applyDeathRepositionEffects };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -313,12 +313,25 @@ export const CARDS = {
     id: 'WATER_QUEENS_SERVANT', name: "Queen's Servant", type: 'UNIT', cost: 4, activation: 2,
     element: 'WATER', atk: 1, hp: 1,
     attackType: 'MAGIC',
-    targetAllEnemies: true,
+    attacks: [ { dir: 'N', ranges: [1, 2, 3], mode: 'ANY' } ],
     blindspots: ['S'], perfectDodge: true, ignoreAlliedBlocking: true,
     manaSteal: {
       onDeath: { amount: 1 },
     },
     desc: "Magic Attack. Perfect Dodge. If Queen's Servant is destroyed, steal 1 mana from your opponent."
+  },
+
+  WATER_DANCING_TEMPTRESS: {
+    id: 'WATER_DANCING_TEMPTRESS', name: 'Dancing Temptress', type: 'UNIT', cost: 3, activation: 2,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    deathPullFrontToSelf: true,
+    manaSteal: {
+      onDeath: { amount: 1, from: 'FRONT_OWNER', to: 'OWNER' },
+    },
+    desc: 'Standard Attack. Blind spot behind. If Dancing Temptress is destroyed, steal 1 mana from the owner of the creature in front of her and move that creature onto her field.'
   },
 
   EARTH_ARELAI_THE_PROTECTOR: {


### PR DESCRIPTION
## Summary
- add the Dancing Temptress unit with on-death mana steal and repositioning behaviour
- adjust Queen's Servant magic attack to target a single enemy like other magic casters
- extend mana steal handling to target the owner of the unit in front and apply front-to-self relocation on death

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d72e5ec31483308fedda97cd9b7ad5