### PR TITLE
Добавить механику кражи маны и новые карты

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -37,6 +37,7 @@ import { hasAuraInvisibility } from './abilityHandlers/invisibilityAura.js';
 import { applyEnemySummonReactions } from './abilityHandlers/summonReactions.js';
 import { applySummonStatBuffs } from './abilityHandlers/summonBuffs.js';
 import { applyTurnStartManaEffects as applyTurnStartManaEffectsInternal } from './abilityHandlers/startPhase.js';
+import { applySummonManaSteal } from './abilityHandlers/manaSteal.js';
 import {
   computeUnitProtection as computeUnitProtectionInternal,
   computeAuraProtection as computeAuraProtectionInternal,
@@ -712,6 +713,15 @@ export function applySummonAbilities(state, r, c) {
     events.heals = [...(events.heals || []), ...reactions.heals];
   }
 
+  const manaStealEvents = applySummonManaSteal(state, { tpl, unit, cell, r, c });
+  if (Array.isArray(manaStealEvents) && manaStealEvents.length) {
+    events.manaStealEvents = manaStealEvents;
+    const logs = manaStealEvents.map(ev => ev?.log).filter(Boolean);
+    if (logs.length) {
+      events.logs = [...(events.logs || []), ...logs];
+    }
+  }
+
   return events;
 }
 
@@ -849,6 +859,7 @@ export const applyTurnStartManaEffects = applyTurnStartManaEffectsInternal;
 export const evaluateFieldFatality = evaluateFieldFatalityInternal;
 export const applyFieldFatalityCheck = applyFieldFatalityCheckInternal;
 export const describeFieldFatality = describeFieldFatalityInternal;
