### PR TITLE
Add Biolith card updates and shared mana-on-summon handler

### DIFF
--- a/src/core/abilityHandlers/attackOverrides.js
+++ b/src/core/abilityHandlers/attackOverrides.js
@@ -1,0 +1,95 @@
+// Модуль для переопределения базовой атаки существ при выполнении условий
+// Логика изолирована для упрощения переноса на другой движок.
+
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+const BOARD_SIZE = 3;
+
+const toArray = (value) => {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+};
+
+function countAlliedElement(state, owner, element, opts = {}) {
+  if (!state?.board) return 0;
+  let total = 0;
+  for (let r = 0; r < BOARD_SIZE; r += 1) {
+    for (let c = 0; c < BOARD_SIZE; c += 1) {
+      if (!opts.includeSelf && opts.exclude && r === opts.exclude.r && c === opts.exclude.c) {
+        continue;
+      }
+      const unit = state.board?.[r]?.[c]?.unit;
+      if (!unit || unit.owner !== owner) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      const tplElement = normalizeElementName(tpl.element);
+      if (tplElement === element) total += 1;
+    }
+  }
+  return total;
+}
+
+function resolveField(element) {
+  return normalizeElementName(element);
+}
+
+function normalizeOverride(raw) {
+  if (!raw) return null;
+  const field = resolveField(raw.field || raw.onField || raw.fieldElement);
+  const type = (raw.type || raw.mode || 'ALLY_ELEMENT_COUNT').toUpperCase();
+  if (type === 'ALLY_ELEMENT_COUNT') {
+    const countElement = normalizeElementName(raw.countElement || raw.element || raw.allyElement);
+    if (!countElement) return null;
+    const base = Number.isFinite(raw.base) ? raw.base : Number(raw.baseValue ?? raw.start ?? raw.initial ?? 0) || 0;
+    const amountPer = Number.isFinite(raw.amountPer) ? raw.amountPer : Number(raw.per ?? raw.amount ?? 1) || 1;
+    const includeSelf = raw.includeSelf === true;
+    return {
+      field,
+      type: 'ALLY_ELEMENT_COUNT',
+      countElement,
+      base,
+      amountPer,
+      includeSelf,
+    };
+  }
+  return null;
+}
+
+export function resolveAttackOverride(state, r, c, tpl) {
+  if (!tpl) return null;
+  const configs = toArray(tpl.overrideAtkOnField).map(normalizeOverride).filter(Boolean);
+  if (!configs.length) return null;
+  const cell = state?.board?.[r]?.[c];
+  if (!cell) return null;
+  const unit = cell.unit;
+  if (!unit) return null;
+  const fieldElement = normalizeElementName(cell.element);
+  const owner = unit.owner;
+
+  for (const cfg of configs) {
+    if (!cfg) continue;
+    if (cfg.field && cfg.field !== fieldElement) continue;
+    if (cfg.type === 'ALLY_ELEMENT_COUNT') {
+      if (owner == null) continue;
+      const count = countAlliedElement(state, owner, cfg.countElement, {
+        includeSelf: cfg.includeSelf,
+        exclude: { r, c },
+      });
+      const atk = cfg.base + cfg.amountPer * count;
+      if (!Number.isFinite(atk)) continue;
+      return {
+        atk,
+        type: cfg.type,
+        element: cfg.countElement,
+        count,
+        base: cfg.base,
+        includeSelf: cfg.includeSelf,
+      };
+    }
+  }
+
+  return null;
+}
+
+export default { resolveAttackOverride };

