### PR TITLE
Add Biolith fieldquake units

### DIFF
--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -51,6 +51,12 @@ import {
   describeFieldFatality as describeFieldFatalityInternal,
   evaluateFieldFatality as evaluateFieldFatalityInternal,
 } from './abilityHandlers/fieldHazards.js';
+import {
+  applyFieldquakeToCell,
+  normalizeFieldquakeOnSummonConfig,
+  normalizeFieldquakeOnDamageConfig,
+} from './abilityHandlers/fieldquake.js';
+import { createDeathEntry } from './abilityHandlers/deathRecords.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -327,6 +333,19 @@ export function collectDamageInteractions(state, context = {}) {
   const { attackerPos, attackerUnit, tpl, hits } = context;
   if (!tpl || !attackerUnit || !Array.isArray(hits) || !hits.length) return result;
 
+  const fieldquakeCfg = normalizeFieldquakeOnDamageConfig(tpl.fieldquakeOnDamage);
+  const attackerCellElement = (typeof attackerPos?.r === 'number' && typeof attackerPos?.c === 'number')
+    ? (state.board?.[attackerPos.r]?.[attackerPos.c]?.element || null)
+    : null;
+  const fieldquakeTargets = new Set();
+
+  const attackerRef = {
+    uid: getUnitUid(attackerUnit),
+    r: attackerPos?.r,
+    c: attackerPos?.c,
+    tplId: tpl.id,
+  };
+
   const processed = [];
   for (const h of hits) {
     if (!h) continue;
@@ -336,9 +355,27 @@ export function collectDamageInteractions(state, context = {}) {
     const target = cell?.unit;
     if (!target) continue;
     const tplTarget = getUnitTemplate(target);
+    const key = `${h.r},${h.c}`;
+    if (
+      fieldquakeCfg
+      && dealt > 0
+      && !fieldquakeTargets.has(key)
+      && (fieldquakeCfg.requireAttackerElement ? attackerCellElement === fieldquakeCfg.requireAttackerElement : true)
+      && (fieldquakeCfg.requireAttackerNotElement ? attackerCellElement !== fieldquakeCfg.requireAttackerNotElement : true)
+    ) {
+      result.events.push({
+        type: 'FIELDQUAKE',
+        target: { r: h.r, c: h.c },
+        source: attackerRef,
+        config: fieldquakeCfg,
+      });
+      if (fieldquakeCfg.preventRetaliation !== false) {
+        result.preventRetaliation.add(key);
+      }
+      fieldquakeTargets.add(key);
+    }
     const alive = (target.currentHP ?? tplTarget?.hp ?? 0) > 0;
     if (!alive) continue;
-    const key = `${h.r},${h.c}`;
     processed.push({
       r: h.r,
       c: h.c,
@@ -359,13 +396,6 @@ export function collectDamageInteractions(state, context = {}) {
   if (!processed.length) {
     return result;
   }
-
-  const attackerRef = {
-    uid: getUnitUid(attackerUnit),
-    r: attackerPos?.r,
-    c: attackerPos?.c,
-    tplId: tpl.id,
-  };
 
   const reposition = collectRepositionOnDamage(state, {
     attackerRef,
@@ -504,6 +534,37 @@ export function applyDamageInteractionResults(state, effects = {}) {
       const hazard = applyFieldFatalityCheckInternal(state.board[to.r][to.c]?.unit, tplTarget, toElement);
       const fatalLog = describeFieldFatalityInternal(tplTarget, hazard, { name: targetName });
       if (fatalLog) logs.push(fatalLog);
+    } else if (ev?.type === 'FIELDQUAKE') {
+      const tr = Number(ev.target?.r);
+      const tc = Number(ev.target?.c);
+      if (!Number.isInteger(tr) || !Number.isInteger(tc)) continue;
+      const fq = applyFieldquakeToCell(state, tr, tc, { respectLocks: ev.config?.respectLocks !== false });
+      if (!fq?.changed) {
+        if (fq?.reason === 'LOCKED') {
+          logs.push('Fieldquake предотвращён защитой поля.');
+        }
+        continue;
+      }
+      const prev = fq.prevElement || 'UNKNOWN';
+      const next = fq.nextElement || prev;
+      logs.push(`Fieldquake: ${prev}→${next} на (${tr},${tc}).`);
+      const unit = state.board?.[tr]?.[tc]?.unit;
+      const tplUnit = unit ? CARDS[unit.tplId] : null;
+      if (unit && tplUnit && fq.hpShift?.deltaHp) {
+        const delta = fq.hpShift.deltaHp;
+        const before = fq.hpShift.beforeHp;
+        const after = fq.hpShift.afterHp;
+        const name = tplUnit.name || 'Цель';
+        if (delta > 0) {
+          logs.push(`${name} усиливается на поле ${next}: HP ${before}→${after}.`);
+        } else if (delta < 0) {
+          logs.push(`${name} теряет силу на поле ${next}: HP ${before}→${after}.`);
+        }
+      }
+      if (unit && tplUnit && fq.fatality?.dies) {
+        const fatalLog = describeFieldFatalityInternal(tplUnit, fq.fatality, { name: tplUnit.name || 'Цель' });
+        if (fatalLog) logs.push(fatalLog);
+      }
     }
   }
 
@@ -659,6 +720,92 @@ export function applySummonAbilities(state, r, c) {
   if (!cell || !unit) return events;
   const tpl = getUnitTemplate(unit);
   if (!tpl) return events;
+
+  const fieldquakeSummonCfg = normalizeFieldquakeOnSummonConfig(tpl.fieldquakeOnSummon);
+  if (fieldquakeSummonCfg) {
+    const coords = new Set();
+    const addPos = (rr, cc) => {
+      if (!inBounds(rr, cc)) return;
+      coords.add(`${rr},${cc}`);
+    };
+    if (Array.isArray(fieldquakeSummonCfg.cells) && fieldquakeSummonCfg.cells.length) {
+      for (const pos of fieldquakeSummonCfg.cells) {
+        if (Number.isInteger(pos?.r) && Number.isInteger(pos?.c)) addPos(pos.r, pos.c);
+      }
+    } else {
+      const pattern = fieldquakeSummonCfg.pattern || 'ADJACENT';
+      if (pattern === 'ALL') {
+        for (let rr = 0; rr < 3; rr += 1) {
+          for (let cc = 0; cc < 3; cc += 1) {
+            if (rr === r && cc === c) continue;
+            addPos(rr, cc);
+          }
+        }
+      } else if (pattern === 'SELF') {
+        addPos(r, c);
+      } else if (pattern === 'FRONT') {
+        const facing = unit.facing || 'N';
+        const vectors = { N: [-1, 0], S: [1, 0], E: [0, 1], W: [0, -1] };
+        const vec = vectors[facing] || vectors.N;
+        addPos(r + vec[0], c + vec[1]);
+      } else {
+        const dirs = [ [-1, 0], [1, 0], [0, -1], [0, 1] ];
+        for (const [dr, dc] of dirs) addPos(r + dr, c + dc);
+      }
+    }
+    const deaths = [];
+    for (const key of coords) {
+      const [rr, cc] = key.split(',').map(Number);
+      const fq = applyFieldquakeToCell(state, rr, cc, { respectLocks: fieldquakeSummonCfg.respectLocks !== false });
+      if (!fq?.changed) continue;
+      events.fieldquakes = [...(events.fieldquakes || []), {
+        r: fq.r,
+        c: fq.c,
+        prevElement: fq.prevElement,
+        nextElement: fq.nextElement,
+        source: { tplId: tpl.id, owner: unit.owner },
+      }];
+      const prevLabel = fq.prevElement || 'UNKNOWN';
+      const nextLabel = fq.nextElement || prevLabel;
+      events.logs = [...(events.logs || []), `${tpl.name}: fieldquake ${prevLabel}→${nextLabel} на (${fq.r},${fq.c}).`];
+      if (fq.hpShift?.deltaHp && fq.unit && fq.tpl?.name) {
+        const delta = fq.hpShift.deltaHp;
+        if (delta > 0) {
+          events.logs.push(`${fq.tpl.name} усиливается на поле ${nextLabel}: HP ${fq.hpShift.beforeHp}→${fq.hpShift.afterHp}.`);
+        } else if (delta < 0) {
+          events.logs.push(`${fq.tpl.name} теряет силу на поле ${nextLabel}: HP ${fq.hpShift.beforeHp}→${fq.hpShift.afterHp}.`);
+        }
+      }
+      if (fq.fatality?.dies && fq.tpl?.name) {
+        const fatalLog = describeFieldFatalityInternal(fq.tpl, fq.fatality, { name: fq.tpl.name });
+        if (fatalLog) events.logs.push(fatalLog);
+      }
+      if (fq.unitDied) {
+        const cellRef = state.board?.[rr]?.[cc] || null;
+        const unitRef = cellRef?.unit || null;
+        if (unitRef) {
+          const deathEntry = createDeathEntry(state, unitRef, rr, cc) || {
+            r: rr,
+            c: cc,
+            owner: unitRef.owner,
+            tplId: unitRef.tplId,
+            uid: unitRef.uid ?? null,
+            element: cellRef?.element || null,
+          };
+          deaths.push(deathEntry);
+          try {
+            if (state.players?.[unitRef.owner]?.graveyard) {
+              state.players[unitRef.owner].graveyard.push(CARDS[unitRef.tplId]);
+            }
+          } catch {}
+          cellRef.unit = null;
+        }
+      }
+    }
+    if (deaths.length) {
+      events.deaths = [...(events.deaths || []), ...deaths];
+    }
+  }
 
   const summonBuffs = applySummonStatBuffs(state, r, c);
   if (Array.isArray(summonBuffs?.logs) && summonBuffs.logs.length) {

--- a/src/core/abilityHandlers/fieldquake.js
+++ b/src/core/abilityHandlers/fieldquake.js
@@ -1,0 +1,151 @@
+// Обработка эффектов fieldquake без привязки к визуальному слою
+import { computeFieldquakeLockedCells } from '../fieldLocks.js';
+import { CARDS } from '../cards.js';
+import { getOppositeElement, applyFieldTransitionToUnit } from '../fieldEffects.js';
+import { applyFieldFatalityCheck } from './fieldHazards.js';
+
+const BOARD_SIZE = 3;
+
+function inBounds(r, c) {
+  return r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE;
+}
+
+function buildLockedSet(state) {
+  const locked = computeFieldquakeLockedCells(state);
+  const set = new Set();
+  for (const cell of locked) {
+    if (!cell) continue;
+    const key = `${cell.r},${cell.c}`;
+    set.add(key);
+  }
+  return set;
+}
+
+export function canFieldquakeCell(state, r, c, opts = {}) {
+  if (!state?.board) return { ok: false, reason: 'NO_BOARD' };
+  if (!inBounds(r, c)) return { ok: false, reason: 'OUT_OF_BOUNDS' };
+  const cell = state.board?.[r]?.[c];
+  if (!cell) return { ok: false, reason: 'NO_CELL' };
+  const prevElement = cell.element || null;
+  if (!prevElement) return { ok: false, reason: 'NO_ELEMENT', prevElement };
+  if (prevElement === 'BIOLITH') {
+    return { ok: false, reason: 'BIOLITH', prevElement };
+  }
+  const respectLocks = opts.respectLocks !== false;
+  if (respectLocks) {
+    const lockedSet = Array.isArray(opts.locked)
+      ? new Set(opts.locked.map(p => `${p.r},${p.c}`))
+      : (opts.lockedSet instanceof Set ? opts.lockedSet : buildLockedSet(state));
+    const key = `${r},${c}`;
+    if (lockedSet.has(key)) {
+      return { ok: false, reason: 'LOCKED', prevElement };
+    }
+  }
+  const nextElement = getOppositeElement(prevElement);
+  if (!nextElement || nextElement === prevElement) {
+    return { ok: false, reason: 'NO_CHANGE', prevElement };
+  }
+  return { ok: true, prevElement, nextElement };
+}
+
+export function applyFieldquakeToCell(state, r, c, opts = {}) {
+  if (!state?.board) return null;
+  if (!inBounds(r, c)) return null;
+  const lockedSet = opts.lockedSet instanceof Set ? opts.lockedSet : null;
+  const check = canFieldquakeCell(state, r, c, {
+    respectLocks: opts.respectLocks !== false,
+    lockedSet,
+  });
+  if (!check.ok) {
+    return { changed: false, reason: check.reason, prevElement: check.prevElement ?? null };
+  }
+  const cell = state.board[r][c];
+  const prevElement = check.prevElement;
+  const nextElement = check.nextElement;
+  cell.element = nextElement;
+
+  const unit = cell.unit || null;
+  const tpl = unit ? CARDS[unit.tplId] : null;
+  let hpShift = null;
+  let fatality = null;
+  if (unit && tpl) {
+    hpShift = applyFieldTransitionToUnit(unit, tpl, prevElement, nextElement);
+    fatality = applyFieldFatalityCheck(unit, tpl, nextElement);
+  }
+
+  const unitDied = !!(unit && ((unit.currentHP ?? tpl?.hp ?? 0) <= 0));
+
+  return {
+    changed: true,
+    r,
+    c,
+    prevElement,
+    nextElement,
+    unit,
+    tpl,
+    hpShift,
+    fatality,
+    unitDied,
+  };
+}
+
+export function normalizeFieldquakeOnSummonConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return { pattern: 'ADJACENT', respectLocks: true };
+  }
+  if (typeof raw === 'string') {
+    return { pattern: raw.toUpperCase(), respectLocks: true };
+  }
+  if (typeof raw === 'object') {
+    const cfg = {
+      pattern: typeof raw.pattern === 'string' ? raw.pattern.toUpperCase() : 'ADJACENT',
+      respectLocks: raw.respectLocks !== false,
+    };
+    if (raw.cells && Array.isArray(raw.cells)) {
+      cfg.cells = raw.cells
+        .map(pos => ({ r: Number(pos.r), c: Number(pos.c) }))
+        .filter(pos => Number.isInteger(pos.r) && Number.isInteger(pos.c));
+    }
+    return cfg;
+  }
+  return null;
+}
+
+export function normalizeFieldquakeOnDamageConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return {
+      respectLocks: true,
+      preventRetaliation: true,
+    };
+  }
+  if (typeof raw === 'object') {
+    const cfg = {
+      respectLocks: raw.respectLocks !== false,
+      preventRetaliation: raw.preventRetaliation !== false,
+    };
+    if (raw.requireAttackerNotElement) {
+      cfg.requireAttackerNotElement = String(raw.requireAttackerNotElement).toUpperCase();
+    }
+    if (raw.requireAttackerElement) {
+      cfg.requireAttackerElement = String(raw.requireAttackerElement).toUpperCase();
+    }
+    return cfg;
+  }
+  if (typeof raw === 'string') {
+    return {
+      respectLocks: true,
+      preventRetaliation: true,
+      requireAttackerNotElement: raw.toUpperCase(),
+    };
+  }
+  return null;
+}
+
+export default {
+  canFieldquakeCell,
+  applyFieldquakeToCell,
+  normalizeFieldquakeOnSummonConfig,
+  normalizeFieldquakeOnDamageConfig,
+};

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -540,6 +540,38 @@ export const CARDS = {
     desc: 'Incarnation. Phaseus’s Magic Attack targets all enemies. Destroy Phaseus if he is on a non-Biolith field.'
   },
 
+  BIOLITH_BEHEMOTH_GROUNDBREAKER: {
+    id: 'BIOLITH_BEHEMOTH_GROUNDBREAKER', name: 'Behemoth Groundbreaker', type: 'UNIT', cost: 4, activation: 3,
+    element: 'BIOLITH', atk: 1, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    fieldquakeOnSummon: { pattern: 'ADJACENT' },
+    desc: 'When Behemoth Groundbreaker is summoned, fieldquake all adjacent fields.'
+  },
+  BIOLITH_UNDEAD_KING_NOVOGUS: {
+    id: 'BIOLITH_UNDEAD_KING_NOVOGUS', name: 'Undead King Novogus', type: 'UNIT', cost: 6, activation: 3,
+    element: 'BIOLITH', atk: 2, hp: 6,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    fieldquakeOnDamage: { requireAttackerNotElement: 'EARTH', preventRetaliation: true },
+    desc: "Magic Attack. If Undead King Novogus is on a non-Earth field and damages a creature, fieldquake the target creature's field. The target creature cannot counterattack."
+  },
+  BIOLITH_OUROBOROS_DRAGON: {
+    id: 'BIOLITH_OUROBOROS_DRAGON', name: 'Ouroboros Dragon', type: 'UNIT', cost: 7, activation: 4,
+    element: 'BIOLITH', atk: 7, hp: 10,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY', ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    dynamicAtk: 'BIOLITH_CREATURES',
+    fieldquakeLock: { type: 'ALL', onlyWhileOnElement: 'BIOLITH' },
+    desc: "Ouroboros Dragon's Attack is equal to 7 plus the number of other Biolith creatures on the board. While Ouroboros Dragon is on a Biolith field, no field can be fieldquaked or exchanged."
+  },
+
   // Ninja cycle
   FIRE_FIREFLY_NINJA: {
     id: 'FIRE_FIREFLY_NINJA', name: 'Firefly Ninja', type: 'UNIT', cost: 3, activation: 2,

--- a/src/core/fieldEffects.js
+++ b/src/core/fieldEffects.js
@@ -12,6 +12,12 @@ const OPPOSITES = {
   FOREST: 'EARTH',
 };
 
+export function getOppositeElement(element) {
+  if (!element) return null;
+  const token = String(element).toUpperCase();
+  return OPPOSITES[token] || null;
+}
+
 export function computeCellBuff(cellElement, unitElement) {
   if (!cellElement || !unitElement) return { atk: 0, hp: 0 };
   if (cellElement === 'BIOLITH') return { atk: 0, hp: 0 };

--- a/src/core/fieldLocks.js
+++ b/src/core/fieldLocks.js
@@ -14,6 +14,15 @@ export function computeFieldquakeLockedCells(state) {
       const tpl = CARDS[unit.tplId];
       const lock = tpl?.fieldquakeLock;
       if (!lock) continue;
+      const requiredElement = lock.onlyWhileOnElement
+        ? String(lock.onlyWhileOnElement).toUpperCase()
+        : null;
+      if (requiredElement) {
+        const currentElement = state.board?.[r]?.[c]?.element || null;
+        if (currentElement !== requiredElement) {
+          continue;
+        }
+      }
       const add = (rr, cc) => {
         if (inBounds(rr, cc)) locked.add(`${rr},${cc}`);
       };

--- a/tests/fieldquake.test.js
+++ b/tests/fieldquake.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { CARDS } from '../src/core/cards.js';
+import {
+  applySummonAbilities,
+  collectDamageInteractions,
+  applyDamageInteractionResults,
+} from '../src/core/abilities.js';
+import { computeFieldquakeLockedCells } from '../src/core/fieldLocks.js';
+import { computeDynamicAttackBonus } from '../src/core/abilityHandlers/dynamicAttack.js';
+
+function makeBoard(defaultElement = 'FIRE') {
+  return Array.from({ length: 3 }, (_, r) => (
+    Array.from({ length: 3 }, (_, c) => ({
+      element: (r === 1 && c === 1) ? 'BIOLITH' : defaultElement,
+      unit: null,
+    }))
+  ));
+}
+
+describe('fieldquake-эффекты биолит-карт', () => {
+  it('Behemoth Groundbreaker меняет стихии соседних клеток при призыве', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [
+        { graveyard: [] },
+        { graveyard: [] },
+      ],
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[2][1].element = 'WATER';
+    state.board[1][0].element = 'FOREST';
+    state.board[1][2].element = 'EARTH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_BEHEMOTH_GROUNDBREAKER',
+      currentHP: 4,
+    };
+
+    const events = applySummonAbilities(state, 1, 1);
+
+    expect(state.board[0][1].element).toBe('WATER');
+    expect(state.board[2][1].element).toBe('FIRE');
+    expect(state.board[1][0].element).toBe('EARTH');
+    expect(state.board[1][2].element).toBe('FOREST');
+    expect(events.fieldquakes).toHaveLength(4);
+  });
+
+  it('Undead King Novogus вызывает fieldquake при уроне вне земли', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'FOREST';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const tpl = CARDS.BIOLITH_UNDEAD_KING_NOVOGUS;
+    const interactions = collectDamageInteractions(state, {
+      attackerPos: { r: 1, c: 1 },
+      attackerUnit: state.board[1][1].unit,
+      tpl,
+      hits: [ { r: 0, c: 1, dealt: 2 } ],
+    });
+
+    expect(interactions.events).toHaveLength(1);
+    expect(interactions.preventRetaliation.has('0,1')).toBe(true);
+
+    const applied = applyDamageInteractionResults(state, interactions);
+    expect(state.board[0][1].element).toBe('WATER');
+    expect(applied.logLines.some(line => line.includes('Fieldquake'))).toBe(true);
+  });
+
+  it('Novogus не срабатывает на земле', () => {
+    const state = {
+      board: makeBoard('EARTH'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'EARTH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const tpl = CARDS.BIOLITH_UNDEAD_KING_NOVOGUS;
+    const interactions = collectDamageInteractions(state, {
+      attackerPos: { r: 1, c: 1 },
+      attackerUnit: state.board[1][1].unit,
+      tpl,
+      hits: [ { r: 0, c: 1, dealt: 2 } ],
+    });
+
+    expect(interactions.events).toHaveLength(0);
+  });
+
+  it('Ouroboros Dragon получает бонус и блокирует fieldquake на биолите', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'BIOLITH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_OUROBOROS_DRAGON',
+      currentHP: 10,
+    };
+    state.board[0][0].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_MORNING_STAR_WARRIOR',
+      currentHP: 3,
+    };
+    state.board[2][2].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_BIOLITH_STINGER',
+      currentHP: 1,
+    };
+
+    const bonus = computeDynamicAttackBonus(state, 1, 1, CARDS.BIOLITH_OUROBOROS_DRAGON);
+    expect(bonus?.amount).toBe(2);
+
+    const locked = computeFieldquakeLockedCells(state);
+    expect(locked).toHaveLength(9);
+
+    state.board[1][1].element = 'FIRE';
+    const unlocked = computeFieldquakeLockedCells(state);
+    expect(unlocked.length).toBeLessThan(9);
+  });
+});


### PR DESCRIPTION
## Summary
- implement reusable fieldquake handler and wire it into summon and damage interactions
- add the Behemoth Groundbreaker, Undead King Novogus, and Ouroboros Dragon card definitions and behaviours
- extend field lock handling and cover the new mechanics with dedicated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7d3c5b868833095189062bb71be09