+export { hasManaStealKeyword } from './abilityHandlers/manaSteal.js';
 
 export function collectUnitActions(state, r, c) {
   const actions = [];

--- a/src/core/abilityHandlers/deathReposition.js
+++ b/src/core/abilityHandlers/deathReposition.js
@@ -1,0 +1,72 @@
+// Перемещения существ, срабатывающие при смерти других юнитов
+// Чистая логика, не зависящая от визуальных компонентов
+import { CARDS } from '../cards.js';
+import { DIR_VECTORS, inBounds } from '../constants.js';
+import { applyFieldTransitionToUnit } from '../fieldEffects.js';
+import { applyFieldFatalityCheck, describeFieldFatality } from './fieldHazards.js';
+
+function describeShift(shift, name) {
+  if (!shift) return null;
+  const fieldLabel = shift.nextElement ? `поле ${shift.nextElement}` : 'нейтральное поле';
+  if (shift.deltaHp > 0) {
+    return `${name} усиливается на ${fieldLabel}: HP ${shift.beforeHp}→${shift.afterHp}.`;
+  }
+  if (shift.deltaHp < 0) {
+    return `${name} теряет силу на ${fieldLabel}: HP ${shift.beforeHp}→${shift.afterHp}.`;
+  }
+  return null;
+}
+
+export function applyDeathRepositionEffects(state, deaths = []) {
+  const logs = [];
+  if (!state?.board || !Array.isArray(deaths) || !deaths.length) {
+    return { logs };
+  }
+
+  for (const death of deaths) {
+    if (!death) continue;
+    const tpl = CARDS[death.tplId];
+    if (!tpl?.deathPullFrontToSelf) continue;
+
+    const facing = typeof death.facing === 'string' ? death.facing : 'N';
+    const vec = DIR_VECTORS[facing] || DIR_VECTORS.N;
+    const frontR = death.r + vec[0];
+    const frontC = death.c + vec[1];
+    if (!inBounds(frontR, frontC)) continue;
+
+    const frontCell = state.board?.[frontR]?.[frontC];
+    const targetUnit = frontCell?.unit;
+    if (!targetUnit) continue;
+    const targetTpl = CARDS[targetUnit.tplId];
+    if (!targetTpl) continue;
+    const targetHp = typeof targetUnit.currentHP === 'number' ? targetUnit.currentHP : targetTpl.hp || 0;
+    if (targetHp <= 0) continue;
+
+    const destCell = state.board?.[death.r]?.[death.c];
+    if (!destCell || destCell.unit) continue;
+
+    frontCell.unit = null;
+    destCell.unit = targetUnit;
+
+    const sourceName = tpl?.name || 'Существо';
+    const targetName = targetTpl?.name || 'Существо';
+    logs.push(`${sourceName}: ${targetName} перемещается на её прежнее поле.`);
+
+    const fromElement = frontCell?.element || null;
+    const toElement = destCell?.element || null;
+
+    const shift = applyFieldTransitionToUnit(targetUnit, targetTpl, fromElement, toElement);
+    const shiftLog = describeShift(shift, targetName);
+    if (shiftLog) logs.push(shiftLog);
+
+    const hazard = applyFieldFatalityCheck(targetUnit, targetTpl, toElement);
+    const fatalLog = describeFieldFatality(targetTpl, hazard, { name: targetName });
+    if (fatalLog) logs.push(fatalLog);
+  }
+
+  return { logs };
+}
+
+export default {
+  applyDeathRepositionEffects,
+};

--- a/src/core/abilityHandlers/incarnation.js
+++ b/src/core/abilityHandlers/incarnation.js
@@ -1,5 +1,6 @@
 // Модуль обработки механики "Инкарнация"
 import { CARDS } from '../cards.js';
+import { createDeathEntry } from '../utils/deaths.js';
 
 function getTemplate(tplOrId) {
   if (!tplOrId) return null;
@@ -69,9 +70,8 @@ export function applyIncarnationSummon(state, context = {}) {
   const cell = board?.[r]?.[c];
   const removedUnit = cell?.unit || null;
   const removedTpl = getTemplate(removedUnit?.tplId);
-  const deathInfo = removedUnit
-    ? [{ r, c, owner: removedUnit.owner, tplId: removedUnit.tplId, uid: removedUnit.uid ?? null, element: cell?.element || null }]
-    : null;
+  const deathEntry = removedUnit ? createDeathEntry(state, removedUnit, r, c) : null;
+  const deathInfo = deathEntry ? [deathEntry] : null;
   if (cell) cell.unit = null;
   return {
     ok: true,

--- a/src/core/abilityHandlers/manaSteal.js
+++ b/src/core/abilityHandlers/manaSteal.js
@@ -1,0 +1,358 @@
+// Модуль обработки механики "кража маны"
+// Чистая игровая логика без привязки к визуальной части
+import { CARDS } from '../cards.js';
+
+const MAX_HISTORY = 20;
+
+const capMana = (value) => {
+  const num = Math.floor(Number(value) || 0);
+  if (!Number.isFinite(num)) return 0;
+  if (num < 0) return 0;
+  if (num > 10) return 10;
+  return num;
+};
+
+function ensureQueue(state) {
+  if (!state) return null;
+  if (!Array.isArray(state.manaStealEvents)) {
+    state.manaStealEvents = [];
+  }
+  return state.manaStealEvents;
+}
+
+function nextEventId(state) {
+  if (!state) return Date.now();
+  const current = Number(state.__manaStealSeq) || 0;
+  const next = current + 1;
+  state.__manaStealSeq = next;
+  return next;
+}
+
+function registerEvent(state, baseEvent) {
+  const queue = ensureQueue(state);
+  const event = {
+    ...baseEvent,
+    id: nextEventId(state),
+    ts: Date.now(),
+  };
+  if (queue) {
+    queue.push(event);
+    if (queue.length > MAX_HISTORY) {
+      queue.splice(0, queue.length - MAX_HISTORY);
+    }
+  }
+  return event;
+}
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
+function normalizeTrigger(raw) {
+  if (!raw) return null;
+  const code = String(raw).toUpperCase();
+  if (code === 'SUMMON' || code === 'ON_SUMMON') return 'SUMMON';
+  if (code === 'DEATH' || code === 'ON_DEATH' || code === 'DESTROYED') return 'DEATH';
+  return null;
+}
+
+function normalizeAmountSpec(raw) {
+  if (raw == null) return null;
+  if (typeof raw === 'number') {
+    const value = Math.max(0, Math.floor(raw));
+    if (!Number.isFinite(value) || value <= 0) return null;
+    return { kind: 'FIXED', value };
+  }
+  if (typeof raw === 'object') {
+    if (typeof raw.value === 'number') {
+      const value = Math.max(0, Math.floor(raw.value));
+      if (!Number.isFinite(value) || value <= 0) return null;
+      return { kind: 'FIXED', value };
+    }
+    const type = String(raw.type || raw.mode || '').toUpperCase();
+    if (type === 'FIELD_COUNT' || type === 'FIELDS') {
+      const element = String(raw.element || raw.field || '').toUpperCase();
+      if (!element) return null;
+      return { kind: 'FIELD_COUNT', element };
+    }
+    if (raw.countFieldsOfElement) {
+      const element = String(raw.countFieldsOfElement || '').toUpperCase();
+      if (!element) return null;
+      return { kind: 'FIELD_COUNT', element };
+    }
+    if (raw.amountByFieldCount) {
+      const element = String(raw.amountByFieldCount || '').toUpperCase();
+      if (!element) return null;
+      return { kind: 'FIELD_COUNT', element };
+    }
+  }
+  return null;
+}
+
+function countFields(state, element) {
+  if (!state?.board || !element) return 0;
+  let total = 0;
+  for (let r = 0; r < state.board.length; r += 1) {
+    for (let c = 0; c < state.board[r].length; c += 1) {
+      if (state.board?.[r]?.[c]?.element === element) total += 1;
+    }
+  }
+  return total;
+}
+
+function resolveAmount(state, spec) {
+  if (!spec) return 0;
+  if (spec.kind === 'FIXED') {
+    return Math.max(0, Math.floor(spec.value || 0));
+  }
+  if (spec.kind === 'FIELD_COUNT') {
+    return countFields(state, spec.element);
+  }
+  return 0;
+}
+
+function normalizeEntry(raw, trigger) {
+  if (!raw) return null;
+  if (typeof raw === 'number') {
+    const amount = Math.max(0, Math.floor(raw));
+    if (amount <= 0) return null;
+    return { trigger, amountSpec: { kind: 'FIXED', value: amount } };
+  }
+  if (typeof raw !== 'object') return null;
+  const entry = { trigger };
+  const cloned = { ...raw };
+  if (typeof cloned.amount === 'number') {
+    entry.amountSpec = normalizeAmountSpec(cloned.amount);
+  } else {
+    entry.amountSpec = normalizeAmountSpec(cloned.amount)
+      || normalizeAmountSpec(cloned.amountSpec)
+      || normalizeAmountSpec(cloned.countFieldsOfElement)
+      || normalizeAmountSpec(cloned.amountByFieldCount);
+  }
+  if (!entry.amountSpec && typeof cloned.countFieldsOfElement === 'string') {
+    entry.amountSpec = { kind: 'FIELD_COUNT', element: String(cloned.countFieldsOfElement).toUpperCase() };
+  }
+  if (!entry.amountSpec && typeof cloned.amountByFieldCount === 'string') {
+    entry.amountSpec = { kind: 'FIELD_COUNT', element: String(cloned.amountByFieldCount).toUpperCase() };
+  }
+  if (!entry.amountSpec && typeof cloned.amount === 'object') {
+    entry.amountSpec = normalizeAmountSpec(cloned.amount);
+  }
+  if (!entry.amountSpec) {
+    entry.amountSpec = normalizeAmountSpec(cloned.value);
+  }
+  if (cloned.max != null) entry.max = Math.max(0, Math.floor(cloned.max));
+  if (cloned.min != null) entry.min = Math.max(0, Math.floor(cloned.min));
+
+  const requireField = cloned.requireFieldElement || cloned.requireElement || cloned.requireField;
+  if (requireField) {
+    entry.requireFieldElement = String(requireField).toUpperCase();
+  }
+  const forbidField = cloned.forbidFieldElement || cloned.forbidElement || cloned.forbidField || cloned.excludeFieldElement;
+  if (forbidField) {
+    entry.forbidFieldElement = String(forbidField).toUpperCase();
+  }
+
+  const fromRaw = cloned.from ?? cloned.stealFrom ?? cloned.target ?? cloned.fromPlayer;
+  const toRaw = cloned.to ?? cloned.recipient ?? cloned.giveTo ?? cloned.toPlayer;
+
+  const mapRole = (value, fallback) => {
+    if (value == null) return fallback;
+    if (typeof value === 'number') return value;
+    const txt = String(value).toUpperCase();
+    if (txt === 'SELF' || txt === 'ALLY' || txt === 'OWNER') return 'OWNER';
+    if (txt === 'OPPONENT' || txt === 'ENEMY') return 'OPPONENT';
+    if (txt === 'FRONT_OWNER' || txt === 'FRONT' || txt === 'FRONT_OPPONENT') return 'FRONT_OWNER';
+    if (txt === 'SOURCE_OWNER') return 'SOURCE_OWNER';
+    return fallback;
+  };
+
+  entry.from = mapRole(fromRaw, 'OPPONENT');
+  entry.to = mapRole(toRaw, 'OWNER');
+  if (cloned.reason) entry.reason = String(cloned.reason);
+  if (cloned.log === false) entry.skipLog = true;
+
+  return entry.amountSpec ? entry : null;
+}
+
+function gatherEntries(tpl, trigger) {
+  if (!tpl?.manaSteal) return [];
+  const data = tpl.manaSteal;
+  const list = [];
+  const pickKeys = [];
+  if (trigger === 'SUMMON') pickKeys.push('onSummon', 'summon');
+  if (trigger === 'DEATH') pickKeys.push('onDeath', 'death', 'onDestroy', 'destroyed');
+  for (const key of pickKeys) {
+    const raw = data[key];
+    for (const item of toArray(raw)) {
+      const entry = normalizeEntry(item, trigger);
+      if (entry) list.push(entry);
+    }
+  }
+  return list;
+}
+
+function resolveRoleIndex(owner, role, ctx = {}) {
+  if (typeof role === 'number') return role;
+  if (role === 'OWNER') return owner;
+  if (role === 'SOURCE_OWNER') return ctx.sourceOwner ?? owner;
+  if (role === 'FRONT_OWNER') {
+    if (ctx.frontOwner == null) return null;
+    return ctx.frontOwner;
+  }
+  if (role === 'OPPONENT') return owner === 0 ? 1 : 0;
+  return owner;
+}
+
+function applyEntry(state, entry, ctx) {
+  if (!state || !entry) return null;
+  const owner = (ctx.owner != null) ? ctx.owner : (ctx.unit?.owner ?? null);
+  if (owner == null) return null;
+  const cellElement = ctx.element || ctx.cellElement || ctx.cell?.element || null;
+  if (entry.requireFieldElement && cellElement !== entry.requireFieldElement) {
+    return null;
+  }
+  if (entry.forbidFieldElement && cellElement === entry.forbidFieldElement) {
+    return null;
+  }
+
+  const amountRaw = resolveAmount(state, entry.amountSpec, ctx);
+  if (!Number.isFinite(amountRaw) || amountRaw <= 0) return null;
+
+  let amount = Math.max(0, Math.floor(amountRaw));
+  if (entry.max != null) amount = Math.min(amount, entry.max);
+  if (entry.min != null) amount = Math.max(amount, entry.min);
+  if (amount <= 0) return null;
+
+  const fromIndex = resolveRoleIndex(owner, entry.from, ctx);
+  const toIndex = resolveRoleIndex(owner, entry.to, ctx);
+  if (fromIndex == null || toIndex == null || fromIndex === toIndex) return null;
+
+  const fromPlayer = state.players?.[fromIndex];
+  const toPlayer = state.players?.[toIndex];
+  if (!fromPlayer || !toPlayer) return null;
+
+  const fromBefore = capMana(fromPlayer.mana);
+  const toBefore = capMana(toPlayer.mana);
+  if (fromBefore <= 0) return null;
+
+  const capacity = Math.max(0, 10 - toBefore);
+  if (capacity <= 0) return null;
+
+  const transfer = Math.min(amount, fromBefore, capacity);
+  if (transfer <= 0) return null;
+
+  const fromAfter = capMana(fromBefore - transfer);
+  const toAfter = capMana(toBefore + transfer);
+
+  fromPlayer.mana = fromAfter;
+  toPlayer.mana = toAfter;
+
+  const sourceTpl = ctx.tpl || (ctx.tplId ? CARDS[ctx.tplId] : null) || (ctx.unit ? CARDS[ctx.unit.tplId] : null);
+  const sourceInfo = ctx.source || {
+    tplId: sourceTpl?.id || ctx.tplId || null,
+    name: sourceTpl?.name || ctx.sourceName || 'Unit',
+    owner,
+  };
+
+  const baseEvent = {
+    trigger: entry.trigger,
+    amount: transfer,
+    from: fromIndex,
+    to: toIndex,
+    before: { fromMana: fromBefore, toMana: toBefore },
+    after: { fromMana: fromAfter, toMana: toAfter },
+    source: sourceInfo,
+    reason: entry.reason || ctx.reason || entry.trigger,
+    element: cellElement || null,
+    position: ctx.position ? { ...ctx.position } : null,
+  };
+
+  const event = registerEvent(state, baseEvent);
+  if (!entry.skipLog) {
+    const name = event.source?.name || 'Существо';
+    const victim = (event.from != null) ? event.from + 1 : '?';
+    event.log = `${name}: крадет ${transfer} маны у игрока ${victim}.`;
+  }
+  return event;
+}
+
+export function applySummonManaSteal(state, context = {}) {
+  const { tpl, unit, cell, r, c } = context;
+  const entries = gatherEntries(tpl, 'SUMMON');
+  if (!entries.length) return [];
+  const events = [];
+  for (const entry of entries) {
+    const ev = applyEntry(state, entry, {
+      owner: unit?.owner,
+      unit,
+      tpl,
+      cell,
+      cellElement: cell?.element || null,
+      element: cell?.element || null,
+      position: (typeof r === 'number' && typeof c === 'number') ? { r, c } : null,
+      reason: 'SUMMON',
+      sourceOwner: unit?.owner ?? null,
+    });
+    if (ev) events.push(ev);
+  }
+  return events;
+}
+
+export function applyDeathManaSteal(state, deaths = [], context = {}) {
+  if (!Array.isArray(deaths) || deaths.length === 0) return [];
+  const events = [];
+  for (const death of deaths) {
+    if (!death) continue;
+    const tpl = CARDS[death.tplId];
+    if (!tpl) continue;
+    const entries = gatherEntries(tpl, 'DEATH');
+    if (!entries.length) continue;
+    for (const entry of entries) {
+      const ev = applyEntry(state, entry, {
+        owner: death.owner,
+        tpl,
+        tplId: tpl.id,
+        element: death.element || null,
+        cellElement: death.element || null,
+        position: (typeof death.r === 'number' && typeof death.c === 'number') ? { r: death.r, c: death.c } : null,
+        reason: context?.cause || 'DEATH',
+        frontOwner: death.frontOwner ?? null,
+        sourceOwner: death.owner ?? null,
+      });
+      if (ev) events.push(ev);
+    }
+  }
+  return events;
+}
+
+export function hasManaStealKeyword(tpl) {
+  if (!tpl?.manaSteal) return false;
+  const onSummon = gatherEntries(tpl, 'SUMMON');
+  if (onSummon.length) return true;
+  const onDeath = gatherEntries(tpl, 'DEATH');
+  return onDeath.length > 0;
+}
+
+export function listManaStealEvents(state) {
+  if (!state || !Array.isArray(state.manaStealEvents)) return [];
+  return state.manaStealEvents.slice();
+}
+
+export function consumeManaStealEvents(state) {
+  if (!state || !Array.isArray(state.manaStealEvents) || !state.manaStealEvents.length) {
+    return [];
+  }
+  const events = state.manaStealEvents.slice();
+  state.manaStealEvents.length = 0;
+  return events;
+}
+
+export default {
+  applySummonManaSteal,
+  applyDeathManaSteal,
+  hasManaStealKeyword,
+  listManaStealEvents,
+  consumeManaStealEvents,
+};

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -635,6 +635,49 @@ export const CARDS = {
     ],
     desc: 'Magic Attack. While on a Water field, Imposter Queen Anfisa gains Possession of all enemies on adjacent fields.'
   },
+  WATER_MOVING_ISLE_OF_KADENA: {
+    id: 'WATER_MOVING_ISLE_OF_KADENA', name: 'Moving Isle of Kadena', type: 'UNIT', cost: 4, activation: 2,
+    element: 'WATER', atk: 1, hp: 4,
+    attackType: 'STANDARD', chooseDir: true,
+    attacks: [
+      { dir: 'N', ranges: [1], ignoreAlliedBlocking: true },
+      { dir: 'E', ranges: [1], ignoreAlliedBlocking: true },
+      { dir: 'S', ranges: [1], ignoreAlliedBlocking: true },
+      { dir: 'W', ranges: [1], ignoreAlliedBlocking: true },
+    ],
+    blindspots: [], fortress: true, ignoreAlliedBlocking: true,
+    diesOnElement: 'FIRE',
+    manaSteal: {
+      onSummon: {
+        amount: { type: 'FIELD_COUNT', element: 'WATER' },
+        forbidFieldElement: 'WATER',
+      },
+    },
+    desc: 'Fortress. If Moving Isle of Kadena is summoned to a non-Water field, steal mana from your opponent equal to the number of Water fields. Destroy Moving Isle of Kadena if it is on a Fire field.'
+  },
+  WATER_QUEENS_SERVANT: {
+    id: 'WATER_QUEENS_SERVANT', name: "Queen's Servant", type: 'UNIT', cost: 4, activation: 2,
+    element: 'WATER', atk: 1, hp: 1,
+    attackType: 'MAGIC',
+    attacks: [ { dir: 'N', ranges: [1, 2, 3], mode: 'ANY' } ],
+    blindspots: ['S'], perfectDodge: true, ignoreAlliedBlocking: true,
+    manaSteal: {
+      onDeath: { amount: 1 },
+    },
+    desc: "Magic Attack. Perfect Dodge. If Queen's Servant is destroyed, steal 1 mana from your opponent."
+  },
+  WATER_DANCING_TEMPTRESS: {
+    id: 'WATER_DANCING_TEMPTRESS', name: 'Dancing Temptress', type: 'UNIT', cost: 3, activation: 2,
+    element: 'NEUTRAL', atk: 1, hp: 2,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1] } ],
+    blindspots: ['S'],
+    deathPullFrontToSelf: true,
+    manaSteal: {
+      onDeath: { amount: 1, from: 'FRONT_OWNER' },
+    },
+    desc: 'Если Dancing Temptress уничтожена, владелец существа перед ней теряет 1 ману, а само существо перемещается на её поле.'
+  },
   FOREST_SWALLOW_NINJA: {
     id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 1, hp: 3,

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -28,6 +28,9 @@ import { computeDynamicAttackBonus } from './abilityHandlers/dynamicAttack.js';
 import { getHpConditionalBonuses } from './abilityHandlers/conditionalBonuses.js';
 import { applyDeathDiscardEffects } from './abilityHandlers/discard.js';
 import { applyManaGainOnDeaths } from './abilityHandlers/manaGain.js';
+import { applyDeathManaSteal } from './abilityHandlers/manaSteal.js';
+import { applyDeathRepositionEffects } from './abilityHandlers/deathReposition.js';
+import { createDeathEntry } from './utils/deaths.js';
 
 export function hasAdjacentGuard(state, r, c) {
   const target = state.board?.[r]?.[c]?.unit;
@@ -577,12 +580,15 @@ export function stagedAttack(state, r, c, opts = {}) {
     }
 
     const deaths = [];
-    for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
-      const cellRef = nFinal.board?.[rr]?.[cc];
-      const u = cellRef?.unit;
-      if (u && (u.currentHP ?? CARDS[u.tplId].hp) <= 0) {
-        deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: cellRef?.element || null });
-        if (cellRef) cellRef.unit = null;
+    for (let rr = 0; rr < 3; rr += 1) {
+      for (let cc = 0; cc < 3; cc += 1) {
+        const cellRef = nFinal.board?.[rr]?.[cc];
+        const u = cellRef?.unit;
+        if (u && (u.currentHP ?? CARDS[u.tplId]?.hp ?? 0) <= 0) {
+          const deathEntry = createDeathEntry(nFinal, u, rr, cc);
+          if (deathEntry) deaths.push(deathEntry);
+          if (cellRef) cellRef.unit = null;
+        }
       }
     }
 
@@ -594,9 +600,22 @@ export function stagedAttack(state, r, c, opts = {}) {
       }
     } catch {}
 
