### PR TITLE
Integrate shared fieldquake effect module

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,6 +618,14 @@
           // Финализация: анимация смерти и орбы перед применением состояния
           const stateBeforeFinish = gameState ? JSON.parse(JSON.stringify(gameState)) : null;
           const res = staged.finish();
+          if (Array.isArray(res.fieldquakes) && res.fieldquakes.length) {
+            try {
+              window.__scene?.fieldquakeFx?.playFieldquakeFxBatch?.(res.fieldquakes, {
+                activeSeat: gameState.active,
+                skipDeathFx: true,
+              });
+            } catch {}
+          }
           const manaPlan = window.__scene?.manaFx?.buildManaGainPlan?.({
             playersBefore: stateBeforeFinish?.players || gameState.players,
             deaths: res.deaths || [],
@@ -756,6 +764,14 @@
       const res = magicAttack(gameState, from.r, from.c, tr, tc);
       if (!res) { showNotification('Incorrect target', 'error'); return; }
       const attackerPosMagic = res.attackerPosUpdate || from;
+      if (Array.isArray(res.fieldquakes) && res.fieldquakes.length) {
+        try {
+          window.__scene?.fieldquakeFx?.playFieldquakeFxBatch?.(res.fieldquakes, {
+            activeSeat: gameState.active,
+            skipDeathFx: true,
+          });
+        } catch {}
+      }
       for (const l of res.logLines.reverse()) addLog(l);
       const aMesh = unitMeshes.find(m => m.userData.row === from.r && m.userData.col === from.c);
       if (aMesh) { gsap.fromTo(aMesh.position, { y: aMesh.position.y }, { y: aMesh.position.y + 0.3, yoyo: true, repeat: 1, duration: 0.12 }); }

--- a/src/core/abilityHandlers/fieldquake.js
+++ b/src/core/abilityHandlers/fieldquake.js
@@ -1,0 +1,185 @@
+// Обработка эффектов fieldquake без привязки к визуальному слою
+import { computeFieldquakeLockedCells } from '../fieldLocks.js';
+import { CARDS } from '../cards.js';
+import { getOppositeElement, applyFieldTransitionToUnit } from '../fieldEffects.js';
+import { applyFieldFatalityCheck } from './fieldHazards.js';
+import { createDeathEntry } from './deathRecords.js';
+
+const BOARD_SIZE = 3;
+
+function inBounds(r, c) {
+  return r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE;
+}
+
+function buildLockedSet(state) {
+  const locked = computeFieldquakeLockedCells(state);
+  const set = new Set();
+  for (const cell of locked) {
+    if (!cell) continue;
+    const key = `${cell.r},${cell.c}`;
+    set.add(key);
+  }
+  return set;
+}
+
+export function canFieldquakeCell(state, r, c, opts = {}) {
+  if (!state?.board) return { ok: false, reason: 'NO_BOARD' };
+  if (!inBounds(r, c)) return { ok: false, reason: 'OUT_OF_BOUNDS' };
+  const cell = state.board?.[r]?.[c];
+  if (!cell) return { ok: false, reason: 'NO_CELL' };
+  const prevElement = cell.element || null;
+  if (!prevElement) return { ok: false, reason: 'NO_ELEMENT', prevElement };
+  if (prevElement === 'BIOLITH') {
+    return { ok: false, reason: 'BIOLITH', prevElement };
+  }
+  const respectLocks = opts.respectLocks !== false;
+  if (respectLocks) {
+    const lockedSet = Array.isArray(opts.locked)
+      ? new Set(opts.locked.map(p => `${p.r},${p.c}`))
+      : (opts.lockedSet instanceof Set ? opts.lockedSet : buildLockedSet(state));
+    const key = `${r},${c}`;
+    if (lockedSet.has(key)) {
+      return { ok: false, reason: 'LOCKED', prevElement };
+    }
+  }
+  const nextElement = getOppositeElement(prevElement);
+  if (!nextElement || nextElement === prevElement) {
+    return { ok: false, reason: 'NO_CHANGE', prevElement };
+  }
+  return { ok: true, prevElement, nextElement };
+}
+
+export function applyFieldquakeToCell(state, r, c, opts = {}) {
+  if (!state?.board) return null;
+  if (!inBounds(r, c)) return null;
+  const lockedSet = opts.lockedSet instanceof Set ? opts.lockedSet : null;
+  const check = canFieldquakeCell(state, r, c, {
+    respectLocks: opts.respectLocks !== false,
+    lockedSet,
+  });
+  if (!check.ok) {
+    return { changed: false, reason: check.reason, prevElement: check.prevElement ?? null };
+  }
+  const cell = state.board[r][c];
+  const prevElement = check.prevElement;
+  const nextElement = check.nextElement;
+  cell.element = nextElement;
+
+  const unit = cell.unit || null;
+  const tpl = unit ? CARDS[unit.tplId] : null;
+  let hpShift = null;
+  let fatality = null;
+  if (unit && tpl) {
+    hpShift = applyFieldTransitionToUnit(unit, tpl, prevElement, nextElement);
+    fatality = applyFieldFatalityCheck(unit, tpl, nextElement);
+  }
+
+  const unitDied = !!(unit && ((unit.currentHP ?? tpl?.hp ?? 0) <= 0));
+
+  return {
+    changed: true,
+    r,
+    c,
+    prevElement,
+    nextElement,
+    unit,
+    tpl,
+    hpShift,
+    fatality,
+    unitDied,
+  };
+}
+
+export function collectFieldquakeDeaths(state, outcomes, opts = {}) {
+  if (!state?.board) return [];
+  const list = Array.isArray(outcomes) ? outcomes : [outcomes];
+  const deaths = [];
+  const seen = new Set();
+  for (const res of list) {
+    if (!res?.unitDied) continue;
+    const rr = Number(res.r);
+    const cc = Number(res.c);
+    if (!Number.isInteger(rr) || !Number.isInteger(cc)) continue;
+    const key = `${rr},${cc}`;
+    if (seen.has(key)) continue;
+    const cell = state.board?.[rr]?.[cc];
+    const unit = cell?.unit;
+    if (!unit) continue;
+    const entry = createDeathEntry(state, unit, rr, cc) || {
+      r: rr,
+      c: cc,
+      owner: unit.owner,
+      tplId: unit.tplId,
+      uid: unit.uid ?? null,
+      element: cell?.element || null,
+    };
+    deaths.push(entry);
+    seen.add(key);
+    if (opts?.keepUnits !== true && cell) {
+      cell.unit = null;
+    }
+  }
+  return deaths;
+}
+
+export function normalizeFieldquakeOnSummonConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return { pattern: 'ADJACENT', respectLocks: true };
+  }
+  if (typeof raw === 'string') {
+    return { pattern: raw.toUpperCase(), respectLocks: true };
+  }
+  if (typeof raw === 'object') {
+    const cfg = {
+      pattern: typeof raw.pattern === 'string' ? raw.pattern.toUpperCase() : 'ADJACENT',
+      respectLocks: raw.respectLocks !== false,
+    };
+    if (raw.cells && Array.isArray(raw.cells)) {
+      cfg.cells = raw.cells
+        .map(pos => ({ r: Number(pos.r), c: Number(pos.c) }))
+        .filter(pos => Number.isInteger(pos.r) && Number.isInteger(pos.c));
+    }
+    return cfg;
+  }
+  return null;
+}
+
+export function normalizeFieldquakeOnDamageConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return {
+      respectLocks: true,
+      preventRetaliation: true,
+    };
+  }
+  if (typeof raw === 'object') {
+    const cfg = {
+      respectLocks: raw.respectLocks !== false,
+      preventRetaliation: raw.preventRetaliation !== false,
+    };
+    if (raw.requireAttackerNotElement) {
+      cfg.requireAttackerNotElement = String(raw.requireAttackerNotElement).toUpperCase();
+    }
+    if (raw.requireAttackerElement) {
+      cfg.requireAttackerElement = String(raw.requireAttackerElement).toUpperCase();
+    }
+    return cfg;
+  }
+  if (typeof raw === 'string') {
+    return {
+      respectLocks: true,
+      preventRetaliation: true,
+      requireAttackerNotElement: raw.toUpperCase(),
+    };
+  }
+  return null;
+}
+
+export default {
+  canFieldquakeCell,
+  applyFieldquakeToCell,
+  normalizeFieldquakeOnSummonConfig,
+  normalizeFieldquakeOnDamageConfig,
+  collectFieldquakeDeaths,
+};

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -540,6 +540,38 @@ export const CARDS = {
     desc: 'Incarnation. Phaseus’s Magic Attack targets all enemies. Destroy Phaseus if he is on a non-Biolith field.'
   },
 