--- a/src/core/abilityHandlers/manaGainOnSummon.js
+++ b/src/core/abilityHandlers/manaGainOnSummon.js
@@ -1,0 +1,171 @@
+// Выделенный модуль для расчёта получения маны при призыве существ
+// Содержит только игровую логику и не зависит от визуального слоя.
+
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+const BOARD_SIZE = 3;
+
+const capMana = (value) => {
+  const num = Number.isFinite(value) ? value : 0;
+  return Math.max(0, Math.min(10, Math.floor(num)));
+};
+
+const toArray = (value) => {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+};
+
+function getCell(state, r, c) {
+  if (!state?.board) return null;
+  if (r < 0 || r >= BOARD_SIZE || c < 0 || c >= BOARD_SIZE) return null;
+  return state.board?.[r]?.[c] || null;
+}
+
+function normalizeTrigger(raw) {
+  const str = typeof raw === 'string' ? raw.trim().toUpperCase() : '';
+  if (str === 'ENEMY' || str === 'ENEMIES') return 'ENEMY';
+  if (str === 'ANY' || str === 'ALL') return 'ANY';
+  return 'ALLY';
+}
+
+function normalizeAmount(raw) {
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return 1;
+  return Math.max(0, Math.floor(num));
+}
+
+function normalizeElementFilter(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    return { element: normalizeElementName(raw) };
+  }
+  if (typeof raw === 'object') {
+    const element = normalizeElementName(raw.element || raw.type || raw.eq || raw.match);
+    const notElement = normalizeElementName(raw.not || raw.exclude || raw.notElement);
+    return {
+      element: element || null,
+      notElement: notElement || null,
+    };
+  }
+  return null;
+}
+
+function matchesFieldFilter(element, filter) {
+  if (!filter) return true;
+  const norm = normalizeElementName(element);
+  if (filter.element && norm !== filter.element) return false;
+  if (filter.notElement && norm === filter.notElement) return false;
+  return true;
+}
+
+function normalizeConfig(raw) {
+  if (!raw) return null;
+  const trigger = normalizeTrigger(raw.trigger || raw.type || raw.side);
+  const amount = normalizeAmount(raw.amount ?? raw.gain ?? raw.value ?? raw.delta ?? 1);
+  const includeSelf = raw.includeSelf === true || raw.self === true;
+  const sourceFilter = normalizeElementFilter(raw.sourceField || raw.sourceElement || raw.source);
+  const summonFilter = normalizeElementFilter(raw.summonField || raw.field || raw.targetField || raw.summonedElement);
+  const requireEnemy = raw.requireEnemy === true;
+  const requireAlly = raw.requireAlly === true;
+  const customLog = typeof raw.log === 'string' ? raw.log : null;
+  return {
+    trigger,
+    amount,
+    includeSelf,
+    sourceFilter,
+    summonFilter,
+    requireEnemy,
+    requireAlly,
+    customLog,
+  };
+}
+
+function resolveConfigs(tpl) {
+  const raw = tpl?.manaOnSummon;
+  if (!raw) return [];
+  return toArray(raw).map(normalizeConfig).filter(Boolean);
+}
+
+function sameUnit(a, b) {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  if (a.uid != null && b.uid != null) return a.uid === b.uid;
+  return false;
+}
+
+function shouldTrigger(config, context) {
+  const { abilityUnit, summonUnit, abilityCell, summonCell } = context;
+  if (!abilityUnit || !summonUnit) return false;
+  const isAlly = abilityUnit.owner === summonUnit.owner;
+  if (config.requireEnemy && isAlly) return false;
+  if (config.requireAlly && !isAlly) return false;
+  if (config.trigger === 'ALLY' && !isAlly) return false;
+  if (config.trigger === 'ENEMY' && isAlly) return false;
+  if (!config.includeSelf && sameUnit(abilityUnit, summonUnit)) return false;
+
+  const sourceElement = abilityCell ? abilityCell.element : null;
+  if (!matchesFieldFilter(sourceElement, config.sourceFilter)) return false;
+
+  const summonElement = summonCell ? summonCell.element : null;
+  if (!matchesFieldFilter(summonElement, config.summonFilter)) return false;
+
+  return true;
+}
+
+function buildLogText(tpl, amount, context, config) {
+  if (config.customLog) return config.customLog;
+  const name = tpl?.name || 'Существо';
+  const value = Math.max(0, amount);
+  const suffix = value === 1 ? 'ману' : 'маны';
+  return `${name}: приносит ${value} ${suffix}.`;
+}
+
+export function applyManaGainOnSummon(state, context = {}) {
+  const result = { events: [], logs: [] };
+  if (!state?.board || !Array.isArray(state.players)) return result;
+
+  const { r, c } = context;
+  const summonCell = getCell(state, r, c);
+  const summonUnit = context.unit || summonCell?.unit || null;
+  if (!summonUnit) return result;
+
+  for (let rr = 0; rr < BOARD_SIZE; rr += 1) {
+    for (let cc = 0; cc < BOARD_SIZE; cc += 1) {
+      const abilityCell = getCell(state, rr, cc);
+      const abilityUnit = abilityCell?.unit;
+      if (!abilityUnit) continue;
+      const tpl = CARDS[abilityUnit.tplId];
+      if (!tpl) continue;
+      const configs = resolveConfigs(tpl);
+      if (!configs.length) continue;
+
+      for (const cfg of configs) {
+        if (!cfg || cfg.amount <= 0) continue;
+        if (!shouldTrigger(cfg, { abilityUnit, summonUnit, abilityCell, summonCell })) continue;
+        const owner = abilityUnit.owner;
+        if (owner == null || !state.players[owner]) continue;
+        const player = state.players[owner];
+        const before = Math.max(0, Number(player.mana) || 0);
+        const after = capMana(before + cfg.amount);
+        if (after === before) continue;
+        player.mana = after;
+        result.events.push({
+          owner,
+          before,
+          after,
+          amount: cfg.amount,
+          r: rr,
+          c: cc,
+          source: { tplId: tpl.id, r: rr, c: cc },
+        });
+        const logText = buildLogText(tpl, cfg.amount, { abilityUnit, summonUnit }, cfg);
+        if (logText) result.logs.push(logText);
+      }
+    }
+  }
+
+  return result;
+}
+
+export default { applyManaGainOnSummon };

