### PR TITLE
Add Dancing Temptress and refine death-trigger handling

### DIFF
--- a/src/core/abilityHandlers/deathReposition.js
+++ b/src/core/abilityHandlers/deathReposition.js
@@ -1,0 +1,98 @@
+// Эффекты перемещения, срабатывающие при гибели существ
+// Чистая логика без зависимостей от визуального слоя
+import { CARDS } from '../cards.js';
+import { inBounds } from '../constants.js';
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
+function normalizePullFrontConfig(raw) {
+  if (!raw) return null;
+  const base = {
+    requireAlive: true,
+    requireUid: true,
+    preventIfOccupied: true,
+    log: true,
+  };
+  if (raw === true) return { ...base };
+  if (typeof raw === 'object') {
+    const cfg = { ...base };
+    if (raw.requireAlive === false) cfg.requireAlive = false;
+    if (raw.requireUid === false) cfg.requireUid = false;
+    if (raw.preventIfOccupied === false) cfg.preventIfOccupied = false;
+    if (raw.log === false) cfg.log = false;
+    return cfg;
+  }
+  return { ...base };
+}
+
+function collectPullFrontConfigs(tpl) {
+  if (!tpl) return [];
+  const entries = [];
+  for (const raw of toArray(tpl.deathPullFront)) {
+    const cfg = normalizePullFrontConfig(raw);
+    if (cfg) entries.push(cfg);
+  }
+  return entries;
+}
+
+export function applyDeathRepositionEffects(state, deaths = [], context = {}) {
+  const result = { moves: [], logs: [] };
+  if (!state?.board || !Array.isArray(deaths) || deaths.length === 0) {
+    return result;
+  }
+
+  for (const death of deaths) {
+    if (!death) continue;
+    const tpl = CARDS[death.tplId];
+    const configs = collectPullFrontConfigs(tpl);
+    if (!configs.length) continue;
+    const front = death.front;
+    if (!front) continue;
+    const destR = death.r;
+    const destC = death.c;
+    if (!inBounds(destR, destC)) continue;
+    const destCell = state.board?.[destR]?.[destC];
+    if (!destCell) continue;
+
+    for (const cfg of configs) {
+      const frontR = front.r;
+      const frontC = front.c;
+      if (!inBounds(frontR, frontC)) continue;
+      const frontCell = state.board?.[frontR]?.[frontC];
+      if (!frontCell) continue;
+      const unit = frontCell.unit;
+      if (!unit) continue;
+      if (cfg.requireUid && front.uid != null && unit.uid != null && unit.uid !== front.uid) {
+        continue;
+      }
+      const tplFront = CARDS[unit.tplId];
+      if (!tplFront) continue;
+      const baseHp = tplFront.hp ?? 0;
+      const alive = (unit.currentHP ?? baseHp) > 0;
+      if (cfg.requireAlive && !alive) continue;
+      if (cfg.preventIfOccupied && destCell.unit) continue;
+
+      destCell.unit = unit;
+      frontCell.unit = null;
+      result.moves.push({
+        unit: { uid: unit.uid ?? null, tplId: unit.tplId, owner: unit.owner ?? null },
+        from: { r: frontR, c: frontC },
+        to: { r: destR, c: destC },
+        source: { tplId: tpl?.id ?? death.tplId, owner: death.owner ?? null },
+        context: context?.cause || 'DEATH',
+      });
+      if (cfg.log) {
+        const name = tpl?.name || tpl?.id || 'Существо';
+        result.logs.push(`${name}: существо перед ним перемещается на освободившееся поле.`);
+      }
+      break;
+    }
+  }
+
+  return result;
+}
+
+export default applyDeathRepositionEffects;

--- a/src/core/abilityHandlers/discard.js
+++ b/src/core/abilityHandlers/discard.js
@@ -1,6 +1,7 @@
-// Логика эффектов принудительного сброса карт
+// Логика эффектов принудительного сброса карт и прочих реакций на смерть
 import { CARDS } from '../cards.js';
 import { applyDeathManaSteal } from './manaSteal.js';
+import { applyDeathRepositionEffects } from './deathReposition.js';
 
 const DEFAULT_TIMER_MS = 20000;
 