+  BIOLITH_BEHEMOTH_GROUNDBREAKER: {
+    id: 'BIOLITH_BEHEMOTH_GROUNDBREAKER', name: 'Behemoth Groundbreaker', type: 'UNIT', cost: 4, activation: 3,
+    element: 'BIOLITH', atk: 1, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    fieldquakeOnSummon: { pattern: 'ADJACENT' },
+    desc: 'When Behemoth Groundbreaker is summoned, fieldquake all adjacent fields.'
+  },
+  BIOLITH_UNDEAD_KING_NOVOGUS: {
+    id: 'BIOLITH_UNDEAD_KING_NOVOGUS', name: 'Undead King Novogus', type: 'UNIT', cost: 6, activation: 3,
+    element: 'BIOLITH', atk: 2, hp: 6,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    fieldquakeOnDamage: { requireAttackerNotElement: 'EARTH', preventRetaliation: true },
+    desc: "Magic Attack. If Undead King Novogus is on a non-Earth field and damages a creature, fieldquake the target creature's field. The target creature cannot counterattack."
+  },
+  BIOLITH_OUROBOROS_DRAGON: {
+    id: 'BIOLITH_OUROBOROS_DRAGON', name: 'Ouroboros Dragon', type: 'UNIT', cost: 7, activation: 4,
+    element: 'BIOLITH', atk: 7, hp: 10,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY', ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    dynamicAtk: 'BIOLITH_CREATURES',
+    fieldquakeLock: { type: 'ALL', onlyWhileOnElement: 'BIOLITH' },
+    desc: "Ouroboros Dragon's Attack is equal to 7 plus the number of other Biolith creatures on the board. While Ouroboros Dragon is on a Biolith field, no field can be fieldquaked or exchanged."
+  },
+
   // Ninja cycle
   FIRE_FIREFLY_NINJA: {
     id: 'FIRE_FIREFLY_NINJA', name: 'Firefly Ninja', type: 'UNIT', cost: 3, activation: 2,

--- a/src/core/fieldEffects.js
+++ b/src/core/fieldEffects.js
@@ -12,6 +12,12 @@ const OPPOSITES = {
   FOREST: 'EARTH',
 };
 
+export function getOppositeElement(element) {
+  if (!element) return null;
+  const token = String(element).toUpperCase();
+  return OPPOSITES[token] || null;
+}
+
 export function computeCellBuff(cellElement, unitElement) {
   if (!cellElement || !unitElement) return { atk: 0, hp: 0 };
   if (cellElement === 'BIOLITH') return { atk: 0, hp: 0 };

--- a/src/core/fieldLocks.js
+++ b/src/core/fieldLocks.js
@@ -14,6 +14,15 @@ export function computeFieldquakeLockedCells(state) {
       const tpl = CARDS[unit.tplId];
       const lock = tpl?.fieldquakeLock;
       if (!lock) continue;
+      const requiredElement = lock.onlyWhileOnElement
+        ? String(lock.onlyWhileOnElement).toUpperCase()
+        : null;
+      if (requiredElement) {
+        const currentElement = state.board?.[r]?.[c]?.element || null;
+        if (currentElement !== requiredElement) {
+          continue;
+        }
+      }
       const add = (rr, cc) => {
         if (inBounds(rr, cc)) locked.add(`${rr},${cc}`);
       };

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -563,6 +563,8 @@ export function stagedAttack(state, r, c, opts = {}) {
 
     const applied = applyDamageInteractionResults(nFinal, damageEffects);
     const attackerPosUpdate = applied?.attackerPosUpdate || null;
+    const interactionDeaths = Array.isArray(applied?.deaths) ? applied.deaths.slice() : [];
+    const fieldquakeEvents = Array.isArray(applied?.fieldquakes) ? applied.fieldquakes.slice() : [];
     if (attackerPosUpdate) {
       r = attackerPosUpdate.r;
       c = attackerPosUpdate.c;
@@ -579,7 +581,10 @@ export function stagedAttack(state, r, c, opts = {}) {
       logLines.push(`Retaliation to ${CARDS[A.tplId]?.name || 'Attacker'}: ${ret.total || 0} (HP ${before}→${A.currentHP})`);
     }
 
-    const deaths = [];
+    const deaths = interactionDeaths.slice();
+    const seenDeathKeys = new Set(deaths.map(d => (d?.uid != null)
+      ? `UID:${d.uid}`
+      : `POS:${d?.r},${d?.c}`));
     for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
       const cellRef = nFinal.board?.[rr]?.[cc];
       const u = cellRef?.unit;
@@ -592,7 +597,11 @@ export function stagedAttack(state, r, c, opts = {}) {
           uid: u.uid ?? null,
           element: cellRef?.element || null,
         };
-        deaths.push(deathEntry);
+        const key = (deathEntry.uid != null) ? `UID:${deathEntry.uid}` : `POS:${deathEntry.r},${deathEntry.c}`;
+        if (!seenDeathKeys.has(key)) {
+          deaths.push(deathEntry);
+          seenDeathKeys.add(key);
+        }
         if (cellRef) cellRef.unit = null;
       }
     }
@@ -703,6 +712,7 @@ export function stagedAttack(state, r, c, opts = {}) {
       schemeKey,
       attackProfile: profile,
       manaGainEvents: Array.isArray(manaFromDeaths?.entries) ? manaFromDeaths.entries : [],
+      fieldquakes: fieldquakeEvents,
     };
   }
 
@@ -931,7 +941,21 @@ export function magicAttack(state, fr, fc, tr, tc) {
     }
   }
 
-  const deaths = [];
+  const applied = applyDamageInteractionResults(n1, damageEffects);
+  const attackerPosUpdate = applied?.attackerPosUpdate || null;
+  if (attackerPosUpdate) {
+    fromR = attackerPosUpdate.r;
+    fromC = attackerPosUpdate.c;
+  }
+  if (Array.isArray(applied?.logLines) && applied.logLines.length) {
+    logLines.push(...applied.logLines);
+  }
+  const interactionDeaths = Array.isArray(applied?.deaths) ? applied.deaths.slice() : [];
+  const fieldquakeEvents = Array.isArray(applied?.fieldquakes) ? applied.fieldquakes.slice() : [];
+  const deaths = interactionDeaths.slice();
+  const seenDeathKeys = new Set(deaths.map(d => (d?.uid != null)
+    ? `UID:${d.uid}`
+    : `POS:${d?.r},${d?.c}`));
   for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
     const cellRef = n1.board[rr][cc];
     const u = cellRef.unit;
@@ -944,7 +968,11 @@ export function magicAttack(state, fr, fc, tr, tc) {
         uid: u.uid ?? null,
         element: cellRef?.element || null,
       };
-      deaths.push(deathEntry);
+      const key = (deathEntry.uid != null) ? `UID:${deathEntry.uid}` : `POS:${deathEntry.r},${deathEntry.c}`;
+      if (!seenDeathKeys.has(key)) {
+        deaths.push(deathEntry);
+        seenDeathKeys.add(key);
+      }
       cellRef.unit = null;
     }
   }