+    let manaStealEvents = [];
     const manaFromDeaths = applyManaGainOnDeaths(nFinal, deaths, { boardState: nFinal });
     if (Array.isArray(manaFromDeaths?.logs) && manaFromDeaths.logs.length) {
       logLines.push(...manaFromDeaths.logs);
+    }
+
+    const reposition = applyDeathRepositionEffects(nFinal, deaths);
+    if (Array.isArray(reposition?.logs) && reposition.logs.length) {
+      logLines.push(...reposition.logs);
+    }
+
+    manaStealEvents = applyDeathManaSteal(nFinal, deaths, { cause: 'BATTLE' });
+    if (Array.isArray(manaStealEvents) && manaStealEvents.length) {
+      for (const ev of manaStealEvents) {
+        if (ev?.log) logLines.push(ev.log);
+      }
     }
 
     for (const d of deaths) {
@@ -678,6 +697,7 @@ export function stagedAttack(state, r, c, opts = {}) {
       schemeKey,
       attackProfile: profile,
       manaGainEvents: Array.isArray(manaFromDeaths?.entries) ? manaFromDeaths.entries : [],
+      manaStealEvents: Array.isArray(manaStealEvents) ? manaStealEvents : [],
     };
   }
 
@@ -907,12 +927,15 @@ export function magicAttack(state, fr, fc, tr, tc) {
   }
 
   const deaths = [];