@@ -99,6 +100,14 @@ function formatCount(count) {
 export function applyDeathDiscardEffects(state, deaths = [], context = {}) {
   const events = { logs: [], requests: [] };
   if (!state || !Array.isArray(deaths) || deaths.length === 0) return events;
+
+  const reposition = applyDeathRepositionEffects(state, deaths, context);
+  if (Array.isArray(reposition?.logs) && reposition.logs.length) {
+    events.logs.push(...reposition.logs);
+  }
+  if (Array.isArray(reposition?.moves) && reposition.moves.length) {
+    events.repositions = reposition.moves.slice();
+  }
 
   const queue = ensureQueue(state);
   if (!queue) return events;

--- a/src/core/abilityHandlers/incarnation.js
+++ b/src/core/abilityHandlers/incarnation.js
@@ -1,5 +1,6 @@
 // Модуль обработки механики "Инкарнация"
 import { CARDS } from '../cards.js';
+import { buildDeathRecord } from '../utils/deaths.js';
 
 function getTemplate(tplOrId) {
   if (!tplOrId) return null;
@@ -70,7 +71,7 @@ export function applyIncarnationSummon(state, context = {}) {
   const removedUnit = cell?.unit || null;
   const removedTpl = getTemplate(removedUnit?.tplId);
   const deathInfo = removedUnit
-    ? [{ r, c, owner: removedUnit.owner, tplId: removedUnit.tplId, uid: removedUnit.uid ?? null, element: cell?.element || null }]
+    ? [buildDeathRecord(state, r, c, removedUnit)].filter(Boolean)
     : null;
   if (cell) cell.unit = null;
   return {

--- a/src/core/abilityHandlers/sacrifice.js
+++ b/src/core/abilityHandlers/sacrifice.js
@@ -3,6 +3,7 @@ import { CARDS } from '../cards.js';
 import { computeCellBuff } from '../fieldEffects.js';
 import { applyFieldFatalityCheck as applyFieldFatalityCheckInternal } from './fieldHazards.js';
 import { applyDeathDiscardEffects } from './discard.js';
+import { buildDeathRecord } from '../utils/deaths.js';
 
 const FACING_ORDER = ['N', 'E', 'S', 'W'];
 
@@ -172,7 +173,7 @@ export function executeSacrificeAction(state, action = {}, payload = {}) {
 
   // Удаляем существо с клетки до появления нового
   const sacrificeDeath = currentUnit
-    ? [{ r, c, owner: currentUnit.owner, tplId: currentUnit.tplId, uid: currentUnit.uid ?? null, element: cell?.element || null }]
+    ? [buildDeathRecord(state, r, c, currentUnit)].filter(Boolean)
     : null;
   cell.unit = null;
 
@@ -258,8 +259,9 @@ export function executeSacrificeAction(state, action = {}, payload = {}) {
     }
     const tplDeath = getTemplateRef(summonTpl);
     graveyard.push(tplDeath);
+    const deathRecord = buildDeathRecord(state, r, c, newUnit);
     cell.unit = null;
-    const replacementDeath = [{ r, c, owner: newUnit.owner, tplId: summonTpl.id, uid: newUnit.uid ?? null, element: cell?.element || null }];
+    const replacementDeath = deathRecord ? [deathRecord] : [];
 
     if (summonTpl.onDeathAddHPAll) {
       const amount = summonTpl.onDeathAddHPAll;

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -313,14 +313,13 @@ export const CARDS = {
     id: 'WATER_QUEENS_SERVANT', name: "Queen's Servant", type: 'UNIT', cost: 4, activation: 2,
     element: 'WATER', atk: 1, hp: 1,
     attackType: 'MAGIC',
-    targetAllEnemies: true,
+    attacks: [ { dir: 'N', ranges: [1, 2, 3], mode: 'ANY' } ],
     blindspots: ['S'], perfectDodge: true, ignoreAlliedBlocking: true,
     manaSteal: {
       onDeath: { amount: 1 },
     },
     desc: "Magic Attack. Perfect Dodge. If Queen's Servant is destroyed, steal 1 mana from your opponent."
   },
-
   EARTH_ARELAI_THE_PROTECTOR: {
     id: 'EARTH_ARELAI_THE_PROTECTOR', name: 'Arelai the Protector', type: 'UNIT', cost: 3, activation: 2,
     element: 'EARTH', atk: 2, hp: 3,
@@ -636,6 +635,18 @@ export const CARDS = {
       { pattern: 'ADJACENT', requireSourceElement: 'WATER', id: 'ANFISA_WATER_AURA' },
     ],
     desc: 'Magic Attack. While on a Water field, Imposter Queen Anfisa gains Possession of all enemies on adjacent fields.'
+  },
+  FOREST_DANCING_TEMPTRESS: {
+    id: 'FOREST_DANCING_TEMPTRESS', name: 'Dancing Temptress', type: 'UNIT', cost: 3, activation: 2,
+    element: 'FOREST', atk: 1, hp: 1,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    manaSteal: {
+      onDeath: { amount: 1, from: 'TARGET' },
+    },
+    deathPullFront: true,
+    desc: 'If Dancing Temptress is destroyed, steal 1 mana from the owner of the creature in front of her. That creature is moved to her former field.',
   },
   FOREST_SWALLOW_NINJA: {
     id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -27,6 +27,7 @@ import { normalizeElementName } from './utils/elements.js';
 import { computeDynamicAttackBonus } from './abilityHandlers/dynamicAttack.js';
 import { getHpConditionalBonuses } from './abilityHandlers/conditionalBonuses.js';
 import { applyDeathDiscardEffects } from './abilityHandlers/discard.js';
+import { buildDeathRecord } from './utils/deaths.js';
 
 export function hasAdjacentGuard(state, r, c) {
   const target = state.board?.[r]?.[c]?.unit;
@@ -581,7 +582,8 @@ export function stagedAttack(state, r, c, opts = {}) {
       const cellRef = nFinal.board?.[rr]?.[cc];
       const u = cellRef?.unit;
       if (u && (u.currentHP ?? CARDS[u.tplId].hp) <= 0) {
-        deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: cellRef?.element || null });
+        const record = buildDeathRecord(nFinal, rr, cc, u);
+        if (record) deaths.push(record);
         if (cellRef) cellRef.unit = null;
       }
     }
@@ -910,7 +912,8 @@ export function magicAttack(state, fr, fc, tr, tc) {
     const cellRef = n1.board[rr][cc];
     const u = cellRef.unit;
     if (u && (u.currentHP ?? CARDS[u.tplId].hp) <= 0) {
-      deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: cellRef?.element || null });
+      const record = buildDeathRecord(n1, rr, cc, u);
+      if (record) deaths.push(record);
       cellRef.unit = null;
     }
   }

--- a/src/core/utils/deaths.js
+++ b/src/core/utils/deaths.js
@@ -1,0 +1,55 @@
+// Утилиты для подготовки информации о погибших существах
+// Модуль не использует визуальную часть и остаётся чисто логическим
+import { CARDS } from '../cards.js';
+import { DIR_VECTORS, inBounds } from '../constants.js';
+
+function resolveFacing(unit, tpl) {
+  if (!unit && !tpl) return 'N';
+  return unit?.facing || tpl?.facing || tpl?.defaultFacing || 'N';
+}
+
+function resolveFrontInfo(state, r, c, facing) {
+  const vec = DIR_VECTORS[facing] || DIR_VECTORS.N || [-1, 0];
+  const fr = r + vec[0];
+  const fc = c + vec[1];
+  if (!inBounds(fr, fc)) return null;
+  const frontCell = state?.board?.[fr]?.[fc] || null;
+  const frontUnit = frontCell?.unit;
+  if (!frontUnit) return null;
+  const tplFront = CARDS[frontUnit.tplId];
+  const baseHp = tplFront?.hp ?? 0;
+  const alive = (frontUnit.currentHP ?? baseHp) > 0;
+  return {
+    r: fr,
+    c: fc,
+    owner: frontUnit.owner ?? null,
+    uid: frontUnit.uid ?? null,
+    tplId: frontUnit.tplId ?? null,
+    alive,
+  };
+}
+
+/**
+ * Формирует запись о гибели существа с дополнительной информацией
+ * о его ориентации и цели перед ним (если она есть).
+ */
+export function buildDeathRecord(state, r, c, unit) {
+  if (!unit) return null;
+  const cell = state?.board?.[r]?.[c] || null;
+  const tpl = CARDS[unit.tplId];
+  const facing = resolveFacing(unit, tpl);
+  const front = resolveFrontInfo(state, r, c, facing);
+  return {
+    r,
+    c,
+    owner: unit.owner,
+    tplId: unit.tplId,
+    uid: unit.uid ?? null,
+    element: cell?.element || null,
+    facing,
+    front,
+    frontOwner: front?.owner ?? null,
+  };
+}
+
+export default { buildDeathRecord };

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -15,6 +15,7 @@ import {
 } from '../core/abilities.js';
 import { capMana } from '../core/constants.js';
 import { applyDeathDiscardEffects } from '../core/abilityHandlers/discard.js';
+import { buildDeathRecord } from '../core/utils/deaths.js';
 
 // Centralized interaction state
 export const interactionState = {
@@ -885,8 +886,7 @@ export function placeUnitWithDirection(direction) {
       window.addLog(`${cardData.name}: союзники получают +${amount} HP`);
     }
     const owner = unit.owner;
-    const deathElement = gameState.board?.[row]?.[col]?.element || null;
-    const deathInfo = [{ r: row, c: col, owner, tplId: unit.tplId, uid: unit.uid ?? null, element: deathElement }];
+    const deathRecord = buildDeathRecord(gameState, row, col, unit);
     const slotBeforeGain = gameState.players?.[owner]?.mana || 0;
     try { gameState.players[owner].graveyard.push(window.CARDS[unit.tplId]); } catch {}
     const ownerPlayer = gameState.players?.[owner];
@@ -898,6 +898,7 @@ export function placeUnitWithDirection(direction) {
     const pos = ctx.tileMeshes[row][col].position.clone().add(new THREE.Vector3(0, 1.2, 0));
     window.animateManaGainFromWorld(pos, owner, true, slotBeforeGain);
     gameState.board[row][col].unit = null;
+    const deathInfo = deathRecord ? [deathRecord] : [];
     const discardEffects = applyDeathDiscardEffects(gameState, deathInfo, { cause: 'SUMMON' });
     if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
       for (const text of discardEffects.logs) {

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -10,6 +10,7 @@ import { discardHandCard } from '../scene/discard.js';
 import { computeFieldquakeLockedCells } from '../core/fieldLocks.js';
 import { refreshPossessionsUI } from '../ui/possessions.js';
 import { applyDeathDiscardEffects } from '../core/abilityHandlers/discard.js';
+import { buildDeathRecord } from '../core/utils/deaths.js';
 
 function animateManaStealEvents(list) {
   if (typeof window === 'undefined') return;
@@ -280,8 +281,7 @@ export const handlers = {
         } catch {}
         if (u.currentHP <= 0) {
           const owner = u.owner;
-          const deathElement = gameState.board?.[r]?.[c]?.element || null;
-          const deathInfo = [{ r, c, owner, tplId: u.tplId, uid: u.uid ?? null, element: deathElement }];
+          const deathRecord = buildDeathRecord(gameState, r, c, u);
           try { gameState.players[owner].graveyard.push(CARDS[u.tplId]); } catch {}
           const pos = getCtx().tileMeshes[r][c].position.clone().add(new THREE.Vector3(0, 1.2, 0));
           const slot = gameState.players?.[owner]?.mana || 0;
@@ -294,6 +294,7 @@ export const handlers = {
             }
           }
           gameState.board[r][c].unit = null;
+          const deathInfo = deathRecord ? [deathRecord] : [];
           const discardEffects = applyDeathDiscardEffects(gameState, deathInfo, { cause: 'SPELL' });
           if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
             for (const text of discardEffects.logs) {
@@ -404,13 +405,13 @@ export const handlers = {
               deltaHp > 0 ? '#22c55e' : '#ef4444'
             );
           if (u.currentHP <= 0) {
-            const deathElement = gameState.board?.[r]?.[c]?.element || null;
-            const deathInfo = [{ r, c, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: deathElement }];
+            const deathRecord = buildDeathRecord(gameState, r, c, u);
             try { gameState.players[u.owner].graveyard.push(CARDS[u.tplId]); } catch {}
             const deadMesh = unitMeshes.find(m => m.userData.row === r && m.userData.col === c);
             if (deadMesh) {
               window.__fx.dissolveAndAsh(deadMesh, new THREE.Vector3(0, 0, 0.6), 0.9);
               gameState.board[r][c].unit = null;
+              const deathInfo = deathRecord ? [deathRecord] : [];
               const discardEffects = applyDeathDiscardEffects(gameState, deathInfo, { cause: 'SPELL' });
               if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
                 for (const text of discardEffects.logs) addLog(text);


### PR DESCRIPTION
## Summary
- add the Dancing Temptress unit with a front-only attack, mana steal on death, and front-unit relocation
- fix Queen's Servant so her magic attack targets a single enemy instead of the whole board
- introduce shared death record/reposition utilities and enhance mana steal handling for context-aware triggers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d72e5ec31483308fedda97cd9b7ad5