@@ -986,15 +1014,6 @@ export function magicAttack(state, fr, fc, tr, tc) {
       logLines.push(`${name}: контроль возвращается к игроку ${rel.owner + 1}.`);
     }
   }
-  const applied = applyDamageInteractionResults(n1, damageEffects);
-  const attackerPosUpdate = applied?.attackerPosUpdate || null;
-  if (attackerPosUpdate) {
-    fromR = attackerPosUpdate.r;
-    fromC = attackerPosUpdate.c;
-  }
-  if (Array.isArray(applied?.logLines) && applied.logLines.length) {
-    logLines.push(...applied.logLines);
-  }
   const continuous = refreshContinuousPossessions(n1);
   if (continuous.possessions.length) {
     for (const ev of continuous.possessions) {
@@ -1034,6 +1053,7 @@ export function magicAttack(state, fr, fc, tr, tc) {
     attackProfile: profile,
     dmg,
     manaGainEvents: Array.isArray(manaFromDeaths?.entries) ? manaFromDeaths.entries : [],
+    fieldquakes: fieldquakeEvents,
   };
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import * as Units from './scene/units.js';
 import * as Hand from './scene/hand.js';
 import * as Interactions from './scene/interactions.js';
 import { getCtx as getSceneCtx } from './scene/context.js';
+import * as FieldquakeFx from './scene/fieldquakeFx.js';
 // UI modules
 import * as UINotifications from './ui/notifications.js';
 import * as UILog from './ui/log.js';
@@ -165,6 +166,7 @@ try {
     animate: sceneAnimate,
     getCtx: getSceneCtx,
     manaFx: ManaFx,
+    fieldquakeFx: FieldquakeFx,
   };
   window.__board = {
     createBoard: Board.createBoard,

--- a/src/scene/fieldquakeFx.js
+++ b/src/scene/fieldquakeFx.js
@@ -1,0 +1,101 @@
+// Визуальные эффекты для fieldquake, отделённые от игровой логики
+import { getCtx } from './context.js';
+import { getTileMaterial } from './board.js';
+
+function isInteger(value) {
+  return typeof value === 'number' && Number.isInteger(value);
+}
+
+function shouldBroadcast(activeSeat) {
+  if (typeof window === 'undefined') return false;
+  const online = typeof window.NET_ON === 'function' ? window.NET_ON() : !!window.NET_ACTIVE;
+  if (!online || !window.socket) return false;
+  const mySeat = typeof window.MY_SEAT === 'number' ? window.MY_SEAT : null;
+  const seatToCheck = typeof activeSeat === 'number'
+    ? activeSeat
+    : (typeof window.gameState?.active === 'number' ? window.gameState.active : null);
+  if (mySeat == null || seatToCheck == null) return false;
+  return mySeat === seatToCheck;
+}
+
+function normalizeHpShift(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const delta = Number(raw.delta ?? raw.deltaHp ?? 0);
+  if (!Number.isFinite(delta) || delta === 0) {
+    return null;
+  }
+  return {
+    delta,
+    before: Number.isFinite(raw.before) ? raw.before : null,
+    after: Number.isFinite(raw.after) ? raw.after : null,
+  };
+}
+
+export function playFieldquakeFx(event, opts = {}) {
+  if (!event) return;
+  const r = isInteger(event.r) ? event.r : Number(event.r);
+  const c = isInteger(event.c) ? event.c : Number(event.c);
+  if (!isInteger(r) || !isInteger(c)) return;
+
+  const prevElement = event.prevElement || opts.prevElement || null;
+  const nextElement = event.nextElement || opts.nextElement || prevElement || null;
+  const ctx = getCtx();
+  const tile = ctx?.tileMeshes?.[r]?.[c] || null;
+
+  if (tile && typeof window !== 'undefined') {
+    try {
+      const prevMat = getTileMaterial(prevElement || tile.userData?.element || null);
+      const nextMat = getTileMaterial(nextElement || prevElement || tile.userData?.element || null);
+      window.__fx?.dissolveTileCrossfade?.(tile, prevMat, nextMat, 0.9);
+    } catch {}
+    try {
+      tile.userData = tile.userData || {};
+      tile.userData.element = nextElement;
+    } catch {}
+  }
+
+  if (opts.sync !== false && shouldBroadcast(opts.activeSeat)) {
+    try {
+      window.socket.emit('tileCrossfade', {
+        r,
+        c,
+        prev: prevElement,
+        next: nextElement,
+      });
+    } catch {}
+  }
+
+  const hpShift = normalizeHpShift(opts.hpShift || event.hpShift || null);
+  if (hpShift && ctx?.unitMeshes) {
+    const mesh = ctx.unitMeshes.find(m => m?.userData?.row === r && m?.userData?.col === c);
+    if (mesh) {
+      const color = hpShift.delta > 0 ? '#22c55e' : '#ef4444';
+      const text = `${hpShift.delta > 0 ? '+' : ''}${hpShift.delta}`;
+      try { window.__fx?.spawnDamageText?.(mesh, text, color); } catch {}
+    }
+  }
+
+  const unitDied = opts.unitDied ?? event.unitDied ?? false;
+  if (unitDied && !opts.skipDeathFx && ctx?.unitMeshes) {
+    const mesh = ctx.unitMeshes.find(m => m?.userData?.row === r && m?.userData?.col === c);
+    if (mesh) {
+      try {
+        const THREE = ctx.THREE || (typeof window !== 'undefined' ? window.THREE : undefined);
+        const offset = THREE ? new THREE.Vector3(0, 0, 0.6) : { x: 0, y: 0, z: 0.6 };
+        window.__fx?.dissolveAndAsh?.(mesh, offset, 0.9);
+      } catch {}
+    }
+  }
+}
+
+export function playFieldquakeFxBatch(list, opts = {}) {
+  if (!Array.isArray(list) || !list.length) return;
+  for (const ev of list) {
+    playFieldquakeFx(ev, { ...opts, hpShift: opts.hpShift ?? ev?.hpShift });
+  }
+}
+
+export default {
+  playFieldquakeFx,
+  playFieldquakeFxBatch,
+};

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -5,6 +5,7 @@ import { setHandCardHoverVisual } from './hand.js';
 import { highlightTiles, clearHighlights } from './highlight.js';
 import { trackUnitHover, resetUnitHover } from './unitTooltip.js';
 import { showTooltip, hideTooltip } from '../ui/tooltip.js';
+import { playFieldquakeFxBatch } from './fieldquakeFx.js';
 import {
   applyFreedonianAura,
   applySummonAbilities,
@@ -1002,6 +1003,13 @@ export function placeUnitWithDirection(direction) {
         if (!text) continue;
         window.addLog?.(text);
       }
+    }
+    if (Array.isArray(summonEvents?.fieldquakes) && summonEvents.fieldquakes.length) {
+      try {
+        playFieldquakeFxBatch(summonEvents.fieldquakes, {
+          activeSeat: gameState.active,
+        });
+      } catch {}
     }
     if (Array.isArray(summonEvents?.manaSteal) && summonEvents.manaSteal.length) {
       try { window.updateUI(); } catch {}

--- a/tests/fieldquake.test.js
+++ b/tests/fieldquake.test.js
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { CARDS } from '../src/core/cards.js';
+import {
+  applySummonAbilities,
+  collectDamageInteractions,
+  applyDamageInteractionResults,
+} from '../src/core/abilities.js';
+import { computeFieldquakeLockedCells } from '../src/core/fieldLocks.js';
+import { computeDynamicAttackBonus } from '../src/core/abilityHandlers/dynamicAttack.js';
+
+function makeBoard(defaultElement = 'FIRE') {
+  return Array.from({ length: 3 }, (_, r) => (
+    Array.from({ length: 3 }, (_, c) => ({
+      element: (r === 1 && c === 1) ? 'BIOLITH' : defaultElement,
+      unit: null,
+    }))
+  ));
+}
+
+describe('fieldquake-эффекты биолит-карт', () => {
+  it('Behemoth Groundbreaker меняет стихии соседних клеток при призыве', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [
+        { graveyard: [] },
+        { graveyard: [] },
+      ],
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[2][1].element = 'WATER';
+    state.board[1][0].element = 'FOREST';
+    state.board[1][2].element = 'EARTH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_BEHEMOTH_GROUNDBREAKER',
+      currentHP: 4,
+    };
+
+    const events = applySummonAbilities(state, 1, 1);
+
+    expect(state.board[0][1].element).toBe('WATER');
+    expect(state.board[2][1].element).toBe('FIRE');
+    expect(state.board[1][0].element).toBe('EARTH');
+    expect(state.board[1][2].element).toBe('FOREST');
+    expect(events.fieldquakes).toHaveLength(4);
+  });
+
+  it('Groundbreaker мгновенно уничтожает существ с нулевым HP после fieldquake', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [
+        { graveyard: [] },
+        { graveyard: [] },
+      ],
+    };
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_BEHEMOTH_GROUNDBREAKER',
+      currentHP: 4,
+    };
+
+    const events = applySummonAbilities(state, 1, 1);
+
+    expect(state.board[0][1].unit).toBeNull();
+    expect(events.deaths).toHaveLength(1);
+    expect(events.deaths[0].tplId).toBe('FIRE_PARTMOLE_FLAME_LIZARD');
+    expect(state.players[1].graveyard).toHaveLength(1);
+  });
+
+  it('Undead King Novogus вызывает fieldquake при уроне вне земли', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'FOREST';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const tpl = CARDS.BIOLITH_UNDEAD_KING_NOVOGUS;
+    const interactions = collectDamageInteractions(state, {
+      attackerPos: { r: 1, c: 1 },
+      attackerUnit: state.board[1][1].unit,
+      tpl,
+      hits: [ { r: 0, c: 1, dealt: 2 } ],
+    });
+
+    expect(interactions.events).toHaveLength(1);
+    expect(interactions.preventRetaliation.has('0,1')).toBe(true);
+
+    const applied = applyDamageInteractionResults(state, interactions);
+    expect(state.board[0][1].element).toBe('WATER');
+    expect(applied.logLines.some(line => line.includes('Fieldquake'))).toBe(true);
+  });
+
+  it('Novogus удаляет цель, потерявшую все HP от смены поля', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [
+        { graveyard: [] },
+        { graveyard: [] },
+      ],
+    };
+    state.board[1][1].element = 'FOREST';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const tpl = CARDS.BIOLITH_UNDEAD_KING_NOVOGUS;
+    const interactions = collectDamageInteractions(state, {
+      attackerPos: { r: 1, c: 1 },
+      attackerUnit: state.board[1][1].unit,
+      tpl,
+      hits: [ { r: 0, c: 1, dealt: 1 } ],
+    });
+
+    const applied = applyDamageInteractionResults(state, interactions);
+
+    expect(state.board[0][1].unit).toBeNull();
+    expect(applied.deaths).toHaveLength(1);
+    expect(applied.deaths[0].tplId).toBe('FIRE_PARTMOLE_FLAME_LIZARD');
+  });
+
+  it('Novogus не срабатывает на земле', () => {
+    const state = {
+      board: makeBoard('EARTH'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'EARTH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const tpl = CARDS.BIOLITH_UNDEAD_KING_NOVOGUS;
+    const interactions = collectDamageInteractions(state, {
+      attackerPos: { r: 1, c: 1 },
+      attackerUnit: state.board[1][1].unit,
+      tpl,
+      hits: [ { r: 0, c: 1, dealt: 2 } ],
+    });
+
+    expect(interactions.events).toHaveLength(0);
+  });
+
+  it('Ouroboros Dragon получает бонус и блокирует fieldquake на биолите', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'BIOLITH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_OUROBOROS_DRAGON',
+      currentHP: 10,
+    };
+    state.board[0][0].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_MORNING_STAR_WARRIOR',
+      currentHP: 3,
+    };
+    state.board[2][2].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_BIOLITH_STINGER',
+      currentHP: 1,
+    };
+
+    const bonus = computeDynamicAttackBonus(state, 1, 1, CARDS.BIOLITH_OUROBOROS_DRAGON);
+    expect(bonus?.amount).toBe(2);
+
+    const locked = computeFieldquakeLockedCells(state);
+    expect(locked).toHaveLength(9);
+
+    state.board[1][1].element = 'FIRE';
+    const unlocked = computeFieldquakeLockedCells(state);
+    expect(unlocked.length).toBeLessThan(9);
+  });
+});


### PR DESCRIPTION
## Summary
- add structured fieldquake event data to core combat and summon flows for UI consumption
- introduce a shared scene-level fieldquake FX helper and reuse it for cards, summons, and combat resolutions
- update fissures spell handling to delegate visual logic to the shared module while preserving discard triggers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7d3c5b868833095189062bb71be09