### PR TITLE
Обновление логики маны при призывах и смертях

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -706,7 +706,7 @@ export function applyFreedonianAura(state, owner, context = {}) {
 }
 
 export function applySummonAbilities(state, r, c) {
-  const events = { possessions: [] };
+  const events = { possessions: [], manaSteals: [] };
   const cell = state?.board?.[r]?.[c];
   const unit = cell?.unit;
   if (!cell || !unit) return events;
@@ -979,10 +979,14 @@ export function executeUnitAction(state, action, payload = {}) {
         : [];
       result.manaGains = manaEvents;
       result.freedonianMana = manaEvents.reduce((acc, ev) => acc + (ev?.total || 0), 0);
+      result.manaSteals = Array.isArray(result.summonEvents?.manaSteals)
+        ? result.summonEvents.manaSteals
+        : [];
     } else {
       result.summonEvents = result.summonEvents || { possessions: [] };
       result.manaGains = [];
       result.freedonianMana = 0;
+      result.manaSteals = [];
     }
     return result;
   }

--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -36,7 +36,10 @@ import {
 import { hasAuraInvisibility } from './abilityHandlers/invisibilityAura.js';
 import { applyEnemySummonReactions } from './abilityHandlers/summonReactions.js';
 import { applySummonStatBuffs } from './abilityHandlers/summonBuffs.js';
-import { applyTurnStartManaEffects as applyTurnStartManaEffectsInternal } from './abilityHandlers/startPhase.js';
+import {
+  applyTurnStartManaEffects as applyTurnStartManaEffectsInternal,
+} from './abilityHandlers/startPhase.js';
+import { applyManaGainOnSummon } from './abilityHandlers/manaGain.js';
 import {
   computeUnitProtection as computeUnitProtectionInternal,
   computeAuraProtection as computeAuraProtectionInternal,
@@ -51,6 +54,7 @@ import {
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
 const inBounds = (r, c) => r >= 0 && r < 3 && c >= 0 && c < 3;
+const DIR_VECTORS = { N: [-1, 0], E: [0, 1], S: [1, 0], W: [0, -1] };
 
 function getUnitTemplate(unit) {
   if (!unit) return null;
@@ -628,46 +632,76 @@ export const hasDoubleAttack = (tpl) => !!(tpl && tpl.doubleAttack);
 // Может ли существо атаковать (крепости не могут)
 export const canAttack = (tpl) => !(tpl && tpl.fortress);
 
-// Реализация ауры Фридонийского Странника при призыве союзников
-// Возвращает подробности прироста маны, чтобы UI мог выводить сообщения
-export function applyFreedonianAura(state, owner) {
-  const result = { total: 0, entries: [] };
-  if (!state || !Array.isArray(state.board) || !Array.isArray(state.players)) {
-    return result;
+function normalizeFieldquakeSummonConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) return { pattern: 'ADJACENT' };
+  if (typeof raw === 'string') {
+    return { pattern: raw.trim().toUpperCase() };
   }
-  const player = state.players[owner];
-  if (!player) return result;
+  if (typeof raw === 'object') {
+    const pattern = String(raw.pattern || raw.type || raw.mode || 'ADJACENT').toUpperCase();
+    return { ...raw, pattern };
+  }
+  return null;
+}
 
-  for (let r = 0; r < 3; r += 1) {
-    for (let c = 0; c < 3; c += 1) {
-      const cell = state.board?.[r]?.[c];
-      const unit = cell?.unit;
-      if (!unit || unit.owner !== owner) continue;
-      const tpl = CARDS[unit.tplId];
-      if (!tpl?.auraGainManaOnSummon) continue;
-      const cellElement = normalizeElementName(cell?.element || null);
-      const nativeElement = normalizeElementName(tpl.element || null);
-      if (cellElement && cellElement === nativeElement) continue;
-
-      const before = Number.isFinite(player.mana) ? player.mana : 0;
-      if (before >= 10) continue;
-      const after = capMana(before + 1);
-      const gained = after - before;
-      if (gained <= 0) continue;
-      player.mana = after;
-      result.total += gained;
-      result.entries.push({
-        owner,
-        amount: gained,
-        sourceTplId: tpl.id,
-        sourceName: tpl.name || tpl.id,
-        r,
-        c,
-        fieldElement: cellElement || null,
-      });
+function collectFieldquakeSummonTargets(r, c, cfg) {
+  const result = [];
+  if (!cfg) return result;
+  if (cfg.pattern === 'SELF') {
+    result.push({ r, c });
+  }
+  if (cfg.pattern === 'ADJACENT') {
+    for (const vec of Object.values(DIR_VECTORS)) {
+      const nr = r + vec[0];
+      const nc = c + vec[1];
+      if (inBounds(nr, nc)) {
+        result.push({ r: nr, c: nc });
+      }
     }
   }
+  if (Array.isArray(cfg.extra)) {
+    for (const entry of cfg.extra) {
+      if (!entry) continue;
+      const nr = Number.isInteger(entry.r) ? entry.r : null;
+      const nc = Number.isInteger(entry.c) ? entry.c : null;
+      if (nr != null && nc != null && inBounds(nr, nc)) {
+        result.push({ r: nr, c: nc });
+      }
+    }
+  }
+  return result;
+}
 
+// Реализация ауры Фридонийского Странника при призыве союзников
+// Возвращает подробности прироста маны, чтобы UI мог выводить сообщения
+export function applyFreedonianAura(state, owner, context = {}) {
+  const result = { total: 0, entries: [], details: [] };
+  const events = Array.isArray(context.events)
+    ? context.events
+    : applyManaGainOnSummon(state, {
+        owner,
+        r: context.r,
+        c: context.c,
+        unit: context.unit,
+        tpl: context.tpl,
+        cell: context.cell,
+      });
+  for (const ev of events) {
+    if (!ev || ev.owner !== owner || ev.reason !== 'FREEDONIAN_AURA') continue;
+    const tpl = CARDS[ev.tplId] || null;
+    result.total += ev.amount || 0;
+    result.entries.push({
+      owner: ev.owner,
+      amount: ev.amount || 0,
+      sourceTplId: ev.tplId || tpl?.id || null,
+      sourceName: ev.tplName || tpl?.name || ev.tplId || 'Существо',
+      r: ev.r,
+      c: ev.c,
+      fieldElement: ev.fieldElement || null,
+    });
+    result.details.push(ev);
+  }
   return result;
 }
 
@@ -735,15 +769,40 @@ export function applySummonAbilities(state, r, c) {
     events.heals = [...(events.heals || []), ...reactions.heals];
   }
 
-  const auraMana = applyFreedonianAura(state, unit.owner);
-  if (auraMana.total > 0) {
-    const manaEvent = {
-      owner: unit.owner,
-      total: auraMana.total,
-      entries: auraMana.entries,
-      source: 'FREEDONIAN_AURA',
-    };
-    events.manaGains = [...(events.manaGains || []), manaEvent];
+  const manaAuraEvents = applyManaGainOnSummon(state, { r, c, unit, tpl, cell });
+  if (Array.isArray(manaAuraEvents) && manaAuraEvents.length) {
+    const freedonian = applyFreedonianAura(state, unit.owner, { events: manaAuraEvents, unit, tpl, r, c, cell });
+    if (freedonian.total > 0) {
+      const manaEvent = {
+        owner: unit.owner,
+        total: freedonian.total,
+        entries: freedonian.entries,
+        source: 'FREEDONIAN_AURA',
+      };
+      events.manaGains = [...(events.manaGains || []), manaEvent];
+    }
+    const otherManaEvents = manaAuraEvents.filter(ev => ev?.reason !== 'FREEDONIAN_AURA');
+    if (otherManaEvents.length) {
+      const mapped = otherManaEvents.map(ev => ({
+        owner: ev.owner,
+        before: ev.before,
+        after: ev.after,
+        amount: ev.amount,
+        total: ev.amount,
+        r: ev.r,
+        c: ev.c,
+        tplId: ev.tplId,
+        tplName: ev.tplName || null,
+        fieldElement: ev.fieldElement || null,
+        reason: ev.reason || 'SUMMON_AURA',
+        source: ev.reason || 'SUMMON_AURA',
+      }));
+      events.manaGains = [...(events.manaGains || []), ...mapped];
+      for (const ev of otherManaEvents) {
+        if (!ev?.log) continue;
+        events.logs = [...(events.logs || []), ev.log];
+      }
+    }
   }
 
   return events;

--- a/src/core/abilityHandlers/manaGain.js
+++ b/src/core/abilityHandlers/manaGain.js
@@ -425,7 +425,7 @@ export function applyTurnStartManaEffects(state, playerIndex) {
 }
 
 export function applyManaGainOnDeaths(state, deaths, opts = {}) {
-  const result = { total: 0, entries: [], logs: [] };
+  const result = { total: 0, entries: [], logs: [], steals: [], fieldquakes: [] };
   if (!state?.players || !Array.isArray(deaths) || deaths.length === 0) {
     return result;
   }

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -28,6 +28,7 @@ import { computeDynamicAttackBonus } from './abilityHandlers/dynamicAttack.js';
 import { getHpConditionalBonuses } from './abilityHandlers/conditionalBonuses.js';
 import { applyDeathDiscardEffects } from './abilityHandlers/discard.js';
 import { applyManaGainOnDeaths } from './abilityHandlers/manaGain.js';
+import { buildDeathRecord } from './utils/deaths.js';
 
 export function hasAdjacentGuard(state, r, c) {
   const target = state.board?.[r]?.[c]?.unit;
@@ -581,7 +582,8 @@ export function stagedAttack(state, r, c, opts = {}) {
       const cellRef = nFinal.board?.[rr]?.[cc];
       const u = cellRef?.unit;
       if (u && (u.currentHP ?? CARDS[u.tplId].hp) <= 0) {
-        deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: cellRef?.element || null });
+        const deathRecord = buildDeathRecord(nFinal, rr, cc, u);
+        if (deathRecord) deaths.push(deathRecord);
         if (cellRef) cellRef.unit = null;
       }
     }
@@ -911,7 +913,8 @@ export function magicAttack(state, fr, fc, tr, tc) {
     const cellRef = n1.board[rr][cc];
     const u = cellRef.unit;
     if (u && (u.currentHP ?? CARDS[u.tplId].hp) <= 0) {
-      deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: cellRef?.element || null });
+      const deathRecord = buildDeathRecord(n1, rr, cc, u);
+      if (deathRecord) deaths.push(deathRecord);
       cellRef.unit = null;
     }
   }

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -662,6 +662,8 @@ export function stagedAttack(state, r, c, opts = {}) {
 
     const targets = step1Damages.map(h => ({ r: h.r, c: h.c, dmg: h.dealt || 0 }));
     const combinedReleases = [...releaseEvents.releases, ...continuous.releases];
+    const manaStealEvents = Array.isArray(manaFromDeaths?.steals) ? manaFromDeaths.steals : [];
+    const appliedFieldquakes = Array.isArray(manaFromDeaths?.fieldquakes) ? manaFromDeaths.fieldquakes : [];
     const dodgeFinal = refreshBoardDodgeStates(nFinal);
     if (Array.isArray(dodgeFinal?.updated) && dodgeFinal.updated.length) {
       dodgeUpdates.push(...dodgeFinal.updated);
@@ -680,6 +682,8 @@ export function stagedAttack(state, r, c, opts = {}) {
       schemeKey,
       attackProfile: profile,
       manaGainEvents: Array.isArray(manaFromDeaths?.entries) ? manaFromDeaths.entries : [],
+      manaSteals: manaStealEvents,
+      fieldquakes: appliedFieldquakes,
     };
   }
 
@@ -976,6 +980,8 @@ export function magicAttack(state, fr, fc, tr, tc) {
     dodgeUpdates.push(...dodgeFinal.updated);
   }
   const combinedReleases = [...releaseEvents.releases, ...continuous.releases];
+  const manaStealEvents = Array.isArray(manaFromDeaths?.steals) ? manaFromDeaths.steals : [];
+  const appliedFieldquakes = Array.isArray(manaFromDeaths?.fieldquakes) ? manaFromDeaths.fieldquakes : [];
   return {
     n1,
     logLines,
@@ -990,6 +996,8 @@ export function magicAttack(state, fr, fc, tr, tc) {
     attackProfile: profile,
     dmg,
     manaGainEvents: Array.isArray(manaFromDeaths?.entries) ? manaFromDeaths.entries : [],
+    manaSteals: manaStealEvents,
+    fieldquakes: appliedFieldquakes,
   };
 }
 

--- a/src/core/utils/deaths.js
+++ b/src/core/utils/deaths.js
@@ -1,0 +1,25 @@
+// Утилиты для формирования записей о погибших существах (чистая логика)
+import { normalizeElementName } from './elements.js';
+
+export function buildDeathRecord(state, r, c, unit) {
+  if (!state || typeof r !== 'number' || typeof c !== 'number' || !unit) {
+    return null;
+  }
+  const tplId = unit.tplId || null;
+  const owner = unit.owner != null ? unit.owner : null;
+  const uid = unit.uid != null ? unit.uid : null;
+  const cellElementRaw = state.board?.[r]?.[c]?.element ?? null;
+  const element = normalizeElementName(cellElementRaw) || null;
+  return {
+    r,
+    c,
+    owner,
+    tplId,
+    uid,
+    element,
+  };
+}
+
+export default {
+  buildDeathRecord,
+};

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -1024,7 +1024,13 @@ export function placeUnitWithDirection(direction) {
       try {
         const cards = window.CARDS || {};
         for (const manaEvent of manaEvents) {
-          const total = Number.isFinite(manaEvent?.total) ? manaEvent.total : 0;
+          if (manaEvent?.log) {
+            window.addLog?.(manaEvent.log);
+            continue;
+          }
+          const totalRaw = Number.isFinite(manaEvent?.total) ? manaEvent.total : null;
+          const amountRaw = Number.isFinite(manaEvent?.amount) ? manaEvent.amount : null;
+          const total = totalRaw != null ? totalRaw : (amountRaw != null ? amountRaw : 0);
           if (total <= 0) continue;
           const entries = Array.isArray(manaEvent.entries) ? manaEvent.entries : [];
           if (manaEvent.source === 'FREEDONIAN_AURA') {
@@ -1043,7 +1049,12 @@ export function placeUnitWithDirection(direction) {
           const ownerLabel = Number.isFinite(manaEvent?.owner)
             ? `игрок ${manaEvent.owner + 1}`
             : 'игрок';
-          window.addLog?.(`${ownerLabel} получает ${total} маны.`);
+          const sourceName = manaEvent.tplName || cards[manaEvent.tplId]?.name || null;
+          if (sourceName) {
+            window.addLog?.(`${sourceName}: ${ownerLabel} получает ${total} маны.`);
+          } else {
+            window.addLog?.(`${ownerLabel} получает ${total} маны.`);
+          }
         }
       } catch (err) {
         console.error('[summon] Не удалось обработать события маны', err);

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -912,6 +912,27 @@ export function placeUnitWithDirection(direction) {
       THREE,
     });
     try { manaPlan?.schedule?.(); } catch {}
+    const manaStealEvents = Array.isArray(manaBonus?.steals) ? manaBonus.steals : [];
+    if (manaStealEvents.length) {
+      const animateSteal = window.__ui?.mana?.animateManaSteal;
+      for (const steal of manaStealEvents) {
+        if (steal?.log) {
+          window.addLog?.(steal.log);
+        } else {
+          const amount = Number.isFinite(steal?.amount) ? steal.amount : 0;
+          if (amount > 0) {
+            const fromLabel = Number.isFinite(steal?.from) ? `игрок ${steal.from + 1}` : 'игрок';
+            const toLabel = Number.isFinite(steal?.to) ? `игрок ${steal.to + 1}` : 'игрок';
+            window.addLog?.(`${toLabel} крадёт ${amount} маны у ${fromLabel}.`);
+          }
+        }
+        if (typeof animateSteal === 'function') {
+          try { animateSteal(steal); } catch (err) {
+            console.error('[mana] Не удалось запустить анимацию кражи маны:', err);
+          }
+        }
+      }
+    }
     gameState.board[row][col].unit = null;
     const discardEffects = applyDeathDiscardEffects(gameState, deathInfo, { cause: 'SUMMON' });
     if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
@@ -1058,6 +1079,27 @@ export function placeUnitWithDirection(direction) {
         }
       } catch (err) {
         console.error('[summon] Не удалось обработать события маны', err);
+      }
+    }
+    const manaSteals = Array.isArray(summonEvents?.manaSteals) ? summonEvents.manaSteals : [];
+    if (manaSteals.length) {
+      const animateSteal = window.__ui?.mana?.animateManaSteal;
+      for (const steal of manaSteals) {
+        if (steal?.log) {
+          window.addLog?.(steal.log);
+        } else {
+          const amount = Number.isFinite(steal?.amount) ? steal.amount : 0;
+          if (amount > 0) {
+            const fromLabel = Number.isFinite(steal?.from) ? `игрок ${steal.from + 1}` : 'игрок';
+            const toLabel = Number.isFinite(steal?.to) ? `игрок ${steal.to + 1}` : 'игрок';
+            window.addLog?.(`${toLabel} крадёт ${amount} маны у ${fromLabel}.`);
+          }
+        }
+        if (typeof animateSteal === 'function') {
+          try { animateSteal(steal); } catch (err) {
+            console.error('[summon] Не удалось запустить анимацию кражи маны:', err);
+          }
+        }
       }
     }
   }

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -399,7 +399,13 @@ export function confirmUnitAbilityOrientation(context, direction) {
     if (manaEvents.length) {
       const cards = w.CARDS || {};
       for (const manaEvent of manaEvents) {
-        const total = Number.isFinite(manaEvent?.total) ? manaEvent.total : 0;
+        if (manaEvent?.log) {
+          w.addLog?.(manaEvent.log);
+          continue;
+        }
+        const totalRaw = Number.isFinite(manaEvent?.total) ? manaEvent.total : null;
+        const amountRaw = Number.isFinite(manaEvent?.amount) ? manaEvent.amount : null;
+        const total = totalRaw != null ? totalRaw : (amountRaw != null ? amountRaw : 0);
         if (total <= 0) continue;
         const entries = Array.isArray(manaEvent.entries) ? manaEvent.entries : [];
         if (manaEvent.source === 'FREEDONIAN_AURA') {
@@ -418,7 +424,12 @@ export function confirmUnitAbilityOrientation(context, direction) {
         const ownerLabel = Number.isFinite(manaEvent?.owner)
           ? `игрок ${manaEvent.owner + 1}`
           : 'игрок';
-        w.addLog?.(`${ownerLabel} получает ${total} маны.`);
+        const sourceName = manaEvent.tplName || cards[manaEvent.tplId]?.name || null;
+        if (sourceName) {
+          w.addLog?.(`${sourceName}: ${ownerLabel} получает ${total} маны.`);
+        } else {
+          w.addLog?.(`${ownerLabel} получает ${total} маны.`);
+        }
       }
     } else if (result.freedonianMana > 0) {
       // обратная совместимость, если сервер ещё не передаёт подробные события

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -396,8 +396,10 @@ export function confirmUnitAbilityOrientation(context, direction) {
     }
 
     const manaEvents = Array.isArray(result.manaGains) ? result.manaGains : [];
+    const cards = w.CARDS || {};
+    let hasDetailedMana = false;
     if (manaEvents.length) {
-      const cards = w.CARDS || {};
+      hasDetailedMana = true;
       for (const manaEvent of manaEvents) {
         if (manaEvent?.log) {
           w.addLog?.(manaEvent.log);
@@ -431,7 +433,30 @@ export function confirmUnitAbilityOrientation(context, direction) {
           w.addLog?.(`${ownerLabel} получает ${total} маны.`);
         }
       }
-    } else if (result.freedonianMana > 0) {
+    }
+    const manaSteals = Array.isArray(result.manaSteals) ? result.manaSteals : [];
+    if (manaSteals.length) {
+      hasDetailedMana = true;
+      const animateSteal = w.__ui?.mana?.animateManaSteal;
+      for (const steal of manaSteals) {
+        if (steal?.log) {
+          w.addLog?.(steal.log);
+        } else {
+          const amount = Number.isFinite(steal?.amount) ? steal.amount : 0;
+          if (amount > 0) {
+            const fromLabel = Number.isFinite(steal?.from) ? `игрок ${steal.from + 1}` : 'игрок';
+            const toLabel = Number.isFinite(steal?.to) ? `игрок ${steal.to + 1}` : 'игрок';
+            w.addLog?.(`${toLabel} крадёт ${amount} маны у ${fromLabel}.`);
+          }
+        }
+        if (typeof animateSteal === 'function') {
+          try { animateSteal(steal); } catch (err) {
+            console.error('[actions] Не удалось запустить анимацию кражи маны:', err);
+          }
+        }
+      }
+    }
+    if (!hasDetailedMana && result.freedonianMana > 0) {
       // обратная совместимость, если сервер ещё не передаёт подробные события
       w.addLog?.(`Фридонийский Странник приносит ${result.freedonianMana} маны.`);
     }


### PR DESCRIPTION
## Summary
- реализована общая обработка прироста маны при призыве существ и интегрирована аура Фридонийского Странника без потери событий
- добавлены вспомогательные функции для fieldquake и новые сообщения об украденной/полученной мане в интерфейсе
- вынесена утилита формирования записей о погибших существах и обновлена логика подсчёта маны и логов на сервере

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7a3dd85b48330a3d144c9e9b2da1c