### PR TITLE
Prevent fieldquake from reviving defeated units

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,6 +626,27 @@
             THREE: window.THREE,
           });
           const attackerPos = res.attackerPosUpdate || { r, c };
+          const pendingFieldquakes = Array.isArray(res.fieldquakes) ? res.fieldquakes.slice() : [];
+          if (pendingFieldquakes.length) {
+            const nextActive = typeof res?.n1?.active === 'number' ? res.n1.active : gameState?.active;
+            const broadcastFx = (typeof NET_ON === 'function' ? NET_ON() : false)
+              && typeof MY_SEAT === 'number'
+              && typeof nextActive === 'number'
+              && MY_SEAT === nextActive;
+            try {
+              const batchFn = window.playFieldquakeFxBatch
+                || ((events, options) => {
+                  for (const fq of events) {
+                    if (!fq) continue;
+                    window.playFieldquakeFx?.(
+                      { r: fq.r, c: fq.c, prevElement: fq.prevElement, nextElement: fq.nextElement },
+                      options,
+                    );
+                  }
+                });
+              batchFn(pendingFieldquakes, { broadcast: broadcastFx });
+            } catch {}
+          }
           gameState = res.n1;
           const finalState = gameState;
           try { window.applyGameState(finalState); } catch {}
@@ -791,6 +812,27 @@
             window.__interactions?.showOracleDeathBuff?.(d.owner, tplDead.onDeathAddHPAll);
           }
         }