-  for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
-    const cellRef = n1.board[rr][cc];
-    const u = cellRef.unit;
-    if (u && (u.currentHP ?? CARDS[u.tplId].hp) <= 0) {
-      deaths.push({ r: rr, c: cc, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: cellRef?.element || null });
-      cellRef.unit = null;
+  for (let rr = 0; rr < 3; rr += 1) {
+    for (let cc = 0; cc < 3; cc += 1) {
+      const cellRef = n1.board[rr][cc];
+      const u = cellRef.unit;
+      if (u && (u.currentHP ?? CARDS[u.tplId]?.hp ?? 0) <= 0) {
+        const deathEntry = createDeathEntry(n1, u, rr, cc);
+        if (deathEntry) deaths.push(deathEntry);
+        cellRef.unit = null;
+      }
     }
   }
   try {
@@ -922,9 +945,20 @@ export function magicAttack(state, fr, fc, tr, tc) {
       }
     }
   } catch {}
+  let manaStealEvents = [];
   const manaFromDeaths = applyManaGainOnDeaths(n1, deaths, { boardState: n1 });
   if (Array.isArray(manaFromDeaths?.logs) && manaFromDeaths.logs.length) {
     logLines.push(...manaFromDeaths.logs);
+  }
+  const reposition = applyDeathRepositionEffects(n1, deaths);
+  if (Array.isArray(reposition?.logs) && reposition.logs.length) {
+    logLines.push(...reposition.logs);
+  }
+  manaStealEvents = applyDeathManaSteal(n1, deaths, { cause: 'MAGIC' });
+  if (Array.isArray(manaStealEvents) && manaStealEvents.length) {
+    for (const ev of manaStealEvents) {
+      if (ev?.log) logLines.push(ev.log);
+    }
   }
   const discardEffects = applyDeathDiscardEffects(n1, deaths, { cause: 'MAGIC' });
   if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