--- a/src/core/abilityHandlers/targetAttackBonuses.js
+++ b/src/core/abilityHandlers/targetAttackBonuses.js
@@ -1,0 +1,101 @@
+// Дополнительные бонусы к атаке, зависящие от цели
+// Модуль инкапсулирует чистую игровую логику.
+
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+const BOARD_SIZE = 3;
+
+const toArray = (value) => {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+};
+
+function normalizeConfig(raw) {
+  if (!raw) return null;
+  const targetElement = normalizeElementName(raw.targetElement || raw.element || raw.matchElement);
+  if (!targetElement) return null;
+  const requireEnemy = raw.requireEnemy === true || raw.enemy === true;
+  const amountPer = Number.isFinite(raw.amountPer) ? raw.amountPer : Number(raw.amount ?? raw.per ?? 1) || 1;
+  const countNonElement = normalizeElementName(raw.countNonElement || raw.excludeElement || raw.notElement);
+  const countElement = normalizeElementName(raw.countElement || raw.includeElement || raw.count);
+  const customLog = typeof raw.log === 'string' ? raw.log : null;
+  return {
+    targetElement,
+    requireEnemy,
+    amountPer,
+    countNonElement,
+    countElement,
+    customLog,
+  };
+}
+
+function unitAlive(unit) {
+  if (!unit) return false;
+  if (typeof unit.currentHP === 'number') return unit.currentHP > 0;
+  return true;
+}
+
+function countUnitsByElement(state, opts = {}) {
+  if (!state?.board) return 0;
+  const { countElement, countNonElement } = opts;
+  let total = 0;
+  for (let r = 0; r < BOARD_SIZE; r += 1) {
+    for (let c = 0; c < BOARD_SIZE; c += 1) {
+      const unit = state.board?.[r]?.[c]?.unit;
+      if (!unitAlive(unit)) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      const element = normalizeElementName(tpl.element);
+      if (countElement && element !== countElement) continue;
+      if (countNonElement && element === countNonElement) continue;
+      total += 1;
+    }
+  }
+  return total;
+}
+
+function buildLog(tpl, amount, info, cfg) {
+  if (cfg.customLog) return cfg.customLog;
+  const name = tpl?.name || 'Существо';
+  if (cfg.countNonElement) {
+    return `${name}: +${amount} ATK (небиолитовых существ: ${info.count}).`;
+  }
+  if (cfg.countElement) {
+    return `${name}: +${amount} ATK (существ стихии ${cfg.countElement}: ${info.count}).`;
+  }
+  return `${name}: +${amount} ATK.`;
+}
+
+export function getTargetConditionalAttackBonus(state, tpl, context = {}, target = null) {
+  if (!tpl || !target) return null;
+  const configs = toArray(tpl.targetConditionalAttack).map(normalizeConfig).filter(Boolean);
+  if (!configs.length) return null;
+  const targetTpl = CARDS[target.tplId];
+  if (!targetTpl) return null;
+  const attacker = context.unit;
+
+  for (const cfg of configs) {
+    if (!cfg) continue;
+    const element = normalizeElementName(targetTpl.element);
+    if (cfg.targetElement && cfg.targetElement !== element) continue;
+    if (cfg.requireEnemy && attacker && target.owner === attacker.owner) continue;
+
+    const count = countUnitsByElement(state, {
+      countElement: cfg.countElement,
+      countNonElement: cfg.countNonElement,
+    });
+    if (count <= 0) continue;
+    const amount = cfg.amountPer * count;
+    if (!Number.isFinite(amount) || amount === 0) continue;
+    return {
+      amount,
+      count,
+      targetElement: cfg.targetElement,
+      log: buildLog(tpl, amount, { count }, cfg),
+    };
+  }
+  return null;
+}
+
+export default { getTargetConditionalAttackBonus };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -29,7 +29,8 @@ export const CARDS = {
     element: 'FIRE', atk: 1, hp: 2,
     attackType: 'STANDARD', pierce: true,
     attacks: [ { dir: 'N', ranges: [1] } ],
-    blindspots: ['S'], auraGainManaOnSummon: true,
+    blindspots: ['S'],
+    manaOnSummon: { trigger: 'ALLY', amount: 1, sourceField: { not: 'FIRE' }, includeSelf: true },
     desc: 'While Freedonian Wanderer is on a non‑Fire field, you gain 1 mana each time you summon an allied creature.'
   },
   FIRE_PARTMOLE_FLAME_LIZARD: {
@@ -478,6 +479,46 @@ export const CARDS = {
       { type: 'ALLY_ELEMENT', element: 'BIOLITH', includeSelf: false },
     ],
     desc: 'Morning Star Warrior adds 2 to its Attack if the target creature has 5 or more HPs.\nMorning Star Warrior gains Protection equal to the number of allied Biolith creatures.'
+  },
+  BIOLITH_IMPERIAL_BIOLITH_GUARD: {
+    id: 'BIOLITH_IMPERIAL_BIOLITH_GUARD', name: 'Imperial Biolith Guard', type: 'UNIT', cost: 3, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'E', ranges: [1], group: 'SIDES', ignoreAlliedBlocking: true },
+      { dir: 'W', ranges: [1], group: 'SIDES', ignoreAlliedBlocking: true },
+    ],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    manaOnSummon: { trigger: 'ALLY', amount: 1, summonField: { element: 'BIOLITH' }, includeSelf: true },
+    desc: 'Gain 1 mana each time you summon a creature to a Biolith field.'
+  },
+  BIOLITH_WORMAK_HEIR_TO_THE_BIOLITHS: {
+    id: 'BIOLITH_WORMAK_HEIR_TO_THE_BIOLITHS', name: 'Wormak Heir to the Bioliths', type: 'UNIT', cost: 4, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    targetConditionalAttack: [
+      { targetElement: 'BIOLITH', requireEnemy: true, countNonElement: 'BIOLITH', amountPer: 1 },
+    ],
+    manaOnSummon: { trigger: 'ENEMY', amount: 1 },
+    desc: "If the target is an enemy Biolith, Wormak's Attack is equal to 2 plus the number of non-Biolith creatures on the board.\nGain 1 mana each time an enemy is summoned."
+  },
+  BIOLITH_TINO_SON_OF_SCION: {
+    id: 'BIOLITH_TINO_SON_OF_SCION', name: 'Tino, Son of Scion', type: 'UNIT', cost: 4, activation: 3,
+    element: 'BIOLITH', atk: 4, hp: 3,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    magicTargetsSameElement: true,
+    overrideAtkOnField: [
+      { field: 'BIOLITH', type: 'ALLY_ELEMENT_COUNT', countElement: 'BIOLITH', base: 1, includeSelf: false },
+    ],
+    manaOnSummon: { trigger: 'ALLY', amount: 1, includeSelf: true },
+    desc: "Tino's Magic Attack targets all enemies of the same element as the target.\nWhile Tino is on a Biolith field, his Attack is equal to 1 plus the number of other allied Biolith creatures.\nGain 1 mana each time you summon a creature."
   },
   BIOLITH_BIOLITH_STINGER: {
     id: 'BIOLITH_BIOLITH_STINGER', name: 'Biolith Stinger', type: 'UNIT', cost: 3, activation: 2,

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -379,6 +379,25 @@ export function confirmUnitAbilityOrientation(context, direction) {
       }
     }
 
