### PR TITLE
Add reusable summon mana gain logic and new Biolith units

### DIFF
--- a/src/core/abilityHandlers/attackModifiers.js
+++ b/src/core/abilityHandlers/attackModifiers.js
@@ -1,5 +1,6 @@
 // Обработчики модификаторов атаки, зависящих от параметров цели
 import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
 
 function normalizeLimit(value) {
   if (value == null) return null;
@@ -89,6 +90,123 @@ function targetHp(state, hit, useCurrent = true) {
   return (typeof tpl.hp === 'number' && Number.isFinite(tpl.hp)) ? tpl.hp : null;
 }
 
+function normalizeOwnerToken(raw) {
+  const value = typeof raw === 'string' ? raw.trim().toUpperCase() : null;
+  if (value === 'ALLY' || value === 'ALLIED' || value === 'FRIENDLY' || value === 'SELF') return 'ALLY';
+  if (value === 'ENEMY' || value === 'OPPONENT' || value === 'FOE') return 'ENEMY';
+  if (value === 'ANY' || value === 'BOTH') return 'ANY';
+  return null;
+}
+
+function normalizeTargetMatchConfig(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const owner = normalizeOwnerToken(raw.owner || raw.side || raw.affinity);
+  const element = normalizeElementName(raw.element || raw.elementType || raw.matchElement);
+  if (!owner && !element) return null;
+  return { owner, element };
+}
+
+function normalizeCountStrategy(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const token = raw.trim().toUpperCase();
+    if (!token) return null;
+    if (token === 'NON_ELEMENT') {
+      return { type: 'NON_ELEMENT', element: null };
+    }
+    const el = normalizeElementName(token);
+    if (el) return { type: 'NON_ELEMENT', element: el };
+    return null;
+  }
+  if (typeof raw === 'object') {
+    const type = (raw.type || raw.mode || raw.count || raw.strategy || '').toUpperCase();
+    if (type === 'NON_ELEMENT' || type === 'NOT_ELEMENT') {
+      const element = normalizeElementName(raw.element || raw.elementType || raw.exclude);
+      return { type: 'NON_ELEMENT', element };
+    }
+    if (!type && raw.element) {
+      const element = normalizeElementName(raw.element);
+      return { type: 'NON_ELEMENT', element };
+    }
+  }
+  return null;
+}
+
+function normalizeTargetCountAttackConfig(raw, tpl) {
+  if (!raw || typeof raw !== 'object') return null;
+  const match = normalizeTargetMatchConfig(raw.match || raw.when || raw.if || raw.target);
+  const count = normalizeCountStrategy(raw.count || raw.counter || raw.measure);
+  const baseValue = Number.isFinite(raw.baseValue)
+    ? Math.floor(raw.baseValue)
+    : Number.isFinite(raw.base)
+      ? Math.floor(raw.base)
+      : (Number.isFinite(tpl?.atk) ? tpl.atk : 0);
+  const amountPer = Number.isFinite(raw.amountPer)
+    ? Math.floor(raw.amountPer)
+    : Number.isFinite(raw.per)
+      ? Math.floor(raw.per)
+      : 1;
+  const log = typeof raw.log === 'string' ? raw.log : null;
+  if (!count) return null;
+  return { match, count, baseValue, amountPer, log };
+}
+
+function formatCountAttackLog(template, data) {
+  if (!template) return null;
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const lower = key.toLowerCase();
+    if (lower === 'targetvalue' || lower === 'value') return String(data.targetValue ?? '');
+    if (lower === 'count') return String(data.count ?? '');
+    return match;
+  });
+}
+
+function isUnitAlive(unit, tpl) {
+  if (!unit || !tpl) return false;
+  if (typeof unit.currentHP === 'number') return unit.currentHP > 0;
+  if (typeof tpl.hp === 'number') return tpl.hp > 0;
+  return true;
+}
+
+function evaluateCountConfig(state, cfg, opts = {}) {
+  if (!cfg || !state?.board) return 0;
+  if (cfg.type === 'NON_ELEMENT') {
+    const excludeElement = cfg.element || null;
+    let total = 0;
+    for (let r = 0; r < state.board.length; r += 1) {
+      const row = state.board[r];
+      if (!Array.isArray(row)) continue;
+      for (let c = 0; c < row.length; c += 1) {
+        const unit = row[c]?.unit;
+        if (!unit) continue;
+        if (opts.exclude && r === opts.exclude.r && c === opts.exclude.c) continue;
+        const tpl = CARDS[unit.tplId];
+        if (!tpl || !isUnitAlive(unit, tpl)) continue;
+        const el = normalizeElementName(tpl.element);
+        if (excludeElement && el === excludeElement) continue;
+        total += 1;
+      }
+    }
+    return total;
+  }
+  return 0;
+}
+
+function matchTargetCondition(state, hit, cfg, sourceOwner) {
+  if (!cfg) return true;
+  const unit = state.board?.[hit.r]?.[hit.c]?.unit;
+  if (!unit) return false;
+  const tpl = CARDS[unit.tplId];
+  if (!tpl || !isUnitAlive(unit, tpl)) return false;
+  if (cfg.owner === 'ALLY' && sourceOwner != null && unit.owner !== sourceOwner) return false;
+  if (cfg.owner === 'ENEMY' && sourceOwner != null && unit.owner === sourceOwner) return false;
+  if (cfg.element) {
+    const el = normalizeElementName(tpl.element);
+    if (el !== cfg.element) return false;
+  }
+  return true;
+}
+
 export function computeTargetCostBonus(state, tpl, hits) {
   if (!tpl || !Array.isArray(hits) || !hits.length) return null;
   const cfgRaw = tpl.plusAtkVsSummonCostAtMost || tpl.plusAtkIfTargetCostLeq;
@@ -122,4 +240,22 @@ export function computeTargetHpBonus(state, tpl, hits) {
   });
   if (!qualifies) return null;
   return { amount, threshold };