@@ -987,6 +1021,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
     attackProfile: profile,
     dmg,
     manaGainEvents: Array.isArray(manaFromDeaths?.entries) ? manaFromDeaths.entries : [],
+    manaStealEvents: Array.isArray(manaStealEvents) ? manaStealEvents : [],
   };
 }
 

--- a/src/core/utils/deaths.js
+++ b/src/core/utils/deaths.js
@@ -1,0 +1,62 @@
+// Вспомогательные функции для описания событий смерти существ
+// Модуль содержит только чистую игровую логику, без привязки к визуализации
+import { CARDS } from '../cards.js';
+import { DIR_VECTORS, inBounds } from '../constants.js';
+
+const FACING_ORDER = ['N', 'E', 'S', 'W'];
+
+function normalizeFacing(value, tpl) {
+  if (typeof value === 'string') {
+    const token = value.trim().toUpperCase();
+    if (FACING_ORDER.includes(token)) return token;
+  }
+  if (tpl && typeof tpl.facing === 'string') {
+    const token = tpl.facing.trim().toUpperCase();
+    if (FACING_ORDER.includes(token)) return token;
+  }
+  if (tpl && typeof tpl.defaultFacing === 'string') {
+    const token = tpl.defaultFacing.trim().toUpperCase();
+    if (FACING_ORDER.includes(token)) return token;
+  }
+  return 'N';
+}
+
+export function computeFrontOwner(state, r, c, facing) {
+  if (!state?.board) return null;
+  const vec = DIR_VECTORS[facing] || DIR_VECTORS.N;
+  const fr = r + vec[0];
+  const fc = c + vec[1];
+  if (!inBounds(fr, fc)) return null;
+  const cell = state.board?.[fr]?.[fc];
+  const unit = cell?.unit;
+  if (!unit) return null;
+  const tpl = CARDS[unit.tplId];
+  if (!tpl) return null;
+  const currentHp = typeof unit.currentHP === 'number' ? unit.currentHP : tpl.hp || 0;
+  if (currentHp <= 0) return null;
+  return unit.owner;
+}
+
+export function createDeathEntry(state, unit, r, c) {
+  if (!state || !unit) return null;
+  const tpl = CARDS[unit.tplId];
+  if (!tpl) return null;
+  const facing = normalizeFacing(unit.facing, tpl);
+  const element = state.board?.[r]?.[c]?.element || null;
+  const frontOwner = computeFrontOwner(state, r, c, facing);
+  return {
+    r,
+    c,
+    owner: unit.owner,
+    tplId: unit.tplId,
+    uid: unit.uid ?? null,
+    element,
+    facing,
+    frontOwner,
+  };
+}
+
+export default {
+  computeFrontOwner,
+  createDeathEntry,
+};

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -1,4 +1,5 @@
 import { getServerBase } from './config.js';
