### PR TITLE
Add Biolith mana-on-summon cards and unify aura logic

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -49,9 +49,8 @@ import {
 } from './abilityHandlers/fieldHazards.js';
 import { applySummonManaSteal } from './abilityHandlers/manaSteal.js';
 import { applyFieldquakeAt } from './abilityHandlers/fieldquake.js';
+import { applyManaGainOnSummon } from './abilityHandlers/manaOnSummon.js';
 
-// локальная функция ограничения маны (без импорта во избежание циклов)
-const capMana = (m) => Math.min(10, m);
 const inBounds = (r, c) => r >= 0 && r < 3 && c >= 0 && c < 3;
 const DIR_VECTORS = { N: [-1, 0], E: [0, 1], S: [1, 0], W: [0, -1] };
 
@@ -712,26 +711,6 @@ export const hasDoubleAttack = (tpl) => !!(tpl && tpl.doubleAttack);
 // Может ли существо атаковать (крепости не могут)
 export const canAttack = (tpl) => !(tpl && tpl.fortress);
 
-// Реализация ауры Фридонийского Странника при призыве союзников
-// Возвращает количество полученных единиц маны
-export function applyFreedonianAura(state, owner) {
-  let gained = 0;
-  for (let r = 0; r < 3; r++) {
-    for (let c = 0; c < 3; c++) {
-      const cell = state.board?.[r]?.[c];
-      const unit = cell?.unit;
-      if (!unit) continue;
-      const tpl = CARDS[unit.tplId];
-      if (tpl?.auraGainManaOnSummon && unit.owner === owner && cell.element !== 'FIRE') {
-        const pl = state.players[owner];
-        pl.mana = capMana((pl.mana || 0) + 1);
-        gained += 1;
-      }
-    }
-  }
-  return gained;
-}
-
 function normalizeFieldquakeSummonConfig(raw) {
   if (!raw) return null;
   if (raw === true) return { pattern: 'ADJACENT' };
@@ -899,6 +878,15 @@ export function applySummonAbilities(state, r, c) {
   const reactions = applyEnemySummonReactions(state, { r, c, unit, tpl });
   if (Array.isArray(reactions?.heals) && reactions.heals.length) {
     events.heals = [...(events.heals || []), ...reactions.heals];
+  }
+
+  const manaEvents = applyManaGainOnSummon(state, { r, c, unit, tpl, cell });
+  if (Array.isArray(manaEvents) && manaEvents.length) {
+    events.manaGains = [...(events.manaGains || []), ...manaEvents];
+    const manaLogs = manaEvents.map(ev => ev?.log).filter(Boolean);
+    if (manaLogs.length) {
+      events.logs = [...(events.logs || []), ...manaLogs];
+    }
   }
 
   return events;
@@ -1070,10 +1058,8 @@ export function executeUnitAction(state, action, payload = {}) {
     const cell = state.board?.[action.r]?.[action.c];
     if (cell?.unit) {
       result.summonEvents = applySummonAbilities(state, action.r, action.c);
-      result.freedonianMana = applyFreedonianAura(state, action.owner);
     } else {
       result.summonEvents = result.summonEvents || { possessions: [] };
-      result.freedonianMana = 0;
     }
     return result;
   }

--- a/src/core/abilityHandlers/manaOnSummon.js
+++ b/src/core/abilityHandlers/manaOnSummon.js
@@ -1,0 +1,160 @@
+// Обработка пассивных способностей, дающих ману при призыве существ
+// Логика полностью отделена от визуального слоя
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+const BOARD_SIZE = 3;
+const capMana = (value) => Math.min(10, value);
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeSummonOwner(raw) {
+  if (!raw) return 'ALLY';
+  const token = String(raw).toUpperCase();
+  if (token === 'ALLY' || token === 'FRIEND' || token === 'OWN') return 'ALLY';
+  if (token === 'ENEMY' || token === 'OPPONENT') return 'ENEMY';
+  if (token === 'ANY' || token === 'BOTH') return 'ANY';
+  return 'ALLY';
+}
+
+function normalizeManaConfigEntry(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return { amount: 1, summonOwner: 'ALLY' };
+  }
+  if (typeof raw === 'number') {
+    const amount = Math.max(0, Math.floor(raw));
+    if (amount <= 0) return null;
+    return { amount, summonOwner: 'ALLY' };
+  }
+  if (typeof raw === 'object') {
+    const amountRaw = raw.amount ?? raw.gain ?? raw.value ?? 1;
+    const amount = Math.max(0, Math.floor(Number(amountRaw)) || 0);
+    if (amount <= 0) return null;
+    const summonOwner = normalizeSummonOwner(raw.summonOwner || raw.trigger || raw.when || raw.owner);
+    const requireSummonFieldElement = normalizeElementName(raw.requireSummonFieldElement || raw.summonFieldElement);
+    const forbidSummonFieldElement = normalizeElementName(raw.forbidSummonFieldElement || raw.blockSummonFieldElement);
+    const requireSelfFieldElement = normalizeElementName(raw.requireSelfFieldElement || raw.selfFieldElement);
+    const forbidSelfFieldElement = normalizeElementName(raw.forbidSelfFieldElement || raw.selfFieldNotElement);
+    const requireSummonUnitElement = normalizeElementName(raw.requireSummonUnitElement || raw.summonElement);
+    return {
+      amount,
+      summonOwner,
+      requireSummonFieldElement,
+      forbidSummonFieldElement,
+      requireSelfFieldElement,
+      forbidSelfFieldElement,
+      requireSummonUnitElement,
+    };
+  }
+  return null;
+}
+
+function normalizeManaConfigs(raw) {
+  const list = [];
+  for (const entry of toArray(raw)) {
+    const cfg = normalizeManaConfigEntry(entry);
+    if (cfg) list.push(cfg);
+  }
+  return list;
+}
+
+function shouldTriggerConfig(cfg, context) {
+  const {
+    abilityOwner,
+    abilityCellElement,
+    summonOwner,
+    summonFieldElement,
+    summonUnitElement,
+  } = context;
+
+  const trigger = cfg.summonOwner || 'ALLY';
+  if (trigger === 'ALLY' && summonOwner !== abilityOwner) return false;
+  if (trigger === 'ENEMY') {
+    if (summonOwner == null) return false;
+    if (summonOwner === abilityOwner) return false;
+  }
+
+  if (cfg.requireSummonFieldElement && cfg.requireSummonFieldElement !== summonFieldElement) {
+    return false;
+  }
+  if (cfg.forbidSummonFieldElement && cfg.forbidSummonFieldElement === summonFieldElement) {
+    return false;
+  }
+  if (cfg.requireSelfFieldElement && cfg.requireSelfFieldElement !== abilityCellElement) {
+    return false;
+  }
+  if (cfg.forbidSelfFieldElement && cfg.forbidSelfFieldElement === abilityCellElement) {
+    return false;
+  }
+  if (cfg.requireSummonUnitElement && cfg.requireSummonUnitElement !== summonUnitElement) {
+    return false;
+  }
+  return true;
+}
+
+export function applyManaGainOnSummon(state, context = {}) {
+  const events = [];
+  if (!state?.board || !Array.isArray(state.players)) return events;
+
+  const summonOwner = context.unit?.owner ?? null;
+  const summonCell = state.board?.[context.r]?.[context.c] || null;
+  const summonFieldElement = normalizeElementName(summonCell?.element);
+  const summonTpl = context.unit ? CARDS[context.unit.tplId] : null;
+  const summonUnitElement = normalizeElementName(summonTpl?.element);
+
+  for (let r = 0; r < BOARD_SIZE; r += 1) {
+    for (let c = 0; c < BOARD_SIZE; c += 1) {
+      const cell = state.board?.[r]?.[c];
+      const abilityUnit = cell?.unit;
+      if (!abilityUnit) continue;
+      const owner = abilityUnit.owner;
+      if (owner == null) continue;
+      const abilityTpl = CARDS[abilityUnit.tplId];
+      if (!abilityTpl) continue;
+      const configs = normalizeManaConfigs(abilityTpl.manaOnSummon);
+      if (!configs.length) continue;
+      const abilityCellElement = normalizeElementName(cell.element);
+
+      for (const cfg of configs) {
+        if (!cfg) continue;
+        const ok = shouldTriggerConfig(cfg, {
+          abilityOwner: owner,
+          abilityCellElement,
+          summonOwner,
+          summonFieldElement,
+          summonUnitElement,
+        });
+        if (!ok) continue;
+        const player = state.players[owner];
+        if (!player) continue;
+        const before = Number.isFinite(player.mana) ? player.mana : 0;
+        const after = capMana(before + cfg.amount);
+        const gained = after - before;
+        if (gained <= 0) continue;
+        player.mana = after;
+        const sourceName = abilityTpl.name || 'Существо';
+        const log = `${sourceName}: игрок ${owner + 1} получает ${gained} маны.`;
+
+        events.push({
+          owner,
+          amount: gained,
+          before,
+          after,
+          r,
+          c,
+          source: { tplId: abilityTpl.id, name: abilityTpl.name },
+          log,
+          origin: 'SUMMON_MANA_AURA',
+        });
+      }
+    }
+  }
+
+  return events;
+}
+
+export default { applyManaGainOnSummon };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -29,7 +29,8 @@ export const CARDS = {
     element: 'FIRE', atk: 1, hp: 2,
     attackType: 'STANDARD', pierce: true,
     attacks: [ { dir: 'N', ranges: [1] } ],
-    blindspots: ['S'], auraGainManaOnSummon: true,
+    blindspots: ['S'],
+    manaOnSummon: { summonOwner: 'ALLY', forbidSelfFieldElement: 'FIRE', amount: 1 },
     desc: 'While Freedonian Wanderer is on a non‑Fire field, you gain 1 mana each time you summon an allied creature.'
   },
   FIRE_PARTMOLE_FLAME_LIZARD: {
@@ -478,6 +479,60 @@ export const CARDS = {
       { type: 'ALLY_ELEMENT', element: 'BIOLITH', includeSelf: false },
     ],
     desc: 'Morning Star Warrior adds 2 to its Attack if the target creature has 5 or more HPs.\nMorning Star Warrior gains Protection equal to the number of allied Biolith creatures.'
+  },
+  BIOLITH_IMPERIAL_BIOLITH_GUARD: {
+    id: 'BIOLITH_IMPERIAL_BIOLITH_GUARD', name: 'Imperial Biolith Guard', type: 'UNIT', cost: 3, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'E', ranges: [1], group: 'SIDE_SWEEP', ignoreAlliedBlocking: true },
+      { dir: 'W', ranges: [1], group: 'SIDE_SWEEP', ignoreAlliedBlocking: true },
+    ],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    manaOnSummon: { summonOwner: 'ALLY', requireSummonFieldElement: 'BIOLITH', amount: 1 },
+    desc: 'Gain 1 mana each time you summon a creature to a Biolith field.'
+  },
+  BIOLITH_TINO_SON_OF_SCION: {
+    id: 'BIOLITH_TINO_SON_OF_SCION', name: 'Tino, Son of Scion', type: 'UNIT', cost: 4, activation: 3,
+    element: 'BIOLITH', atk: 3, hp: 4,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    magicTargetsSameElement: true,
+    dynamicAtkFormulas: [
+      {
+        when: { selfFieldElement: 'BIOLITH' },
+        value: {
+          base: 1,
+          addAlliedElement: { element: 'BIOLITH', includeSelf: false },
+        },
+        log: 'Tino, Son of Scion: атака установлена по количеству союзных биолитов.'
+      },
+    ],
+    manaOnSummon: { summonOwner: 'ALLY', amount: 1 },
+    desc: "Tino's Magic Attack targets all enemies of the same element as the target.\nWhile Tino is on a Biolith field, his Attack is equal to 1 plus the number of other allied Biolith creatures.\nGain 1 mana each time you summon a creature."
+  },
+  BIOLITH_WORMAK_HEIR_TO_THE_BIOLITHS: {
+    id: 'BIOLITH_WORMAK_HEIR_TO_THE_BIOLITHS', name: 'Wormak, Heir to the Bioliths', type: 'UNIT', cost: 4, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    dynamicAtkFormulas: [
+      {
+        when: { targetEnemyElement: 'BIOLITH' },
+        value: {
+          base: 2,
+          addBoardCount: { excludeElement: 'BIOLITH' },
+        },
+        log: "Wormak, Heir to the Bioliths: атака усиливается против биолитов цели."
+      },
+    ],
+    manaOnSummon: { summonOwner: 'ENEMY', amount: 1 },
+    desc: "If the target is an enemy Biolith, Wormak's Attack is equal to 2 plus the number of non-Biolith creatures on the board.\nGain 1 mana each time an enemy is summoned."
   },
   BIOLITH_BIOLITH_STINGER: {
     id: 'BIOLITH_BIOLITH_STINGER', name: 'Biolith Stinger', type: 'UNIT', cost: 3, activation: 2,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -305,8 +305,16 @@ export function stagedAttack(state, r, c, opts = {}) {
   const hitsRaw = computeHits(base, r, c, { ...opts, profile });
   if (!hitsRaw.length) return { empty: true };
 
-  const dynamicBonus = computeDynamicAttackBonus(base, r, c, tplA);
-  if (dynamicBonus?.amount) {
+  const dynamicBonus = computeDynamicAttackBonus(base, r, c, tplA, { hits: hitsRaw });
+  if (dynamicBonus?.override != null) {
+    const prev = atk;
+    atk = dynamicBonus.override;
+    if (dynamicBonus.log) {
+      logLines.push(dynamicBonus.log);
+    } else if (prev !== atk) {
+      logLines.push(`${tplA.name}: атака установлена на ${atk}.`);
+    }
+  } else if (dynamicBonus?.amount) {
     atk += dynamicBonus.amount;
     if (dynamicBonus.type === 'ELEMENT_CREATURES' && dynamicBonus.element) {
       logLines.push(`${tplA.name}: атака увеличена на ${dynamicBonus.amount} (существа стихии ${dynamicBonus.element})`);

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -409,10 +409,6 @@ export function confirmUnitAbilityOrientation(context, direction) {
       }
     }
 
-    if (result.freedonianMana > 0) {
-      w.addLog?.(`Фридонийский Странник приносит ${result.freedonianMana} маны.`);
-    }
-
     if (info.unitMesh?.userData) delete info.unitMesh.userData.availableActions;
     clearPendingAbilityOrientation();
     clearPendingUnitAbility();


### PR DESCRIPTION
## Summary
- extract a reusable mana-on-summon handler and integrate it into summon processing
- add Imperial Biolith Guard, Tino, Son of Scion, and Wormak, Heir to the Bioliths with their attack patterns, blind spots, and mana abilities
- extend dynamic attack handling to support conditional attack overrides for new card effects

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d754155e6483308a2baa0b2c93398b