+}
+
+export function computeTargetCountAttack(state, tpl, hits, opts = {}) {
+  if (!tpl || !tpl.targetCountAttack || !Array.isArray(hits) || !hits.length) return null;
+  const cfg = normalizeTargetCountAttackConfig(tpl.targetCountAttack, tpl);
+  if (!cfg) return null;
+  const owner = opts.owner ?? state?.board?.[opts.r]?.[opts.c]?.unit?.owner ?? null;
+  const match = hits.some(hit => matchTargetCondition(state, hit, cfg.match, owner));
+  if (!match) return null;
+  const count = evaluateCountConfig(state, cfg.count, { exclude: opts.exclude });
+  const total = cfg.baseValue + cfg.amountPer * count;
+  const log = formatCountAttackLog(cfg.log, { targetValue: total, count });
+  return {
+    attackValue: total,
+    count,
+    targetValue: total,
+    log,
+  };
 }

--- a/src/core/abilityHandlers/manaOnSummon.js
+++ b/src/core/abilityHandlers/manaOnSummon.js
@@ -1,0 +1,180 @@
+// Логика генерации маны при призыве существ (чистая игровая логика)
+import { CARDS } from '../cards.js';
+import { capMana } from '../constants.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+const BOARD_SIZE = 3;
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeTrigger(raw) {
+  const value = typeof raw === 'string' ? raw.trim().toUpperCase() : null;
+  if (value === 'ALLY' || value === 'ALLIED' || value === 'FRIENDLY' || value === 'SELF') {
+    return 'ALLY';
+  }
+  if (value === 'ENEMY' || value === 'OPPONENT' || value === 'FOE') {
+    return 'ENEMY';
+  }
+  if (value === 'ANY' || value === 'BOTH') {
+    return 'ANY';
+  }
+  return 'ALLY';
+}
+
+function parseElement(raw) {
+  if (!raw) return null;
+  return normalizeElementName(raw);
+}
+
+function normalizeConfigEntry(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return { trigger: 'ALLY', amount: 1, excludeSelfSummon: true };
+  }
+  if (typeof raw !== 'object') return null;
+  const trigger = normalizeTrigger(raw.trigger || raw.type || raw.mode);
+  const amount = Number.isFinite(raw.amount)
+    ? Math.floor(raw.amount)
+    : Number.isFinite(raw.gain)
+      ? Math.floor(raw.gain)
+      : 1;
+  const entry = {
+    trigger,
+    amount: Math.max(0, amount),
+    excludeSelfSummon: raw.excludeSelfSummon === true || raw.excludeSelf === true,
+    log: typeof raw.log === 'string' ? raw.log : null,
+    sourceFieldElement: parseElement(raw.sourceFieldElement || raw.sourceElement || raw.sourceOnElement),
+    sourceFieldNotElement: parseElement(raw.sourceFieldNotElement || raw.sourceFieldNot || raw.sourceNotElement),
+    summonFieldElement: parseElement(raw.summonFieldElement || raw.targetFieldElement || raw.summonElement),
+    summonFieldNotElement: parseElement(raw.summonFieldNotElement || raw.summonFieldNot || raw.summonNotElement),
+    requireSummonedElement: parseElement(raw.requireSummonedElement || raw.summonedElement || raw.unitElement),
+  };
+  return entry;
+}
+
+function normalizeConfigs(raw) {
+  const res = [];
+  for (const item of toArray(raw)) {
+    const cfg = normalizeConfigEntry(item);
+    if (cfg && cfg.amount > 0) {
+      res.push(cfg);
+    }
+  }
+  return res;
+}
+
+function formatLog(template, data) {
+  if (!template) return null;
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const lower = key.toLowerCase();
+    if (lower === 'amount') return String(data.amount ?? '');
+    if (lower === 'name') return data.name ?? '';
+    if (lower === 'player') return data.player ?? '';
+    if (lower === 'targetvalue') return String(data.targetValue ?? '');
+    if (lower === 'count') return String(data.count ?? '');
+    return match;
+  });
+}
+
+function shouldTrigger(cfg, ctx) {
+  const { sourceOwner, summonOwner, sourcePos, summonPos, sourceElement, summonFieldElement, summonedElement } = ctx;
+  if (cfg.trigger === 'ALLY' && (sourceOwner == null || sourceOwner !== summonOwner)) {
+    return false;
+  }
+  if (cfg.trigger === 'ENEMY' && (sourceOwner == null || summonOwner == null || sourceOwner === summonOwner)) {
+    return false;
+  }
+  if (cfg.excludeSelfSummon && sourcePos && summonPos && sourcePos.r === summonPos.r && sourcePos.c === summonPos.c) {
+    return false;
+  }
+  if (cfg.sourceFieldElement && sourceElement !== cfg.sourceFieldElement) {
+    return false;
+  }
+  if (cfg.sourceFieldNotElement && sourceElement === cfg.sourceFieldNotElement) {
+    return false;
+  }
+  if (cfg.summonFieldElement && summonFieldElement !== cfg.summonFieldElement) {
+    return false;
+  }
+  if (cfg.summonFieldNotElement && summonFieldElement === cfg.summonFieldNotElement) {
+    return false;
+  }
+  if (cfg.requireSummonedElement && summonedElement !== cfg.requireSummonedElement) {
+    return false;
+  }
+  return true;
+}
+
+function getCellElement(state, r, c) {
+  return normalizeElementName(state?.board?.[r]?.[c]?.element);
+}
+
+function isUnitAlive(unit, tpl) {
+  if (!unit || !tpl) return false;
+  if (typeof unit.currentHP === 'number') {
+    return unit.currentHP > 0;
+  }
+  if (typeof tpl.hp === 'number') {
+    return tpl.hp > 0;
+  }
+  return true;
+}
+
+export function applyManaGainOnSummon(state, context = {}) {
+  const events = [];
+  if (!state?.board || !Array.isArray(state.players)) return events;
+  const summonOwner = context.unit?.owner ?? context.owner ?? null;
+  const summonPos = { r: context.r ?? null, c: context.c ?? null };
+  const summonFieldElement = parseElement(
+    context.cell?.element ?? (typeof context.fieldElement === 'string' ? context.fieldElement : null)
+  );
+  const summonedTpl = context.tpl || (context.unit ? CARDS[context.unit.tplId] : null);
+  const summonedElement = parseElement(summonedTpl?.element);
+
+  for (let r = 0; r < BOARD_SIZE; r += 1) {
+    for (let c = 0; c < BOARD_SIZE; c += 1) {
+      const cell = state.board?.[r]?.[c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl?.manaOnSummon) continue;
+      if (!isUnitAlive(unit, tpl)) continue;
+      const configs = normalizeConfigs(tpl.manaOnSummon);
+      if (!configs.length) continue;
+      const sourceOwner = unit.owner;
+      const sourceElement = getCellElement(state, r, c);
+      for (const cfg of configs) {
+        if (!shouldTrigger(cfg, { sourceOwner, summonOwner, sourcePos: { r, c }, summonPos, sourceElement, summonFieldElement, summonedElement })) {
+          continue;
+        }
+        const player = state.players[sourceOwner];
+        if (!player) continue;
+        const before = typeof player.mana === 'number' ? player.mana : 0;
+        const after = capMana(before + cfg.amount);
+        const gained = after - before;
+        if (gained <= 0) continue;
+        player.mana = after;
+        events.push({
+          owner: sourceOwner,
+          before,
+          after,
+          amount: gained,
+          r,
+          c,
+          tplId: tpl.id,
+          log: formatLog(cfg.log, {
+            amount: gained,
+            name: tpl.name || tpl.id || 'Существо',
+            player: (sourceOwner ?? 0) + 1,
+          }),
+        });
+      }
+    }
+  }
+  return events;
+}
+
+export default { applyManaGainOnSummon };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -29,7 +29,13 @@ export const CARDS = {
     element: 'FIRE', atk: 1, hp: 2,
     attackType: 'STANDARD', pierce: true,
     attacks: [ { dir: 'N', ranges: [1] } ],
-    blindspots: ['S'], auraGainManaOnSummon: true,
+    blindspots: ['S'],
+    manaOnSummon: {
+      trigger: 'ALLY',
+      sourceFieldNotElement: 'FIRE',
+      excludeSelfSummon: true,
+      log: 'Фридонийский Странник приносит {amount} маны.',
+    },
     desc: 'While Freedonian Wanderer is on a non‑Fire field, you gain 1 mana each time you summon an allied creature.'
   },
   FIRE_PARTMOLE_FLAME_LIZARD: {
@@ -475,6 +481,69 @@ export const CARDS = {
       { stat: 'PROTECTION', amount: 1, scope: 'ADJACENT', target: 'ALLY' },
     ],
     desc: 'Allied creatures on adjacent fields gain +1 Protection.'
+  },
+
+  BIOLITH_IMPERIAL_BIOLITH_GUARD: {
+    id: 'BIOLITH_IMPERIAL_BIOLITH_GUARD', name: 'Imperial Biolith Guard', type: 'UNIT', cost: 3, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'E', ranges: [1], group: 'SIDE_SWEEP', ignoreAlliedBlocking: true },
+      { dir: 'W', ranges: [1], group: 'SIDE_SWEEP', ignoreAlliedBlocking: true },
+    ],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    manaOnSummon: {
+      trigger: 'ALLY',
+      summonFieldElement: 'BIOLITH',
+      excludeSelfSummon: true,
+      log: 'Imperial Biolith Guard генерирует {amount} ману за биолитовый призыв.',
+    },
+    desc: 'Gain 1 mana each time you summon a creature to a Biolith field.'
+  },
+
+  BIOLITH_WORMAK_HEIR: {
+    id: 'BIOLITH_WORMAK_HEIR', name: 'Wormak Heir to the Bioliths', type: 'UNIT', cost: 4, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    targetCountAttack: {
+      match: { owner: 'ENEMY', element: 'BIOLITH' },
+      count: { type: 'NON_ELEMENT', element: 'BIOLITH' },
+      baseValue: 2,
+      amountPer: 1,
+      log: 'Wormak Heir to the Bioliths: атака против биолитов установлена на {targetValue} (небиолитовых существ: {count}).',
+    },
+    manaOnSummon: {
+      trigger: 'ENEMY',
+      log: 'Wormak Heir to the Bioliths получает {amount} ману за призыв врага.',
+    },
+    desc: "If the target is an enemy Biolith, Wormak's Attack is equal to 2 plus the number of non-Biolith creatures on the board.\nGain 1 mana each time an enemy is summoned."
+  },
+
+  BIOLITH_TINO_SON_OF_SCION: {
+    id: 'BIOLITH_TINO_SON_OF_SCION', name: 'Tino, Son of Scion', type: 'UNIT', cost: 4, activation: 3,
+    element: 'BIOLITH', atk: 3, hp: 4,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    magicTargetsSameElement: true,
+    dynamicAtkAlliedElementOnField: {
+      element: 'BIOLITH',
+      baseValue: 1,
+      amountPer: 1,
+      requireFieldElement: 'BIOLITH',
+      includeSelf: false,
+    },
+    manaOnSummon: {
+      trigger: 'ALLY',
+      excludeSelfSummon: true,
+      log: 'Tino, Son of Scion приносит {amount} ману.',
+    },
+    desc: "Tino's Magic Attack targets all enemies of the same element as the target.\nWhile Tino is on a Biolith field, his Attack is equal to 1 plus the number of other allied Biolith creatures.\nGain 1 mana each time you summon a creature."
   },
 
   BIOLITH_MORNING_STAR_WARRIOR: {


### PR DESCRIPTION
## Summary
- extract a reusable summon mana gain handler and migrate Freedonian Wanderer alongside three new Biolith cards to it
- implement allied Biolith attack scaling and target-count attack adjustments for the new units
- hook summon mana gain events into scene/UI animations and extend rules tests for the new mechanics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8df8413e0833089c050540b6f4309