+import { flushManaStealFx } from '../scene/manaStealFx.js';
 
   /* MODULE: network/multiplayer
      Purpose: handle server connection, matchmaking, state sync,
@@ -287,6 +288,7 @@ import { getServerBase } from './config.js';
     try {
       gameState = state;
       try { window.applyGameState(state); } catch {}
+      try { flushManaStealFx(gameState, { addLog: window.addLog }); } catch {}
       lastDigest = digest(state);
       // Сразу обновим руку, чтобы скрыть добранные карты до анимации
       try { updateHand(); } catch {}

--- a/src/scene/manaStealFx.js
+++ b/src/scene/manaStealFx.js
@@ -1,0 +1,30 @@
+// Вспомогательные функции для воспроизведения визуальных эффектов кражи маны
+import { consumeManaStealEvents } from '../core/abilityHandlers/manaSteal.js';
+
+export function flushManaStealFx(state, opts = {}) {
+  try {
+    if (!state) return [];
+    const events = consumeManaStealEvents(state);
+    if (!Array.isArray(events) || !events.length) return [];
+    const addLog = typeof opts.addLog === 'function' ? opts.addLog : null;
+    const animator = (typeof window !== 'undefined')
+      ? (window.animateManaSteal || window.__ui?.mana?.animateManaSteal)
+      : null;
+    for (const ev of events) {
+      if (ev?.log && addLog) {
+        addLog(ev.log);
+      }
+    }
+    if (typeof animator === 'function') {
+      events.forEach((event, idx) => {
+        try { animator(event, idx); } catch (err) { console.warn('[manaStealFx] анимация не выполнена', err); }
+      });
+    }
+    return events;
+  } catch (err) {
+    console.warn('[manaStealFx] не удалось обработать события кражи маны', err);
+    return [];
+  }
+}
+
+export default { flushManaStealFx };

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -10,6 +10,10 @@ import { discardHandCard } from '../scene/discard.js';
 import { computeFieldquakeLockedCells } from '../core/fieldLocks.js';
 import { refreshPossessionsUI } from '../ui/possessions.js';
 import { applyDeathDiscardEffects } from '../core/abilityHandlers/discard.js';
+import { applyDeathManaSteal } from '../core/abilityHandlers/manaSteal.js';
+import { applyDeathRepositionEffects } from '../core/abilityHandlers/deathReposition.js';
+import { createDeathEntry } from '../core/utils/deaths.js';
+import { flushManaStealFx } from '../scene/manaStealFx.js';
 
 // Общая реализация ритуала Holy Feast
 function runHolyFeast({ tpl, pl, idx, cardMesh, tileMesh }) {
@@ -268,9 +272,9 @@ export const handlers = {
           if (tMesh) window.__fx.spawnDamageText(tMesh, `-1`, '#ef4444');
         } catch {}
         if (u.currentHP <= 0) {
+          const deathEntry = createDeathEntry(gameState, u, r, c);
+          const deathInfo = deathEntry ? [deathEntry] : [];
           const owner = u.owner;
-          const deathElement = gameState.board?.[r]?.[c]?.element || null;
-          const deathInfo = [{ r, c, owner, tplId: u.tplId, uid: u.uid ?? null, element: deathElement }];
           try { gameState.players[owner].graveyard.push(CARDS[u.tplId]); } catch {}
           const pos = getCtx().tileMeshes[r][c].position.clone().add(new THREE.Vector3(0, 1.2, 0));
           const slot = gameState.players?.[owner]?.mana || 0;
@@ -288,6 +292,21 @@ export const handlers = {
             for (const text of discardEffects.logs) {
               addLog(text);
             }
+          }
+          if (deathInfo.length) {
+            const reposition = applyDeathRepositionEffects(gameState, deathInfo);
+            if (Array.isArray(reposition?.logs)) {
+              for (const text of reposition.logs) {
+                if (text) addLog(text);
+              }
+            }
+            const manaStealEvents = applyDeathManaSteal(gameState, deathInfo, { cause: 'SPELL' });
+            if (Array.isArray(manaStealEvents)) {
+              for (const ev of manaStealEvents) {
+                if (ev?.log) addLog(ev.log);
+              }
+            }
+            flushManaStealFx(gameState, { addLog });
           }
           setTimeout(() => {
             refreshPossessionsUI(gameState);
@@ -392,8 +411,8 @@ export const handlers = {
               deltaHp > 0 ? '#22c55e' : '#ef4444'
             );
           if (u.currentHP <= 0) {
-            const deathElement = gameState.board?.[r]?.[c]?.element || null;
-            const deathInfo = [{ r, c, owner: u.owner, tplId: u.tplId, uid: u.uid ?? null, element: deathElement }];
+            const deathEntry = createDeathEntry(gameState, u, r, c);
+            const deathInfo = deathEntry ? [deathEntry] : [];
             try { gameState.players[u.owner].graveyard.push(CARDS[u.tplId]); } catch {}
             const deadMesh = unitMeshes.find(m => m.userData.row === r && m.userData.col === c);
             if (deadMesh) {
@@ -403,6 +422,21 @@ export const handlers = {
               if (Array.isArray(discardEffects.logs) && discardEffects.logs.length) {
                 for (const text of discardEffects.logs) addLog(text);
               }
+              if (deathInfo.length) {
+                const reposition = applyDeathRepositionEffects(gameState, deathInfo);
+                if (Array.isArray(reposition?.logs)) {
+                  for (const text of reposition.logs) {
+                    if (text) addLog(text);
+                  }
+                }
+              const manaStealEvents = applyDeathManaSteal(gameState, deathInfo, { cause: 'SPELL' });
+              if (Array.isArray(manaStealEvents)) {
+                for (const ev of manaStealEvents) {
+                  if (ev?.log) addLog(ev.log);
+                }
+              }
+              flushManaStealFx(gameState, { addLog });
+            }
               setTimeout(() => {
                 refreshPossessionsUI(gameState);
                 updateUnits();

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -20,6 +20,7 @@ import {
   showOracleDeathBuff,
   hasPendingForcedDiscards,
 } from '../scene/interactions.js';
+import { flushManaStealFx } from '../scene/manaStealFx.js';
 
 export function rotateUnit(unitMesh, dir) {
   try {
@@ -301,6 +302,7 @@ export function performUnitAbility(unitMesh, actionId) {
     w.updateHand?.(gameState);
     w.updateUnits?.(gameState);
     w.updateUI?.(gameState);
+    flushManaStealFx(gameState, { addLog: w.addLog });
   } catch (err) {
     console.error('[performUnitAbility]', err);
   }
@@ -412,6 +414,7 @@ export function confirmUnitAbilityOrientation(context, direction) {
     w.updateHand?.(gameState);
     w.updateUnits?.(gameState);
     w.updateUI?.(gameState);
+    flushManaStealFx(gameState, { addLog: w.addLog });
   } catch (err) {
     console.error('[confirmUnitAbilityOrientation]', err);
   }

--- a/src/ui/mana.js
+++ b/src/ui/mana.js
@@ -717,7 +717,153 @@ export function animateTurnManaGain(ownerIndex, beforeMana, afterMana, durationM
   });
 }
 
-const api = { renderBars, animateManaGainFromWorld, animateTurnManaGain };
+export function animateManaSteal(event) {
+  try {
+    if (!event) return;
+    const amountRaw = Number(event.amount || event.count || 0);
+    const amount = Math.max(0, Math.floor(amountRaw));
+    const fromIndex = Number.isInteger(event.from) ? event.from : null;
+    const toIndex = Number.isInteger(event.to) ? event.to : null;
+    if (amount <= 0 || fromIndex == null || toIndex == null) return;
+    const fromBar = document.getElementById(`mana-display-${fromIndex}`);
+    const toBar = document.getElementById(`mana-display-${toIndex}`);
+    if (!fromBar || !toBar) return;
+
+    const beforeFrom = Number.isFinite(event?.before?.fromMana)
+      ? event.before.fromMana
+      : (Number(event?.after?.fromMana) || 0) + amount;
+    const beforeTo = Number.isFinite(event?.before?.toMana)
+      ? event.before.toMana
+      : Math.max(0, (Number(event?.after?.toMana) || 0) - amount);
+    const afterTo = Number.isFinite(event?.after?.toMana)
+      ? event.after.toMana
+      : Math.min(10, beforeTo + amount);
+
+    const fromSlots = [];
+    for (let i = 0; i < amount; i += 1) {
+      fromSlots.push(Math.max(0, Math.min(9, beforeFrom - 1 - i)));
+    }
+    const newSlots = [];
+    for (let idx = beforeTo; idx < afterTo; idx += 1) {
+      newSlots.push(Math.max(0, Math.min(9, idx)));
+    }
+    while (newSlots.length < amount) {
+      const fallback = newSlots.length ? newSlots[newSlots.length - 1] : Math.max(0, Math.min(9, afterTo - 1));
+      newSlots.push(fallback);
+    }
+
+    const getSlotRect = (barEl, idx) => {
+      if (!barEl) return null;
+      const child = barEl.children?.[idx];
+      if (child) return child.getBoundingClientRect();
+      if (barEl.children && barEl.children.length) {
+        const last = barEl.children[Math.min(idx, barEl.children.length - 1)];
+        if (last) return last.getBoundingClientRect();
+      }
+      return barEl.getBoundingClientRect();
+    };
+
+    const spawnSteal = (fromIdx, toIdx, delayMs) => {
+      const fromRect = getSlotRect(fromBar, fromIdx);
+      if (!fromRect) return;
+      const orb = document.createElement('div');
+      orb.className = 'mana-orb--steal-fx';
+      orb.style.position = 'fixed';
+      orb.style.left = `${fromRect.left + fromRect.width / 2}px`;
+      orb.style.top = `${fromRect.top + fromRect.height / 2}px`;
+      orb.style.transform = 'translate(-50%, -50%) scale(0.9)';
+      orb.style.opacity = '0';
+      orb.style.zIndex = '90';
+      document.body.appendChild(orb);
+
+      const ensureTargetVisible = () => {
+        const targetEl = toBar.children?.[toIdx];
+        if (targetEl) {
+          targetEl.style.transition = 'opacity 220ms ease';
+          targetEl.style.opacity = '1';
+        }
+      };
+
+      const playArrival = () => {
+        const targetRect = getSlotRect(toBar, toIdx);
+        if (!targetRect) { ensureTargetVisible(); return; }
+        const spark = document.createElement('div');
+        spark.className = 'mana-orb--steal-gain';
+        spark.style.position = 'fixed';
+        spark.style.left = `${targetRect.left + targetRect.width / 2}px`;
+        spark.style.top = `${targetRect.top + targetRect.height / 2}px`;
+        spark.style.transform = 'translate(-50%, -50%) scale(0.4)';
+        spark.style.opacity = '0';
+        spark.style.zIndex = '92';
+        document.body.appendChild(spark);
+        const tlGain = window.gsap?.timeline({
+          onComplete: () => {
+            try { if (spark.parentNode) spark.parentNode.removeChild(spark); } catch {}
+            ensureTargetVisible();
+          },
+        });
+        if (tlGain) {
+          tlGain.to(spark, { duration: 0.15, opacity: 1, scale: 0.9, ease: 'power1.out' })
+            .to(spark, { duration: 0.32, opacity: 0, scale: 1.2, ease: 'power2.in' }, '>-0.05');
+        } else {
+          spark.style.transition = 'opacity 180ms ease, transform 180ms ease';
+          requestAnimationFrame(() => {
+            spark.style.opacity = '1';
+            spark.style.transform = 'translate(-50%, -50%) scale(0.9)';
+            setTimeout(() => {
+              spark.style.opacity = '0';
+              spark.style.transform = 'translate(-50%, -50%) scale(1.2)';
+              setTimeout(() => {
+                try { if (spark.parentNode) spark.parentNode.removeChild(spark); } catch {}
+                ensureTargetVisible();
+              }, 200);
+            }, 200);
+          });
+        }
+      };
+
+      const targetEl = toBar.children?.[toIdx];
+      if (targetEl) {
+        targetEl.style.opacity = '0';
+      }
+
+      const cleanup = () => {
+        try { if (orb.parentNode) orb.parentNode.removeChild(orb); } catch {}
+        playArrival();
+      };
+
+      const tl = window.gsap?.timeline({ delay: Math.max(0, delayMs) / 1000, onComplete: cleanup });
+      if (tl) {
+        tl.to(orb, { duration: 0.2, opacity: 1, scale: 1.05, ease: 'power2.out' })
+          .to(orb, { duration: 0.36, y: '-32', ease: 'power1.out' }, '>-0.06')
+          .to(orb, { duration: 0.28, opacity: 0, scale: 0.6, ease: 'power2.in' }, '>-0.2');
+      } else {
+        setTimeout(() => {
+          orb.style.transition = 'transform 260ms ease, opacity 260ms ease';
+          requestAnimationFrame(() => {
+            orb.style.opacity = '1';
+            orb.style.transform = 'translate(-50%, -80%) scale(1.05)';
+            setTimeout(() => {
+              orb.style.opacity = '0';
+              orb.style.transform = 'translate(-50%, -110%) scale(0.6)';
+              setTimeout(cleanup, 260);
+            }, 200);
+          });
+        }, Math.max(0, delayMs));
+      }
+    };
+
+    for (let i = 0; i < amount; i += 1) {
+      const fromIdx = fromSlots[i] ?? fromSlots[fromSlots.length - 1] ?? 0;
+      const toIdx = newSlots[i] ?? newSlots[newSlots.length - 1] ?? 0;
+      spawnSteal(fromIdx, toIdx, i * 140);
+    }
+  } catch (err) {
+    console.warn('[mana] animateManaSteal failed', err);
+  }
+}
+
+const api = { renderBars, animateManaGainFromWorld, animateTurnManaGain, animateManaSteal };
 try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.mana = api; } } catch {}
 export default api;
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -5,16 +5,32 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 
 /* Мана орбы */
 .mana-bar { display: flex; gap: 6px; align-items: center; }