+    if (Array.isArray(result.summonEvents?.manaGains) && result.summonEvents.manaGains.length) {
+      const ctxScene = w.__scene?.getCtx?.();
+      const animateManaGain = w.animateManaGainFromWorld;
+      const THREE = ctxScene?.THREE || w.THREE;
+      if (ctxScene && typeof animateManaGain === 'function' && THREE) {
+        for (const gain of result.summonEvents.manaGains) {
+          if (!gain || typeof gain.owner !== 'number') continue;
+          const tile = ctxScene.tileMeshes?.[gain.r]?.[gain.c];
+          if (!tile) continue;
+          try {
+            const pos = tile.position.clone().add(new THREE.Vector3(0, 1.2, 0));
+            animateManaGain(pos, gain.owner, true, gain.before);
+          } catch (err) {
+            console.warn('[unitAbility] mana gain animation failed', err);
+          }
+        }
+      }
+    }
+
     if (result.summonEvents?.possessions?.length) {
       for (const ev of result.summonEvents.possessions) {
         const unitTaken = gameState.board?.[ev.r]?.[ev.c]?.unit;
@@ -407,10 +426,6 @@ export function confirmUnitAbilityOrientation(context, direction) {
           }
         }
       }
-    }
-
-    if (result.freedonianMana > 0) {
-      w.addLog?.(`Фридонийский Странник приносит ${result.freedonianMana} маны.`);
     }
 
     if (info.unitMesh?.userData) delete info.unitMesh.userData.availableActions;


### PR DESCRIPTION
## Summary
- add Imperial Biolith Guard, Wormak Heir to the Bioliths, and Tino, Son of Scion cards with updated Freedonian mana trigger
- introduce reusable mana-on-summon ability handler and wire animations on scene and UI layers
- add attack override and target-conditional bonus modules to support new card mechanics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d754155e6483308a2baa0b2c93398b