### PR TITLE
Fix mana gain handlers and clean duplicate declarations

### DIFF
--- a/src/core/abilityHandlers/manaOnSummon.js
+++ b/src/core/abilityHandlers/manaOnSummon.js
@@ -31,7 +31,12 @@ function parseElement(raw) {
 function normalizeConfigEntry(raw) {
   if (!raw) return null;
   if (raw === true) {
-    return { trigger: 'ALLY', amount: 1, excludeSelfSummon: true };
+    return {
+      trigger: 'ALLY',
+      amount: 1,
+      excludeSelfSummon: true,
+      reason: 'SUMMON_AURA',
+    };
   }
   if (typeof raw !== 'object') return null;
   const trigger = normalizeTrigger(raw.trigger || raw.type || raw.mode);
@@ -51,6 +56,11 @@ function normalizeConfigEntry(raw) {
     summonFieldNotElement: parseElement(raw.summonFieldNotElement || raw.summonFieldNot || raw.summonNotElement),
     requireSummonedElement: parseElement(raw.requireSummonedElement || raw.summonedElement || raw.unitElement),
   };
+  const reasonRaw = typeof raw.reason === 'string' ? raw.reason.trim().toUpperCase() : null;
+  const defaultReason = (entry.trigger === 'ALLY' && entry.sourceFieldNotElement)
+    ? 'FREEDONIAN_AURA'
+    : 'SUMMON_AURA';
+  entry.reason = reasonRaw || defaultReason;
   return entry;
 }
 
@@ -148,6 +158,9 @@ export function applyManaGainOnSummon(state, context = {}) {
           r,
           c,
           tplId: tpl.id,
+          tplName: tpl.name || null,
+          fieldElement: sourceElement,
+          reason: cfg.reason || 'SUMMON_AURA',
           log: formatLog(cfg.log, {
             amount: gained,
             name: tpl.name || tpl.id || 'Существо',


### PR DESCRIPTION
## Summary
- разделил обработчики прироста маны по ауре и конфигурации призыва, устранив конфликт имен и расширив объединение событий
- добавил причину и метаданные для событий manaOnSummon, чтобы сохранить корректные уведомления (включая ауру Фридонийского странника)
- почистил rules.js от дублирующихся объявлений после слияний и исправил сбор событий fieldquake/mana steal

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7bb284dd4833095714fb9045a9fd6