-.mana-orb { 
-  width: 18px; height: 18px; border-radius: 50%; 
-  background: radial-gradient(circle at 30% 30%, #fff, #8bd5ff 30%, #1ea0ff 70%, #0a67b7); 
-  box-shadow: 0 0 10px rgba(30,160,255,0.8); 
+.mana-orb {
+  width: 18px; height: 18px; border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #fff, #8bd5ff 30%, #1ea0ff 70%, #0a67b7);
+  box-shadow: 0 0 10px rgba(30,160,255,0.8);
 }
-.mana-slot { 
-  width: 18px; height: 18px; border-radius: 50%; 
-  border: 1px solid rgba(255,255,255,0.25); 
-  background: rgba(255,255,255,0.06); 
-  box-shadow: inset 0 2px 6px rgba(0,0,0,0.5); 
+.mana-orb--steal-fx {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  pointer-events: none;
+  background: radial-gradient(circle at 30% 30%, #f8fafc, #60a5fa 45%, #2563eb 75%, rgba(37,99,235,0.1));
+  box-shadow: 0 0 12px rgba(59,130,246,0.65);
+}
+.mana-orb--steal-gain {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  pointer-events: none;
+  background: radial-gradient(circle at 40% 40%, rgba(191,219,254,0.9), rgba(59,130,246,0.85) 55%, rgba(30,64,175,0.6));
+  box-shadow: 0 0 18px rgba(96,165,250,0.75);
+}
+.mana-slot {
+  width: 18px; height: 18px; border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.25);
+  background: rgba(255,255,255,0.06);
+  box-shadow: inset 0 2px 6px rgba(0,0,0,0.5);
 }
 /* Кнопка завершения хода с круговым таймером **/ 
 .end-turn-btn { 

--- a/tests/manaSteal.test.js
+++ b/tests/manaSteal.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applySummonManaSteal,
+  applyDeathManaSteal,
+  consumeManaStealEvents,
+} from '../src/core/abilityHandlers/manaSteal.js';
+
+function makeState() {
+  return {
+    board: Array.from({ length: 3 }, () => Array.from({ length: 3 }, () => ({ element: 'NEUTRAL', unit: null }))),
+    players: [
+      { mana: 5 },
+      { mana: 7 },
+    ],
+  };
+}
+
+describe('логика кражи маны', () => {
+  it('Moving Isle of Kadena крадёт ману при призыве на чужой элемент', () => {
+    const state = makeState();
+    state.board[0][0].element = 'WATER';
+    state.board[1][1].element = 'WATER';
+    state.board[2][2].element = 'WATER';
+    const tpl = {
+      id: 'WATER_MOVING_ISLE_OF_KADENA',
+      manaSteal: {
+        onSummon: {
+          amount: { type: 'FIELD_COUNT', element: 'WATER' },
+          forbidFieldElement: 'WATER',
+        },
+      },
+    };
+    const unit = { owner: 0, tplId: tpl.id };
+    const cell = { element: 'EARTH' };
+    const events = applySummonManaSteal(state, { tpl, unit, cell, r: 1, c: 0 });
+    expect(events).toHaveLength(1);
+    expect(state.players[1].mana).toBe(4);
+    expect(state.players[0].mana).toBe(8);
+    const [event] = consumeManaStealEvents(state);
+    expect(event.amount).toBe(3);
+    expect(event.from).toBe(1);
+    expect(event.to).toBe(0);
+  });
+
+  it("Queen's Servant крадёт 1 ману при смерти", () => {
+    const state = makeState();
+    const deathEntry = {
+      r: 1,
+      c: 1,
+      owner: 0,
+      tplId: 'WATER_QUEENS_SERVANT',
+      element: 'WATER',
+    };
+    const events = applyDeathManaSteal(state, [deathEntry], { cause: 'TEST' });
+    expect(events).toHaveLength(1);
+    expect(state.players[1].mana).toBe(6);
+    expect(state.players[0].mana).toBe(6);
+    const [event] = consumeManaStealEvents(state);
+    expect(event.amount).toBe(1);
+    expect(event.reason).toBe('TEST');
+  });
+
+  it('Dancing Temptress крадёт ману у владельца существа перед ней', () => {
+    const state = makeState();
+    state.players[1].mana = 3;
+    const deathEntry = {
+      r: 1,
+      c: 1,
+      owner: 0,
+      tplId: 'WATER_DANCING_TEMPTRESS',
+      element: 'NEUTRAL',
+      frontOwner: 1,
+    };
+    const events = applyDeathManaSteal(state, [deathEntry], { cause: 'BATTLE' });
+    expect(events).toHaveLength(1);
+    expect(state.players[1].mana).toBe(2);
+    expect(state.players[0].mana).toBe(6);
+    const [event] = consumeManaStealEvents(state);
+    expect(event.from).toBe(1);
+    expect(event.to).toBe(0);
+    expect(event.amount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- реализовал модуль кражи маны и утилиты для описания смерти/перемещений существ
- добавил новые карты Water Moving Isle of Kadena, Queen's Servant и Dancing Temptress с эффектами кражи маны
- интегрировал механику в правила, интерфейс и анимацию, а также покрыл тестами

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7ccc7a5dc8330915c6fe4056348c3