+        const pendingFieldquakes = Array.isArray(res.fieldquakes) ? res.fieldquakes.slice() : [];
+        if (pendingFieldquakes.length) {
+          const nextActive = typeof res?.n1?.active === 'number' ? res.n1.active : gameState?.active;
+          const broadcastFx = (typeof NET_ON === 'function' ? NET_ON() : false)
+            && typeof MY_SEAT === 'number'
+            && typeof nextActive === 'number'
+            && MY_SEAT === nextActive;
+          try {
+            const batchFn = window.playFieldquakeFxBatch
+              || ((events, options) => {
+                for (const fq of events) {
+                  if (!fq) continue;
+                  window.playFieldquakeFx?.(
+                    { r: fq.r, c: fq.c, prevElement: fq.prevElement, nextElement: fq.nextElement },
+                    options,
+                  );
+                }
+              });
+            batchFn(pendingFieldquakes, { broadcast: broadcastFx });
+          } catch {}
+        }
         gameState = res.n1;
         try { window.applyGameState(gameState); } catch {}
         if (Array.isArray(res.dodgeUpdates) && res.dodgeUpdates.length) {
@@ -815,6 +857,27 @@
         }, 1000);
       } else {
         // Если смертей нет — применяем состояние сразу
+        const pendingFieldquakes = Array.isArray(res.fieldquakes) ? res.fieldquakes.slice() : [];
+        if (pendingFieldquakes.length) {
+          const nextActive = typeof res?.n1?.active === 'number' ? res.n1.active : gameState?.active;
+          const broadcastFx = (typeof NET_ON === 'function' ? NET_ON() : false)
+            && typeof MY_SEAT === 'number'
+            && typeof nextActive === 'number'
+            && MY_SEAT === nextActive;
+          try {
+            const batchFn = window.playFieldquakeFxBatch
+              || ((events, options) => {
+                for (const fq of events) {
+                  if (!fq) continue;
+                  window.playFieldquakeFx?.(
+                    { r: fq.r, c: fq.c, prevElement: fq.prevElement, nextElement: fq.nextElement },
+                    options,
+                  );
+                }
+              });
+            batchFn(pendingFieldquakes, { broadcast: broadcastFx });
+          } catch {}
+        }
         gameState = res.n1; try { window.applyGameState(gameState); } catch {}
         if (Array.isArray(res.dodgeUpdates) && res.dodgeUpdates.length) {
           try { window.__interactions?.logDodgeUpdates?.(res.dodgeUpdates, gameState, attackerName); } catch {}

--- a/src/core/abilities.js
+++ b/src/core/abilities.js
@@ -51,6 +51,12 @@ import {
   describeFieldFatality as describeFieldFatalityInternal,
   evaluateFieldFatality as evaluateFieldFatalityInternal,
 } from './abilityHandlers/fieldHazards.js';
+import {
+  applyFieldquakeToCell,
+  normalizeFieldquakeOnSummonConfig,
+  normalizeFieldquakeOnDamageConfig,
+  collectFieldquakeDeaths,
+} from './abilityHandlers/fieldquake.js';
 
 // локальная функция ограничения маны (без импорта во избежание циклов)
 const capMana = (m) => Math.min(10, m);
@@ -327,6 +333,19 @@ export function collectDamageInteractions(state, context = {}) {
   const { attackerPos, attackerUnit, tpl, hits } = context;
   if (!tpl || !attackerUnit || !Array.isArray(hits) || !hits.length) return result;
 
+  const fieldquakeCfg = normalizeFieldquakeOnDamageConfig(tpl.fieldquakeOnDamage);
+  const attackerCellElement = (typeof attackerPos?.r === 'number' && typeof attackerPos?.c === 'number')
+    ? (state.board?.[attackerPos.r]?.[attackerPos.c]?.element || null)
+    : null;
+  const fieldquakeTargets = new Set();
+
+  const attackerRef = {
+    uid: getUnitUid(attackerUnit),
+    r: attackerPos?.r,
+    c: attackerPos?.c,
+    tplId: tpl.id,
+  };
+
   const processed = [];
   for (const h of hits) {
     if (!h) continue;
@@ -336,9 +355,27 @@ export function collectDamageInteractions(state, context = {}) {
     const target = cell?.unit;
     if (!target) continue;
     const tplTarget = getUnitTemplate(target);
+    const key = `${h.r},${h.c}`;
+    if (
+      fieldquakeCfg
+      && dealt > 0
+      && !fieldquakeTargets.has(key)
+      && (fieldquakeCfg.requireAttackerElement ? attackerCellElement === fieldquakeCfg.requireAttackerElement : true)
+      && (fieldquakeCfg.requireAttackerNotElement ? attackerCellElement !== fieldquakeCfg.requireAttackerNotElement : true)
+    ) {
+      result.events.push({
+        type: 'FIELDQUAKE',
+        target: { r: h.r, c: h.c },
+        source: attackerRef,
+        config: fieldquakeCfg,
+      });
+      if (fieldquakeCfg.preventRetaliation !== false) {
+        result.preventRetaliation.add(key);
+      }
+      fieldquakeTargets.add(key);
+    }
     const alive = (target.currentHP ?? tplTarget?.hp ?? 0) > 0;
     if (!alive) continue;
-    const key = `${h.r},${h.c}`;
     processed.push({
       r: h.r,
       c: h.c,
@@ -359,13 +396,6 @@ export function collectDamageInteractions(state, context = {}) {
   if (!processed.length) {
     return result;
   }
-
-  const attackerRef = {
-    uid: getUnitUid(attackerUnit),
-    r: attackerPos?.r,
-    c: attackerPos?.c,
-    tplId: tpl.id,
-  };
 
   const reposition = collectRepositionOnDamage(state, {
     attackerRef,
@@ -396,6 +426,8 @@ export function applyDamageInteractionResults(state, effects = {}) {
   const logs = [];
   let attackerPosUpdate = null;
   const events = Array.isArray(effects?.events) ? effects.events : [];
+  const fieldquakeDeaths = [];
+  const fieldquakeEvents = [];
 
   for (const ev of events) {
     if (ev?.type === 'SWAP_POSITIONS') {
@@ -504,10 +536,51 @@ export function applyDamageInteractionResults(state, effects = {}) {
       const hazard = applyFieldFatalityCheckInternal(state.board[to.r][to.c]?.unit, tplTarget, toElement);
       const fatalLog = describeFieldFatalityInternal(tplTarget, hazard, { name: targetName });
       if (fatalLog) logs.push(fatalLog);
+    } else if (ev?.type === 'FIELDQUAKE') {
+      const tr = Number(ev.target?.r);
+      const tc = Number(ev.target?.c);
+      if (!Number.isInteger(tr) || !Number.isInteger(tc)) continue;
+      const fq = applyFieldquakeToCell(state, tr, tc, { respectLocks: ev.config?.respectLocks !== false });
+      if (!fq?.changed) {
+        if (fq?.reason === 'LOCKED') {
+          logs.push('Fieldquake предотвращён защитой поля.');
+        }
+        continue;
+      }
+      const prev = fq.prevElement || 'UNKNOWN';
+      const next = fq.nextElement || prev;
+      logs.push(`Fieldquake: ${prev}→${next} на (${tr},${tc}).`);
+      fieldquakeEvents.push({ r: fq.r, c: fq.c, prevElement: prev, nextElement: next, source: ev?.source || null });
+      const unit = state.board?.[tr]?.[tc]?.unit;
+      const tplUnit = unit ? CARDS[unit.tplId] : null;
+      if (unit && tplUnit && fq.hpShift?.deltaHp) {
+        const delta = fq.hpShift.deltaHp;
+        const before = fq.hpShift.beforeHp;
+        const after = fq.hpShift.afterHp;
+        const name = tplUnit.name || 'Цель';
+        if (delta > 0) {
+          logs.push(`${name} усиливается на поле ${next}: HP ${before}→${after}.`);
+        } else if (delta < 0) {
+          logs.push(`${name} теряет силу на поле ${next}: HP ${before}→${after}.`);
+        }
+      }
+      if (unit && tplUnit && fq.fatality?.dies) {
+        const fatalLog = describeFieldFatalityInternal(tplUnit, fq.fatality, { name: tplUnit.name || 'Цель' });
+        if (fatalLog) logs.push(fatalLog);
+      }
+      const deaths = collectFieldquakeDeaths(state, fq);
+      if (deaths.length) {
+        fieldquakeDeaths.push(...deaths);
+      }
     }
   }
 
-  return { attackerPosUpdate, logLines: logs };
+  return {
+    attackerPosUpdate,
+    logLines: logs,
+    deaths: fieldquakeDeaths,
+    fieldquakes: fieldquakeEvents,
+  };
 }
 
 function normalizeElementConfig(value, defaults = {}) {
@@ -659,6 +732,87 @@ export function applySummonAbilities(state, r, c) {
   if (!cell || !unit) return events;
   const tpl = getUnitTemplate(unit);
   if (!tpl) return events;
+
+  const fieldquakeSummonCfg = normalizeFieldquakeOnSummonConfig(tpl.fieldquakeOnSummon);
+  if (fieldquakeSummonCfg) {
+    const coords = new Set();
+    const addPos = (rr, cc) => {
+      if (!inBounds(rr, cc)) return;
+      coords.add(`${rr},${cc}`);
+    };
+    if (Array.isArray(fieldquakeSummonCfg.cells) && fieldquakeSummonCfg.cells.length) {
+      for (const pos of fieldquakeSummonCfg.cells) {
+        if (Number.isInteger(pos?.r) && Number.isInteger(pos?.c)) addPos(pos.r, pos.c);
+      }
+    } else {
+      const pattern = fieldquakeSummonCfg.pattern || 'ADJACENT';
+      if (pattern === 'ALL') {
+        for (let rr = 0; rr < 3; rr += 1) {
+          for (let cc = 0; cc < 3; cc += 1) {
+            if (rr === r && cc === c) continue;
+            addPos(rr, cc);
+          }
+        }
+      } else if (pattern === 'SELF') {
+        addPos(r, c);
+      } else if (pattern === 'FRONT') {
+        const facing = unit.facing || 'N';
+        const vectors = { N: [-1, 0], S: [1, 0], E: [0, 1], W: [0, -1] };
+        const vec = vectors[facing] || vectors.N;
+        addPos(r + vec[0], c + vec[1]);
+      } else {
+        const dirs = [ [-1, 0], [1, 0], [0, -1], [0, 1] ];
+        for (const [dr, dc] of dirs) addPos(r + dr, c + dc);
+      }
+    }
+    const deaths = [];
+    for (const key of coords) {
+      const [rr, cc] = key.split(',').map(Number);
+      const fq = applyFieldquakeToCell(state, rr, cc, { respectLocks: fieldquakeSummonCfg.respectLocks !== false });
+      if (!fq?.changed) continue;
+      events.fieldquakes = [...(events.fieldquakes || []), {
+        r: fq.r,
+        c: fq.c,
+        prevElement: fq.prevElement,
+        nextElement: fq.nextElement,
+        source: { tplId: tpl.id, owner: unit.owner },
+      }];
+      const prevLabel = fq.prevElement || 'UNKNOWN';
+      const nextLabel = fq.nextElement || prevLabel;
+      events.logs = [...(events.logs || []), `${tpl.name}: fieldquake ${prevLabel}→${nextLabel} на (${fq.r},${fq.c}).`];
+      if (fq.hpShift?.deltaHp && fq.unit && fq.tpl?.name) {
+        const delta = fq.hpShift.deltaHp;
+        if (delta > 0) {
+          events.logs.push(`${fq.tpl.name} усиливается на поле ${nextLabel}: HP ${fq.hpShift.beforeHp}→${fq.hpShift.afterHp}.`);
+        } else if (delta < 0) {
+          events.logs.push(`${fq.tpl.name} теряет силу на поле ${nextLabel}: HP ${fq.hpShift.beforeHp}→${fq.hpShift.afterHp}.`);
+        }
+      }
+      if (fq.fatality?.dies && fq.tpl?.name) {
+        const fatalLog = describeFieldFatalityInternal(fq.tpl, fq.fatality, { name: fq.tpl.name });
+        if (fatalLog) events.logs.push(fatalLog);
+      }
+      if (fq.unitDied) {
+        const deathEntries = collectFieldquakeDeaths(state, fq);
+        if (deathEntries.length) {
+          deaths.push(...deathEntries);
+          for (const entry of deathEntries) {
+            try {
+              const owner = entry?.owner;
+              const tplDeath = owner != null ? CARDS[entry.tplId] : null;
+              const player = owner != null ? state.players?.[owner] : null;
+              if (tplDeath && Array.isArray(player?.graveyard)) {
+                player.graveyard.push(tplDeath);
+              }
+            } catch {}
+          }
+        }
+      }
+    }
+    if (deaths.length) {
+      events.deaths = [...(events.deaths || []), ...deaths];
+    }
+  }
 
   const summonBuffs = applySummonStatBuffs(state, r, c);
   if (Array.isArray(summonBuffs?.logs) && summonBuffs.logs.length) {

--- a/src/core/abilityHandlers/fieldquake.js
+++ b/src/core/abilityHandlers/fieldquake.js
@@ -1,0 +1,188 @@
+// Обработка эффектов fieldquake без привязки к визуальному слою
+import { computeFieldquakeLockedCells } from '../fieldLocks.js';
+import { CARDS } from '../cards.js';
+import { getOppositeElement, applyFieldTransitionToUnit } from '../fieldEffects.js';
+import { applyFieldFatalityCheck } from './fieldHazards.js';
+import { createDeathEntry } from './deathRecords.js';
+
+const BOARD_SIZE = 3;
+
+function inBounds(r, c) {
+  return r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE;
+}
+
+function buildLockedSet(state) {
+  const locked = computeFieldquakeLockedCells(state);
+  const set = new Set();
+  for (const cell of locked) {
+    if (!cell) continue;
+    const key = `${cell.r},${cell.c}`;
+    set.add(key);
+  }
+  return set;
+}
+
+export function canFieldquakeCell(state, r, c, opts = {}) {
+  if (!state?.board) return { ok: false, reason: 'NO_BOARD' };
+  if (!inBounds(r, c)) return { ok: false, reason: 'OUT_OF_BOUNDS' };
+  const cell = state.board?.[r]?.[c];
+  if (!cell) return { ok: false, reason: 'NO_CELL' };
+  const prevElement = cell.element || null;
+  if (!prevElement) return { ok: false, reason: 'NO_ELEMENT', prevElement };
+  if (prevElement === 'BIOLITH') {
+    return { ok: false, reason: 'BIOLITH', prevElement };
+  }
+  const respectLocks = opts.respectLocks !== false;
+  if (respectLocks) {
+    const lockedSet = Array.isArray(opts.locked)
+      ? new Set(opts.locked.map(p => `${p.r},${p.c}`))
+      : (opts.lockedSet instanceof Set ? opts.lockedSet : buildLockedSet(state));
+    const key = `${r},${c}`;
+    if (lockedSet.has(key)) {
+      return { ok: false, reason: 'LOCKED', prevElement };
+    }
+  }
+  const nextElement = getOppositeElement(prevElement);
+  if (!nextElement || nextElement === prevElement) {
+    return { ok: false, reason: 'NO_CHANGE', prevElement };
+  }
+  return { ok: true, prevElement, nextElement };
+}
+
+export function applyFieldquakeToCell(state, r, c, opts = {}) {
+  if (!state?.board) return null;
+  if (!inBounds(r, c)) return null;
+  const lockedSet = opts.lockedSet instanceof Set ? opts.lockedSet : null;
+  const check = canFieldquakeCell(state, r, c, {
+    respectLocks: opts.respectLocks !== false,
+    lockedSet,
+  });
+  if (!check.ok) {
+    return { changed: false, reason: check.reason, prevElement: check.prevElement ?? null };
+  }
+  const cell = state.board[r][c];
+  const prevElement = check.prevElement;
+  const nextElement = check.nextElement;
+  cell.element = nextElement;
+
+  const unit = cell.unit || null;
+  const tpl = unit ? CARDS[unit.tplId] : null;
+  const preDead = !!(unit && tpl && ((unit.currentHP ?? tpl.hp ?? 0) <= 0));
+  let hpShift = null;
+  let fatality = null;
+  if (unit && tpl) {
+    if (!preDead) {
+      hpShift = applyFieldTransitionToUnit(unit, tpl, prevElement, nextElement);
+    }
+    fatality = applyFieldFatalityCheck(unit, tpl, nextElement);
+  }
+
+  const unitDied = !!(unit && ((unit.currentHP ?? tpl?.hp ?? 0) <= 0));
+
+  return {
+    changed: true,
+    r,
+    c,
+    prevElement,
+    nextElement,
+    unit,
+    tpl,
+    hpShift,
+    fatality,
+    unitDied,
+  };
+}
+
+export function collectFieldquakeDeaths(state, outcomes, opts = {}) {
+  if (!state?.board) return [];
+  const list = Array.isArray(outcomes) ? outcomes : [outcomes];
+  const deaths = [];
+  const seen = new Set();
+  for (const res of list) {
+    if (!res?.unitDied) continue;
+    const rr = Number(res.r);
+    const cc = Number(res.c);
+    if (!Number.isInteger(rr) || !Number.isInteger(cc)) continue;
+    const key = `${rr},${cc}`;
+    if (seen.has(key)) continue;
+    const cell = state.board?.[rr]?.[cc];
+    const unit = cell?.unit;
+    if (!unit) continue;
+    const entry = createDeathEntry(state, unit, rr, cc) || {
+      r: rr,
+      c: cc,
+      owner: unit.owner,
+      tplId: unit.tplId,
+      uid: unit.uid ?? null,
+      element: cell?.element || null,
+    };
+    deaths.push(entry);
+    seen.add(key);
+    if (opts?.keepUnits !== true && cell) {
+      cell.unit = null;
+    }
+  }
+  return deaths;
+}
+
+export function normalizeFieldquakeOnSummonConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return { pattern: 'ADJACENT', respectLocks: true };
+  }
+  if (typeof raw === 'string') {
+    return { pattern: raw.toUpperCase(), respectLocks: true };
+  }
+  if (typeof raw === 'object') {
+    const cfg = {
+      pattern: typeof raw.pattern === 'string' ? raw.pattern.toUpperCase() : 'ADJACENT',
+      respectLocks: raw.respectLocks !== false,
+    };
+    if (raw.cells && Array.isArray(raw.cells)) {
+      cfg.cells = raw.cells
+        .map(pos => ({ r: Number(pos.r), c: Number(pos.c) }))
+        .filter(pos => Number.isInteger(pos.r) && Number.isInteger(pos.c));
+    }
+    return cfg;
+  }
+  return null;
+}
+
+export function normalizeFieldquakeOnDamageConfig(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return {
+      respectLocks: true,
+      preventRetaliation: true,
+    };
+  }
+  if (typeof raw === 'object') {
+    const cfg = {
+      respectLocks: raw.respectLocks !== false,
+      preventRetaliation: raw.preventRetaliation !== false,
+    };
+    if (raw.requireAttackerNotElement) {
+      cfg.requireAttackerNotElement = String(raw.requireAttackerNotElement).toUpperCase();
+    }
+    if (raw.requireAttackerElement) {
+      cfg.requireAttackerElement = String(raw.requireAttackerElement).toUpperCase();
+    }
+    return cfg;
+  }
+  if (typeof raw === 'string') {
+    return {
+      respectLocks: true,
+      preventRetaliation: true,
+      requireAttackerNotElement: raw.toUpperCase(),
+    };
+  }
+  return null;
+}
+
+export default {
+  canFieldquakeCell,
+  applyFieldquakeToCell,
+  normalizeFieldquakeOnSummonConfig,
+  normalizeFieldquakeOnDamageConfig,
+  collectFieldquakeDeaths,
+};

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -540,6 +540,38 @@ export const CARDS = {
     desc: 'Incarnation. Phaseus’s Magic Attack targets all enemies. Destroy Phaseus if he is on a non-Biolith field.'
   },
 
+  BIOLITH_BEHEMOTH_GROUNDBREAKER: {
+    id: 'BIOLITH_BEHEMOTH_GROUNDBREAKER', name: 'Behemoth Groundbreaker', type: 'UNIT', cost: 4, activation: 3,
+    element: 'BIOLITH', atk: 1, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    fieldquakeOnSummon: { pattern: 'ADJACENT' },
+    desc: 'When Behemoth Groundbreaker is summoned, fieldquake all adjacent fields.'
+  },
+  BIOLITH_UNDEAD_KING_NOVOGUS: {
+    id: 'BIOLITH_UNDEAD_KING_NOVOGUS', name: 'Undead King Novogus', type: 'UNIT', cost: 6, activation: 3,
+    element: 'BIOLITH', atk: 2, hp: 6,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    fieldquakeOnDamage: { requireAttackerNotElement: 'EARTH', preventRetaliation: true },
+    desc: "Magic Attack. If Undead King Novogus is on a non-Earth field and damages a creature, fieldquake the target creature's field. The target creature cannot counterattack."
+  },
+  BIOLITH_OUROBOROS_DRAGON: {
+    id: 'BIOLITH_OUROBOROS_DRAGON', name: 'Ouroboros Dragon', type: 'UNIT', cost: 7, activation: 4,
+    element: 'BIOLITH', atk: 7, hp: 10,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1, 2], mode: 'ANY', ignoreAlliedBlocking: true } ],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    dynamicAtk: 'BIOLITH_CREATURES',
+    fieldquakeLock: { type: 'ALL', onlyWhileOnElement: 'BIOLITH' },
+    desc: "Ouroboros Dragon's Attack is equal to 7 plus the number of other Biolith creatures on the board. While Ouroboros Dragon is on a Biolith field, no field can be fieldquaked or exchanged."
+  },
+
   // Ninja cycle
   FIRE_FIREFLY_NINJA: {
     id: 'FIRE_FIREFLY_NINJA', name: 'Firefly Ninja', type: 'UNIT', cost: 3, activation: 2,

--- a/src/core/fieldEffects.js
+++ b/src/core/fieldEffects.js
@@ -12,6 +12,12 @@ const OPPOSITES = {
   FOREST: 'EARTH',
 };
 
+export function getOppositeElement(element) {
+  if (!element) return null;
+  const token = String(element).toUpperCase();
+  return OPPOSITES[token] || null;
+}
+
 export function computeCellBuff(cellElement, unitElement) {
   if (!cellElement || !unitElement) return { atk: 0, hp: 0 };
   if (cellElement === 'BIOLITH') return { atk: 0, hp: 0 };

--- a/src/core/fieldLocks.js
+++ b/src/core/fieldLocks.js
@@ -14,6 +14,15 @@ export function computeFieldquakeLockedCells(state) {
       const tpl = CARDS[unit.tplId];
       const lock = tpl?.fieldquakeLock;
       if (!lock) continue;
+      const requiredElement = lock.onlyWhileOnElement
+        ? String(lock.onlyWhileOnElement).toUpperCase()
+        : null;
+      if (requiredElement) {
+        const currentElement = state.board?.[r]?.[c]?.element || null;
+        if (currentElement !== requiredElement) {
+          continue;
+        }
+      }
       const add = (rr, cc) => {
         if (inBounds(rr, cc)) locked.add(`${rr},${cc}`);
       };

--- a/src/core/rules.js
+++ b/src/core/rules.js
@@ -563,6 +563,10 @@ export function stagedAttack(state, r, c, opts = {}) {
 
     const applied = applyDamageInteractionResults(nFinal, damageEffects);
     const attackerPosUpdate = applied?.attackerPosUpdate || null;
+    const interactionDeaths = Array.isArray(applied?.deaths) ? applied.deaths.slice() : [];
+    const interactionFieldquakes = Array.isArray(applied?.fieldquakes)
+      ? applied.fieldquakes.slice()
+      : [];
     if (attackerPosUpdate) {
       r = attackerPosUpdate.r;
       c = attackerPosUpdate.c;
@@ -579,7 +583,10 @@ export function stagedAttack(state, r, c, opts = {}) {
       logLines.push(`Retaliation to ${CARDS[A.tplId]?.name || 'Attacker'}: ${ret.total || 0} (HP ${before}→${A.currentHP})`);
     }
 
-    const deaths = [];
+    const deaths = interactionDeaths.slice();
+    const seenDeathKeys = new Set(deaths.map(d => (d?.uid != null)
+      ? `UID:${d.uid}`
+      : `POS:${d?.r},${d?.c}`));
     for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
       const cellRef = nFinal.board?.[rr]?.[cc];
       const u = cellRef?.unit;
@@ -592,7 +599,11 @@ export function stagedAttack(state, r, c, opts = {}) {
           uid: u.uid ?? null,
           element: cellRef?.element || null,
         };
-        deaths.push(deathEntry);
+        const key = (deathEntry.uid != null) ? `UID:${deathEntry.uid}` : `POS:${deathEntry.r},${deathEntry.c}`;
+        if (!seenDeathKeys.has(key)) {
+          deaths.push(deathEntry);
+          seenDeathKeys.add(key);
+        }
         if (cellRef) cellRef.unit = null;
       }
     }
@@ -931,7 +942,23 @@ export function magicAttack(state, fr, fc, tr, tc) {
     }
   }
 
-  const deaths = [];
+  const applied = applyDamageInteractionResults(n1, damageEffects);
+  const attackerPosUpdate = applied?.attackerPosUpdate || null;
+  if (attackerPosUpdate) {
+    fromR = attackerPosUpdate.r;
+    fromC = attackerPosUpdate.c;
+  }
+  if (Array.isArray(applied?.logLines) && applied.logLines.length) {
+    logLines.push(...applied.logLines);
+  }
+  const interactionDeaths = Array.isArray(applied?.deaths) ? applied.deaths.slice() : [];
+  const interactionFieldquakes = Array.isArray(applied?.fieldquakes)
+    ? applied.fieldquakes.slice()
+    : [];
+  const deaths = interactionDeaths.slice();
+  const seenDeathKeys = new Set(deaths.map(d => (d?.uid != null)
+    ? `UID:${d.uid}`
+    : `POS:${d?.r},${d?.c}`));
   for (let rr = 0; rr < 3; rr++) for (let cc = 0; cc < 3; cc++) {
     const cellRef = n1.board[rr][cc];
     const u = cellRef.unit;
@@ -944,7 +971,11 @@ export function magicAttack(state, fr, fc, tr, tc) {
         uid: u.uid ?? null,
         element: cellRef?.element || null,
       };
-      deaths.push(deathEntry);
+      const key = (deathEntry.uid != null) ? `UID:${deathEntry.uid}` : `POS:${deathEntry.r},${deathEntry.c}`;
+      if (!seenDeathKeys.has(key)) {
+        deaths.push(deathEntry);
+        seenDeathKeys.add(key);
+      }
       cellRef.unit = null;
     }
   }
@@ -986,15 +1017,6 @@ export function magicAttack(state, fr, fc, tr, tc) {
       logLines.push(`${name}: контроль возвращается к игроку ${rel.owner + 1}.`);
     }
   }
-  const applied = applyDamageInteractionResults(n1, damageEffects);
-  const attackerPosUpdate = applied?.attackerPosUpdate || null;
-  if (attackerPosUpdate) {
-    fromR = attackerPosUpdate.r;
-    fromC = attackerPosUpdate.c;
-  }
-  if (Array.isArray(applied?.logLines) && applied.logLines.length) {
-    logLines.push(...applied.logLines);
-  }
   const continuous = refreshContinuousPossessions(n1);
   if (continuous.possessions.length) {
     for (const ev of continuous.possessions) {
@@ -1019,12 +1041,14 @@ export function magicAttack(state, fr, fc, tr, tc) {
   if (Array.isArray(dodgeFinal?.updated) && dodgeFinal.updated.length) {
     dodgeUpdates.push(...dodgeFinal.updated);
   }
+
   const combinedReleases = [...releaseEvents.releases, ...continuous.releases];
   return {
     n1,
     logLines,
     targets,
     deaths,
+    fieldquakes: interactionFieldquakes,
     releases: combinedReleases,
     possessions: continuous.possessions,
     attackerPosUpdate,

--- a/src/main.js
+++ b/src/main.js
@@ -49,6 +49,7 @@ import * as SummonLock from './ui/summonLock.js';
 import * as CancelButton from './ui/cancelButton.js';
 import { initDebugControls } from './ui/debugControls.js';
 import { initDiscardManager, syncWithState as syncDiscardManager } from './ui/discardManager.js';
+import { playFieldquakeFx, playFieldquakeFxBatch } from './scene/fieldquakeFx.js';
 
 // Expose to window to keep compatibility while refactoring incrementally
 try {
@@ -207,6 +208,8 @@ try {
   window.__ui.mainMenu = MainMenu;
   window.updateUI = updateUI;
   window.__fx = SceneEffects;
+  window.playFieldquakeFx = playFieldquakeFx;
+  window.playFieldquakeFxBatch = playFieldquakeFxBatch;
   window.spendAndDiscardSpell = UISpellUtils.spendAndDiscardSpell;
   window.burnSpellCard = UISpellUtils.burnSpellCard;
   window.__spells = Spells;

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -1,4 +1,5 @@
 import { getServerBase } from './config.js';
+import { playFieldquakeFx } from '../scene/fieldquakeFx.js';
 
   /* MODULE: network/multiplayer
      Purpose: handle server connection, matchmaking, state sync,
@@ -690,10 +691,13 @@ import { getServerBase } from './config.js';
 
   // ===== 10) Tile crossfade sync =====
   socket.on('tileCrossfade', ({ r, c, prev, next }) => {
-    try {
-      const tile = tileMeshes?.[r]?.[c]; if (!tile) return;
-      window.__fx?.dissolveTileCrossfade(tile, getTileMaterial(prev), getTileMaterial(next), 0.9);
-    } catch {}
+    const handled = playFieldquakeFx({ r, c, prevElement: prev, nextElement: next }, { broadcast: false });
+    if (!handled) {
+      try {
+        const tile = tileMeshes?.[r]?.[c]; if (!tile) return;
+        window.__fx?.dissolveTileCrossfade(tile, getTileMaterial(prev), getTileMaterial(next), 0.9);
+      } catch {}
+    }
   });
 
   // ===== 5) Queue / start =====

--- a/src/scene/fieldquakeFx.js
+++ b/src/scene/fieldquakeFx.js
@@ -1,0 +1,92 @@
+// Визуальные эффекты смены стихий (fieldquake) без логики игры
+import { getCtx } from './context.js';
+import { getTileMaterial } from './board.js';
+
+function normalizeElement(el) {
+  if (typeof el !== 'string') return null;
+  return el.toUpperCase();
+}
+
+function canBroadcastTileFx() {
+  try {
+    if (typeof window === 'undefined') return false;
+    const netActive = typeof window.NET_ON === 'function'
+      ? window.NET_ON()
+      : !!window.NET_ACTIVE;
+    if (!netActive) return false;
+    if (!window.socket) return false;
+    const seat = (typeof window.MY_SEAT === 'number') ? window.MY_SEAT : null;
+    const active = (typeof window.gameState?.active === 'number') ? window.gameState.active : null;
+    if (seat != null && active != null && seat !== active) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function playFieldquakeFx(event = {}, opts = {}) {
+  try {
+    const r = Number(event.r);
+    const c = Number(event.c);
+    if (!Number.isInteger(r) || !Number.isInteger(c)) return false;
+    const prevElement = normalizeElement(event.prevElement);
+    const nextElement = normalizeElement(event.nextElement);
+    if (!prevElement || !nextElement || prevElement === nextElement) return false;
+
+    const ctx = getCtx();
+    const tileMeshes = ctx?.tileMeshes;
+    const tile = tileMeshes?.[r]?.[c];
+    if (!tile) return false;
+
+    const duration = typeof opts.duration === 'number' ? opts.duration : 0.9;
+
+    const prevMat = getTileMaterial(prevElement);
+    const nextMat = getTileMaterial(nextElement);
+    if (window?.__fx?.dissolveTileCrossfade) {
+      try {
+        window.__fx.dissolveTileCrossfade(tile, prevMat, nextMat, duration);
+      } catch {}
+    }
+
+    const shouldBroadcast = opts.broadcast === true;
+    if (shouldBroadcast && canBroadcastTileFx()) {
+      try {
+        window.socket.emit('tileCrossfade', {
+          r,
+          c,
+          prev: prevElement,
+          next: nextElement,
+        });
+      } catch {}
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Вспомогательная обёртка для пакетного проигрывания нескольких fieldquake-эффектов
+// Используется при атаках и массовых событиях, чтобы гарантировать одинаковую
+// визуализацию для всех затронутых клеток и по возможности отправить один и тот же
+// пакет на сервер для синхронизации.
+export function playFieldquakeFxBatch(events, opts = {}) {
+  if (!Array.isArray(events) || events.length === 0) return false;
+  let played = false;
+  for (const ev of events) {
+    if (!ev) continue;
+    const success = playFieldquakeFx({
+      r: ev.r,
+      c: ev.c,
+      prevElement: ev.prevElement ?? ev.prev,
+      nextElement: ev.nextElement ?? ev.next,
+    }, opts);
+    played = played || success;
+  }
+  return played;
+}
+
+export default {
+  playFieldquakeFx,
+  playFieldquakeFxBatch,
+};

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -10,6 +10,7 @@ import { discardHandCard } from '../scene/discard.js';
 import { computeFieldquakeLockedCells } from '../core/fieldLocks.js';
 import { refreshPossessionsUI } from '../ui/possessions.js';
 import { applyDeathDiscardEffects } from '../core/abilityHandlers/discard.js';
+import { playFieldquakeFx } from '../scene/fieldquakeFx.js';
 
 // Общая реализация ритуала Holy Feast
 function runHolyFeast({ tpl, pl, idx, cardMesh, tileMesh }) {
@@ -361,20 +362,14 @@ export const handlers = {
       const nextEl = oppMap[prevEl] || prevEl;
       cell.element = nextEl;
       refreshPossessionsUI(gameState);
-      try {
-        const tile = getCtx().tileMeshes[r][c];
-        const mat = getTileMaterial(nextEl);
-        window.__fx.dissolveTileCrossfade(
-          tile,
-          getTileMaterial(prevEl),
-          mat,
-          0.9
-        );
-        try {
-          if (NET_ON() && MY_SEAT === gameState.active && window.socket)
-            window.socket.emit('tileCrossfade', { r, c, prev: prevEl, next: nextEl });
-        } catch {}
-      } catch {}
+      const broadcastFx = (typeof NET_ON === 'function' ? NET_ON() : false)
+        && typeof MY_SEAT === 'number'
+        && typeof gameState?.active === 'number'
+        && MY_SEAT === gameState.active;
+      playFieldquakeFx(
+        { r, c, prevElement: prevEl, nextElement: nextEl },
+        { broadcast: broadcastFx },
+      );
       const u = gameState.board[r][c].unit;
       if (u) {
         const tplUnit = CARDS[u.tplId];

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -20,6 +20,7 @@ import {
   showOracleDeathBuff,
   hasPendingForcedDiscards,
 } from '../scene/interactions.js';
+import { playFieldquakeFxBatch } from '../scene/fieldquakeFx.js';
 
 export function rotateUnit(unitMesh, dir) {
   try {
@@ -363,6 +364,13 @@ export function confirmUnitAbilityOrientation(context, direction) {
       for (const text of result.events.discardLogs) {
         if (text) w.addLog?.(text);
       }
+    }
+
+    if (Array.isArray(result.summonEvents?.fieldquakes) && result.summonEvents.fieldquakes.length) {
+      const broadcastFx = (typeof w.NET_ON === 'function' ? w.NET_ON() : false)
+        && typeof w.MY_SEAT === 'number'
+        && w.MY_SEAT === gameState.active;
+      playFieldquakeFxBatch(result.summonEvents.fieldquakes, { broadcast: broadcastFx });
     }
 
     if (result.summonEvents?.possessions?.length) {

--- a/tests/fieldquake.test.js
+++ b/tests/fieldquake.test.js
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+import { CARDS } from '../src/core/cards.js';
+import {
+  applySummonAbilities,
+  collectDamageInteractions,
+  applyDamageInteractionResults,
+} from '../src/core/abilities.js';
+import { magicAttack } from '../src/core/rules.js';
+import { computeFieldquakeLockedCells } from '../src/core/fieldLocks.js';
+import { computeDynamicAttackBonus } from '../src/core/abilityHandlers/dynamicAttack.js';
+
+function makeBoard(defaultElement = 'FIRE') {
+  return Array.from({ length: 3 }, (_, r) => (
+    Array.from({ length: 3 }, (_, c) => ({
+      element: (r === 1 && c === 1) ? 'BIOLITH' : defaultElement,
+      unit: null,
+    }))
+  ));
+}
+
+describe('fieldquake-эффекты биолит-карт', () => {
+  it('Behemoth Groundbreaker меняет стихии соседних клеток при призыве', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [
+        { graveyard: [] },
+        { graveyard: [] },
+      ],
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[2][1].element = 'WATER';
+    state.board[1][0].element = 'FOREST';
+    state.board[1][2].element = 'EARTH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_BEHEMOTH_GROUNDBREAKER',
+      currentHP: 4,
+    };
+
+    const events = applySummonAbilities(state, 1, 1);
+
+    expect(state.board[0][1].element).toBe('WATER');
+    expect(state.board[2][1].element).toBe('FIRE');
+    expect(state.board[1][0].element).toBe('EARTH');
+    expect(state.board[1][2].element).toBe('FOREST');
+    expect(events.fieldquakes).toHaveLength(4);
+    for (const fq of events.fieldquakes) {
+      expect(fq).toHaveProperty('prevElement');
+      expect(fq).toHaveProperty('nextElement');
+    }
+  });
+
+  it('Groundbreaker мгновенно уничтожает существ с нулевым HP после fieldquake', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [
+        { graveyard: [] },
+        { graveyard: [] },
+      ],
+    };
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_BEHEMOTH_GROUNDBREAKER',
+      currentHP: 4,
+    };
+
+    const events = applySummonAbilities(state, 1, 1);
+
+    expect(state.board[0][1].unit).toBeNull();
+    expect(events.deaths).toHaveLength(1);
+    expect(events.deaths[0].tplId).toBe('FIRE_PARTMOLE_FLAME_LIZARD');
+    expect(state.players[1].graveyard).toHaveLength(1);
+  });
+
+  it('Undead King Novogus вызывает fieldquake при уроне вне земли', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'FOREST';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const tpl = CARDS.BIOLITH_UNDEAD_KING_NOVOGUS;
+    const interactions = collectDamageInteractions(state, {
+      attackerPos: { r: 1, c: 1 },
+      attackerUnit: state.board[1][1].unit,
+      tpl,
+      hits: [ { r: 0, c: 1, dealt: 2 } ],
+    });
+
+    expect(interactions.events).toHaveLength(1);
+    expect(interactions.preventRetaliation.has('0,1')).toBe(true);
+
+    const applied = applyDamageInteractionResults(state, interactions);
+    expect(state.board[0][1].element).toBe('WATER');
+    expect(applied.logLines.some(line => line.includes('Fieldquake'))).toBe(true);
+    expect(applied.fieldquakes).toHaveLength(1);
+    expect(applied.fieldquakes[0]).toMatchObject({ r: 0, c: 1, prevElement: 'FIRE', nextElement: 'WATER' });
+  });
+
+  it('Novogus удаляет цель, потерявшую все HP от смены поля', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [
+        { graveyard: [] },
+        { graveyard: [] },
+      ],
+    };
+    state.board[1][1].element = 'FOREST';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const tpl = CARDS.BIOLITH_UNDEAD_KING_NOVOGUS;
+    const interactions = collectDamageInteractions(state, {
+      attackerPos: { r: 1, c: 1 },
+      attackerUnit: state.board[1][1].unit,
+      tpl,
+      hits: [ { r: 0, c: 1, dealt: 1 } ],
+    });
+
+    const applied = applyDamageInteractionResults(state, interactions);
+
+    expect(state.board[0][1].unit).toBeNull();
+    expect(applied.deaths).toHaveLength(1);
+    expect(applied.deaths[0].tplId).toBe('FIRE_PARTMOLE_FLAME_LIZARD');
+  });
+
+  it('Novogus наносит урон до fieldquake, цель не возрождается за счёт смены поля', () => {
+    const state = {
+      board: makeBoard('WATER'),
+      players: [
+        { mana: 10 },
+        { mana: 10 },
+      ],
+      turn: 1,
+      active: 0,
+    };
+    state.board[1][1].element = 'FOREST';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'WATER';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const result = magicAttack(state, 1, 1, 0, 1);
+
+    expect(result).not.toBeNull();
+    expect(result.fieldquakes).toHaveLength(1);
+    expect(result.fieldquakes[0]).toMatchObject({ prevElement: 'WATER', nextElement: 'FIRE' });
+    expect(result.n1.board[0][1].unit).toBeNull();
+  });
+
+  it('Novogus не срабатывает на земле', () => {
+    const state = {
+      board: makeBoard('EARTH'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'EARTH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    state.board[0][1].element = 'FIRE';
+    state.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+
+    const tpl = CARDS.BIOLITH_UNDEAD_KING_NOVOGUS;
+    const interactions = collectDamageInteractions(state, {
+      attackerPos: { r: 1, c: 1 },
+      attackerUnit: state.board[1][1].unit,
+      tpl,
+      hits: [ { r: 0, c: 1, dealt: 2 } ],
+    });
+
+    expect(interactions.events).toHaveLength(0);
+  });
+
+  it('Novogus вызывает fieldquake при повторных магических атаках', () => {
+    const baseState = {
+      board: makeBoard('FIRE'),
+      players: [ { mana: 10 }, { mana: 10 } ],
+      turn: 1,
+      active: 0,
+    };
+    baseState.board[1][1].element = 'FOREST';
+    baseState.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_UNDEAD_KING_NOVOGUS',
+      currentHP: 6,
+    };
+    baseState.board[0][1].element = 'FIRE';
+    baseState.board[0][1].unit = {
+      owner: 1,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 10,
+    };
+
+    const res1 = magicAttack(baseState, 1, 1, 0, 1);
+    expect(res1?.fieldquakes).toHaveLength(1);
+    expect(res1.n1.board[0][1].element).toBe('WATER');
+
+    const nextState = res1.n1;
+    nextState.turn = (nextState.turn || 1) + 1;
+    const res2 = magicAttack(nextState, 1, 1, 0, 1);
+    expect(res2?.fieldquakes).toHaveLength(1);
+    expect(res2.n1.board[0][1].element).toBe('FIRE');
+  });
+
+  it('Ouroboros Dragon получает бонус и блокирует fieldquake на биолите', () => {
+    const state = {
+      board: makeBoard('FIRE'),
+      players: [{}, {}],
+    };
+    state.board[1][1].element = 'BIOLITH';
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_OUROBOROS_DRAGON',
+      currentHP: 10,
+    };
+    state.board[0][0].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_MORNING_STAR_WARRIOR',
+      currentHP: 3,
+    };
+    state.board[2][2].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_BIOLITH_STINGER',
+      currentHP: 1,
+    };
+
+    const bonus = computeDynamicAttackBonus(state, 1, 1, CARDS.BIOLITH_OUROBOROS_DRAGON);
+    expect(bonus?.amount).toBe(2);
+
+    const locked = computeFieldquakeLockedCells(state);
+    expect(locked).toHaveLength(9);
+
+    state.board[1][1].element = 'FIRE';
+    const unlocked = computeFieldquakeLockedCells(state);
+    expect(unlocked.length).toBeLessThan(9);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent fieldquake transitions from restoring HP to already defeated units after Novogus attacks
- add regression coverage ensuring fieldquake occurs after damage without reviving the target

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7d3c5b868833095189062bb71be09