### PR TITLE
Fix mana gain rollback on cancelled summons

### DIFF
--- a/src/core/abilityHandlers/manaOnSummon.js
+++ b/src/core/abilityHandlers/manaOnSummon.js
@@ -1,0 +1,167 @@
+// Логика генерации маны при призыве существ (ауры и пассивные способности)
+// Модуль не содержит визуального кода и может быть переиспользован при миграции на Unity
+import { CARDS } from '../cards.js';
+import { capMana } from '../constants.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function normalizeTrigger(raw) {
+  const value = typeof raw === 'string' ? raw.trim().toUpperCase() : null;
+  if (value === 'ALLY' || value === 'ALLIED' || value === 'FRIENDLY' || value === 'SELF') {
+    return 'ALLY';
+  }
+  if (value === 'ENEMY' || value === 'OPPONENT' || value === 'FOE') {
+    return 'ENEMY';
+  }
+  if (value === 'ANY' || value === 'BOTH') {
+    return 'ANY';
+  }
+  return 'ALLY';
+}
+
+function parseElement(raw) {
+  if (!raw) return null;
+  return normalizeElementName(raw);
+}
+
+function normalizeConfigEntry(raw) {
+  if (!raw) return null;
+  if (raw === true) {
+    return { trigger: 'ALLY', amount: 1, excludeSelfSummon: true };
+  }
+  if (typeof raw !== 'object') return null;
+  const trigger = normalizeTrigger(raw.trigger || raw.type || raw.mode);
+  const amount = Number.isFinite(raw.amount)
+    ? Math.floor(raw.amount)
+    : Number.isFinite(raw.gain)
+      ? Math.floor(raw.gain)
+      : 1;
+  const entry = {
+    trigger,
+    amount: Math.max(0, amount),
+    excludeSelfSummon: raw.excludeSelfSummon === true || raw.excludeSelf === true,
+    log: typeof raw.log === 'string' ? raw.log : null,
+    sourceFieldElement: parseElement(raw.sourceFieldElement || raw.sourceElement || raw.sourceOnElement),
+    sourceFieldNotElement: parseElement(raw.sourceFieldNotElement || raw.sourceFieldNot || raw.sourceNotElement),
+    summonFieldElement: parseElement(raw.summonFieldElement || raw.targetFieldElement || raw.summonElement),
+    summonFieldNotElement: parseElement(raw.summonFieldNotElement || raw.summonFieldNot || raw.summonNotElement),
+    requireSummonedElement: parseElement(raw.requireSummonedElement || raw.summonedElement || raw.unitElement),
+  };
+  return entry;
+}
+
+function normalizeConfigs(raw) {
+  const res = [];
+  for (const item of toArray(raw)) {
+    const cfg = normalizeConfigEntry(item);
+    if (cfg && cfg.amount > 0) {
+      res.push(cfg);
+    }
+  }
+  return res;
+}
+
+function formatLog(template, data) {
+  if (!template) return null;
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const lower = key.toLowerCase();
+    if (lower === 'amount') return String(data.amount ?? '');
+    if (lower === 'name') return data.name ?? '';
+    if (lower === 'player') return data.player ?? '';
+    if (lower === 'count') return data.count ?? '';
+    if (lower === 'targetvalue') return data.targetValue ?? '';
+    return match;
+  });
+}
+
+function shouldTrigger(cfg, ctx) {
+  const { sourceOwner, summonOwner, sourcePos, summonPos, sourceElement, summonFieldElement, summonedElement } = ctx;
+  if (cfg.trigger === 'ALLY' && (sourceOwner == null || sourceOwner !== summonOwner)) {
+    return false;
+  }
+  if (cfg.trigger === 'ENEMY' && (sourceOwner == null || summonOwner == null || sourceOwner === summonOwner)) {
+    return false;
+  }
+  if (cfg.excludeSelfSummon && sourcePos && summonPos && sourcePos.r === summonPos.r && sourcePos.c === summonPos.c) {
+    return false;
+  }
+  if (cfg.sourceFieldElement && sourceElement !== cfg.sourceFieldElement) {
+    return false;
+  }
+  if (cfg.sourceFieldNotElement && sourceElement === cfg.sourceFieldNotElement) {
+    return false;
+  }
+  if (cfg.summonFieldElement && summonFieldElement !== cfg.summonFieldElement) {
+    return false;
+  }
+  if (cfg.summonFieldNotElement && summonFieldElement === cfg.summonFieldNotElement) {
+    return false;
+  }
+  if (cfg.requireSummonedElement && summonedElement !== cfg.requireSummonedElement) {
+    return false;
+  }
+  return true;
+}
+
+export function applyManaGainOnSummon(state, context = {}) {
+  const events = [];
+  if (!state?.board || !Array.isArray(state.players)) return events;
+  const summonOwner = context.unit?.owner ?? context.owner ?? null;
+  const summonPos = { r: context.r ?? null, c: context.c ?? null };
+  const summonFieldElement = parseElement(
+    context.cell?.element ?? (typeof context.fieldElement === 'string' ? context.fieldElement : null)
+  );
+  const summonedTpl = context.tpl || (context.unit ? CARDS[context.unit.tplId] : null);
+  const summonedElement = parseElement(summonedTpl?.element);
+
+  for (let r = 0; r < state.board.length; r += 1) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c += 1) {
+      const cell = row[c];
+      const unit = cell?.unit;
+      if (!unit) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl?.manaOnSummon) continue;
+      const configs = normalizeConfigs(tpl.manaOnSummon);
+      if (!configs.length) continue;
+      const sourceOwner = unit.owner;
+      const sourceElement = parseElement(cell?.element);
+      for (const cfg of configs) {
+        if (!shouldTrigger(cfg, { sourceOwner, summonOwner, sourcePos: { r, c }, summonPos, sourceElement, summonFieldElement, summonedElement })) {
+          continue;
+        }
+        const player = state.players[sourceOwner];
+        if (!player) continue;
+        const before = typeof player.mana === 'number' ? player.mana : 0;
+        const after = capMana(before + cfg.amount);
+        const gained = after - before;
+        if (gained <= 0) continue;
+        player.mana = after;
+        const entry = {
+          owner: sourceOwner,
+          before,
+          after,
+          amount: gained,
+          r,
+          c,
+          tplId: tpl.id,
+          source: { r, c },
+          log: formatLog(cfg.log, {
+            amount: gained,
+            name: tpl.name || tpl.id || 'Существо',
+            player: (sourceOwner ?? 0) + 1,
+          }),
+        };
+        events.push(entry);
+      }
+    }
+  }
+  return events;
+}
+
+export default { applyManaGainOnSummon };

--- a/src/core/abilityHandlers/targetCountAttack.js
+++ b/src/core/abilityHandlers/targetCountAttack.js
@@ -1,0 +1,149 @@
+// Поддержка эффектов, изменяющих атаку в зависимости от цели и количества существ
+// Чистая игровая логика без зависимостей от визуального слоя
+import { CARDS } from '../cards.js';
+import { normalizeElementName } from '../utils/elements.js';
+
+function normalizeOwnerToken(raw) {
+  if (typeof raw !== 'string') return null;
+  const token = raw.trim().toUpperCase();
+  if (token === 'ALLY' || token === 'ALLIED' || token === 'FRIENDLY' || token === 'SELF') return 'ALLY';
+  if (token === 'ENEMY' || token === 'OPPONENT' || token === 'FOE') return 'ENEMY';
+  if (token === 'ANY' || token === 'BOTH') return 'ANY';
+  return null;
+}
+
+function normalizeMatchConfig(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const owner = normalizeOwnerToken(raw.owner || raw.by || raw.side);
+  const element = normalizeElementName(raw.element || raw.targetElement);
+  const fieldElement = normalizeElementName(raw.fieldElement || raw.field || raw.requireFieldElement);
+  return { owner, element, fieldElement };
+}
+
+function normalizeCountConfig(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const token = raw.trim().toUpperCase();
+    if (token.startsWith('NON_')) {
+      const el = normalizeElementName(token.replace(/^NON_/, ''));
+      if (!el) return null;
+      return { type: 'NON_ELEMENT', element: el };
+    }
+    return null;
+  }
+  if (typeof raw === 'object') {
+    const type = (raw.type || raw.mode || '').toString().toUpperCase();
+    if (type === 'NON_ELEMENT' || type === 'NON_ELEMENTAL') {
+      const element = normalizeElementName(raw.element || raw.reference || raw.exclude);
+      if (!element) return null;
+      return { type: 'NON_ELEMENT', element };
+    }
+  }
+  return null;
+}
+
+function normalizeTargetCountConfig(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const match = normalizeMatchConfig(raw.match || raw.condition || raw.when);
+  const count = normalizeCountConfig(raw.count || raw.counter || raw.by || raw.source);
+  if (!count) return null;
+  const baseValue = Number.isFinite(raw.baseValue)
+    ? Number(raw.baseValue)
+    : Number.isFinite(raw.base)
+      ? Number(raw.base)
+      : Number.isFinite(raw.value)
+        ? Number(raw.value)
+        : 0;
+  const amountPer = Number.isFinite(raw.amountPer)
+    ? Number(raw.amountPer)
+    : Number.isFinite(raw.per)
+      ? Number(raw.per)
+      : Number.isFinite(raw.factor)
+        ? Number(raw.factor)
+        : 1;
+  const log = typeof raw.log === 'string' ? raw.log : null;
+  return { match, count, baseValue, amountPer, log };
+}
+
+function targetMatchesCondition(state, targetPos, cfg, attackerOwner) {
+  if (!cfg) return true;
+  const cell = state?.board?.[targetPos.r]?.[targetPos.c];
+  const unit = cell?.unit;
+  if (!unit) return false;
+  const tpl = CARDS[unit.tplId];
+  if (!tpl) return false;
+  if (cfg.owner === 'ALLY' && attackerOwner != null && unit.owner !== attackerOwner) return false;
+  if (cfg.owner === 'ENEMY' && attackerOwner != null && unit.owner === attackerOwner) return false;
+  if (cfg.element) {
+    const elem = normalizeElementName(tpl.element);
+    if (!elem || elem !== cfg.element) return false;
+  }
+  if (cfg.fieldElement) {
+    const cellElement = normalizeElementName(cell?.element);
+    if (!cellElement || cellElement !== cfg.fieldElement) return false;
+  }
+  return true;
+}
+
+function countUnitsByConfig(state, cfg) {
+  if (!state?.board || !cfg) return 0;
+  if (cfg.type === 'NON_ELEMENT') {
+    const element = cfg.element;
+    let total = 0;
+    for (let r = 0; r < state.board.length; r += 1) {
+      const row = state.board[r];
+      if (!Array.isArray(row)) continue;
+      for (let c = 0; c < row.length; c += 1) {
+        const unit = row[c]?.unit;
+        if (!unit) continue;
+        const tpl = CARDS[unit.tplId];
+        if (!tpl) continue;
+        const elem = normalizeElementName(tpl.element);
+        if (!elem || elem !== element) {
+          total += 1;
+        }
+      }
+    }
+    return total;
+  }
+  return 0;
+}
+
+function formatLog(template, data) {
+  if (!template) return null;
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const lower = key.toLowerCase();
+    if (lower === 'count') return String(data.count ?? '');
+    if (lower === 'targetvalue' || lower === 'value') return String(data.targetValue ?? '');
+    if (lower === 'amount') return String(data.amount ?? '');
+    if (lower === 'name') return data.name ?? '';
+    return match;
+  });
+}
+
+export function computeTargetCountAttack(state, attackerPos, targetPos, tpl, opts = {}) {
+  if (!tpl?.targetCountAttack) return null;
+  const cfg = normalizeTargetCountConfig(tpl.targetCountAttack);
+  if (!cfg) return null;
+  if (!state || !attackerPos || !targetPos) return null;
+  const attackerOwner = opts.attackerUnit?.owner
+    ?? state.board?.[attackerPos.r]?.[attackerPos.c]?.unit?.owner
+    ?? null;
+  if (!targetMatchesCondition(state, targetPos, cfg.match, attackerOwner)) {
+    return null;
+  }
+  const count = countUnitsByConfig(state, cfg.count);
+  const targetValue = cfg.baseValue + cfg.amountPer * count;
+  if (!Number.isFinite(targetValue)) return null;
+  const baseAtk = Number.isFinite(tpl.atk) ? tpl.atk : 0;
+  const amount = targetValue - baseAtk;
+  const log = formatLog(cfg.log, {
+    count,
+    targetValue,
+    amount,
+    name: tpl.name || tpl.id || 'Существо',
+  });
+  return { targetValue, amount, count, log };
+}
+
+export default { computeTargetCountAttack };

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -29,7 +29,13 @@ export const CARDS = {
     element: 'FIRE', atk: 1, hp: 2,
     attackType: 'STANDARD', pierce: true,
     attacks: [ { dir: 'N', ranges: [1] } ],
-    blindspots: ['S'], auraGainManaOnSummon: true,
+    blindspots: ['S'],
+    manaOnSummon: {
+      trigger: 'ALLY',
+      sourceFieldNotElement: 'FIRE',
+      excludeSelfSummon: true,
+      log: 'Фридонийский Странник приносит {amount} маны.',
+    },
     desc: 'While Freedonian Wanderer is on a non‑Fire field, you gain 1 mana each time you summon an allied creature.'
   },
   FIRE_PARTMOLE_FLAME_LIZARD: {
@@ -505,6 +511,66 @@ export const CARDS = {
     swapOnDamage: true,
     swapOnDamageAllowZero: true,
     desc: 'Dodge attempt. If Biolith Stinger damages (but does not destroy) a creature, it switches locations with that creature (which cannot counterattack).'
+  },
+  BIOLITH_IMPERIAL_BIOLITH_GUARD: {
+    id: 'BIOLITH_IMPERIAL_BIOLITH_GUARD', name: 'Imperial Biolith Guard', type: 'UNIT', cost: 3, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [
+      { dir: 'E', ranges: [1], group: 'SIDE_SWEEP', ignoreAlliedBlocking: true },
+      { dir: 'W', ranges: [1], group: 'SIDE_SWEEP', ignoreAlliedBlocking: true },
+    ],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    manaOnSummon: {
+      trigger: 'ALLY',
+      summonFieldElement: 'BIOLITH',
+      excludeSelfSummon: true,
+      log: 'Imperial Biolith Guard генерирует {amount} ману за биолитовый призыв.',
+    },
+    desc: 'Gain 1 mana each time you summon a creature to a Biolith field.'
+  },
+  BIOLITH_WORMAK_HEIR: {
+    id: 'BIOLITH_WORMAK_HEIR', name: 'Wormak Heir to the Bioliths', type: 'UNIT', cost: 4, activation: 2,
+    element: 'BIOLITH', atk: 2, hp: 4,
+    attackType: 'STANDARD',
+    attacks: [ { dir: 'N', ranges: [1], ignoreAlliedBlocking: true } ],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    targetCountAttack: {
+      match: { owner: 'ENEMY', element: 'BIOLITH' },
+      count: { type: 'NON_ELEMENT', element: 'BIOLITH' },
+      baseValue: 2,
+      amountPer: 1,
+      log: 'Wormak Heir to the Bioliths: атака против биолитов установлена на {targetValue} (небиолитовых существ: {count}).',
+    },
+    manaOnSummon: {
+      trigger: 'ENEMY',
+      log: 'Wormak Heir to the Bioliths получает {amount} ману за призыв врага.',
+    },
+    desc: "If the target is an enemy Biolith, Wormak's Attack is equal to 2 plus the number of non-Biolith creatures on the board.\nGain 1 mana each time an enemy is summoned."
+  },
+  BIOLITH_TINO_SON_OF_SCION: {
+    id: 'BIOLITH_TINO_SON_OF_SCION', name: 'Tino, Son of Scion', type: 'UNIT', cost: 4, activation: 3,
+    element: 'BIOLITH', atk: 3, hp: 4,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: ['S'],
+    ignoreAlliedBlocking: true,
+    magicTargetsSameElement: true,
+    dynamicAtkAlliedElementOnField: {
+      element: 'BIOLITH',
+      baseValue: 1,
+      amountPer: 1,
+      requireFieldElement: 'BIOLITH',
+      includeSelf: false,
+    },
+    manaOnSummon: {
+      trigger: 'ALLY',
+      excludeSelfSummon: true,
+      log: 'Tino, Son of Scion приносит {amount} ману.',
+    },
+    desc: "Tino's Magic Attack targets all enemies of the same element as the target.\nWhile Tino is on a Biolith field, his Attack is equal to 1 plus the number of other allied Biolith creatures.\nGain 1 mana each time you summon a creature."
   },
 
   EARTH_NOVOGUS_GRAVEKEEPER: {

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -21,6 +21,8 @@ import {
   hasPendingForcedDiscards,
 } from '../scene/interactions.js';
 import { playFieldquakeFxBatch } from '../scene/fieldquakeFx.js';
+import { buildManaGainPlan } from '../scene/manaFx.js';
+import { getCtx } from '../scene/context.js';
 
 export function rotateUnit(unitMesh, dir) {
   try {
@@ -320,6 +322,9 @@ export function confirmUnitAbilityOrientation(context, direction) {
       facing: direction,
       uidFn: typeof w.uid === 'function' ? () => w.uid() : undefined,
     };
+    const playersBefore = Array.isArray(gameState.players)
+      ? gameState.players.map(pl => ({ mana: Math.max(0, Number(pl?.mana || 0)) }))
+      : [];
     const result = executeUnitAction(gameState, info.action, payload);
     if (!result?.ok) {
       const reason = result?.reason || 'Action failed';
@@ -366,6 +371,28 @@ export function confirmUnitAbilityOrientation(context, direction) {
       }
     }
 
+    const manaGainEntries = Array.isArray(result.summonEvents?.manaGainEvents)
+      ? result.summonEvents.manaGainEvents
+      : [];
+    let summonManaPlan = null;
+    if (manaGainEntries.length) {
+      const ctxScene = getCtx();
+      const THREE = ctxScene.THREE || w.THREE;
+      summonManaPlan = buildManaGainPlan({
+        playersBefore,
+        deaths: Array.isArray(result.summonEvents?.deaths) ? result.summonEvents.deaths : [],
+        manaGainEntries,
+        tileMeshes: ctxScene.tileMeshes,
+        THREE,
+      });
+    }
+
+    if (Array.isArray(result.summonEvents?.logs) && result.summonEvents.logs.length) {
+      for (const text of result.summonEvents.logs) {
+        if (text) w.addLog?.(text);
+      }
+    }
+
     if (Array.isArray(result.summonEvents?.fieldquakes) && result.summonEvents.fieldquakes.length) {
       const broadcastFx = (typeof w.NET_ON === 'function' ? w.NET_ON() : false)
         && typeof w.MY_SEAT === 'number'
@@ -403,9 +430,7 @@ export function confirmUnitAbilityOrientation(context, direction) {
       }
     }
 
-    if (result.freedonianMana > 0) {
-      w.addLog?.(`Фридонийский Странник приносит ${result.freedonianMana} маны.`);
-    }
+    try { summonManaPlan?.schedule?.(); } catch {}
 
     if (info.unitMesh?.userData) delete info.unitMesh.userData.availableActions;
     clearPendingAbilityOrientation();

--- a/src/ui/cancelButton.js
+++ b/src/ui/cancelButton.js
@@ -1,5 +1,5 @@
 // Кнопка отмены действий при установке карты или выборе цели
-import { interactionState, returnCardToHand } from '../scene/interactions.js';
+import { interactionState, returnCardToHand, undoPendingSummonManaGain } from '../scene/interactions.js';
 import { clearHighlights } from '../scene/highlight.js';
 import { capMana } from '../core/constants.js';
 import { refreshPossessionsUI } from './possessions.js';
@@ -14,13 +14,15 @@ function refundSummon(row, col) {
   if (!tpl) return;
   const player = gs.players[unit.owner];
   // возврат маны
-  player.mana += tpl.cost;
+  player.mana = capMana((player.mana || 0) + tpl.cost);
   // вернуть карту из сброса в руку
   const idx = player.discard.findIndex(c => c.id === tpl.id);
   if (idx >= 0) player.discard.splice(idx, 1);
   player.hand.push(tpl);
   // убрать юнита с поля
   cell.unit = null;
+  // отменить бонусную ману от способностей призыва
+  try { undoPendingSummonManaGain(); } catch {}
   refreshPossessionsUI(gs);
 }
 

--- a/tests/manaOnSummon.test.js
+++ b/tests/manaOnSummon.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { applyManaGainOnSummon } from '../src/core/abilityHandlers/manaOnSummon.js';
+import { CARDS } from '../src/core/cards.js';
+
+function makeState(defaultElement = 'FIRE') {
+  const board = Array.from({ length: 3 }, () => (
+    Array.from({ length: 3 }, () => ({ element: defaultElement, unit: null }))
+  ));
+  const players = [ { mana: 0, graveyard: [] }, { mana: 0, graveyard: [] } ];
+  return { board, players };
+}
+
+describe('manaOnSummon ауры', () => {
+  it('Фридонийский странник даёт ману только вне огненных полей', () => {
+    const state = makeState('FOREST');
+    state.players[0].mana = 0;
+    state.board[1][1] = { element: 'FOREST', unit: { owner: 0, tplId: 'FIRE_FREEDONIAN_WANDERER' } };
+    const summoned = { owner: 0, tplId: 'FIRE_FLAME_MAGUS' };
+    state.board[0][1] = { element: 'FOREST', unit: summoned };
+
+    const events = applyManaGainOnSummon(state, {
+      unit: summoned,
+      tpl: CARDS[summoned.tplId],
+      r: 0,
+      c: 1,
+      cell: state.board[0][1],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].owner).toBe(0);
+    expect(state.players[0].mana).toBe(1);
+    expect(events[0].log).toMatch(/Фридонийский Странник/);
+
+    // Тот же странник на огненном поле не даёт ману
+    const state2 = makeState('FIRE');
+    state2.players[0].mana = 0;
+    state2.board[1][1] = { element: 'FIRE', unit: { owner: 0, tplId: 'FIRE_FREEDONIAN_WANDERER' } };
+    state2.board[0][0] = { element: 'FOREST', unit: summoned };
+    const events2 = applyManaGainOnSummon(state2, {
+      unit: summoned,
+      tpl: CARDS[summoned.tplId],
+      r: 0,
+      c: 0,
+      cell: state2.board[0][0],
+    });
+    expect(events2).toHaveLength(0);
+    expect(state2.players[0].mana).toBe(0);
+  });
+
+  it('Имперский биолитовый гвардеец реагирует на призывы на биолитовые поля', () => {
+    const state = makeState('BIOLITH');
+    state.players[0].mana = 0;
+    state.board[1][0] = { element: 'BIOLITH', unit: { owner: 0, tplId: 'BIOLITH_IMPERIAL_BIOLITH_GUARD' } };
+    const summoned = { owner: 0, tplId: 'BIOLITH_BIOLITH_STINGER' };
+    state.board[0][0] = { element: 'BIOLITH', unit: summoned };
+
+    const events = applyManaGainOnSummon(state, {
+      unit: summoned,
+      tpl: CARDS[summoned.tplId],
+      r: 0,
+      c: 0,
+      cell: state.board[0][0],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].owner).toBe(0);
+    expect(state.players[0].mana).toBe(1);
+  });
+
+  it('Тино не выдаёт ману при собственном призыве, но усиливает союзные вызовы', () => {
+    const state = makeState('BIOLITH');
+    state.players[0].mana = 0;
+    const tino = { owner: 0, tplId: 'BIOLITH_TINO_SON_OF_SCION' };
+    state.board[1][1] = { element: 'BIOLITH', unit: tino };
+
+    const noGain = applyManaGainOnSummon(state, {
+      unit: tino,
+      tpl: CARDS[tino.tplId],
+      r: 1,
+      c: 1,
+      cell: state.board[1][1],
+    });
+    expect(noGain).toHaveLength(0);
+    expect(state.players[0].mana).toBe(0);
+
+    const ally = { owner: 0, tplId: 'BIOLITH_BIOLITH_STINGER' };
+    state.board[0][1] = { element: 'FOREST', unit: ally };
+    const allyGain = applyManaGainOnSummon(state, {
+      unit: ally,
+      tpl: CARDS[ally.tplId],
+      r: 0,
+      c: 1,
+      cell: state.board[0][1],
+    });
+    expect(allyGain).toHaveLength(1);
+    expect(state.players[0].mana).toBe(1);
+  });
+
+  it('Наследник Вормака получает ману за вражеские призывы', () => {
+    const state = makeState('BIOLITH');
+    state.players[0].mana = 0;
+    state.players[1].mana = 0;
+    state.board[1][2] = { element: 'BIOLITH', unit: { owner: 0, tplId: 'BIOLITH_WORMAK_HEIR' } };
+    const enemy = { owner: 1, tplId: 'EARTH_VERZAR_FOOT_SOLDIER' };
+    state.board[0][2] = { element: 'FIRE', unit: enemy };
+
+    const events = applyManaGainOnSummon(state, {
+      unit: enemy,
+      tpl: CARDS[enemy.tplId],
+      r: 0,
+      c: 2,
+      cell: state.board[0][2],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].owner).toBe(0);
+    expect(state.players[0].mana).toBe(1);
+    expect(state.players[1].mana).toBe(0);
+  });
+});

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -820,6 +820,19 @@ describe('новые способности (Хильда и Диос)', () => {
     expect(target.dmg).toBeGreaterThanOrEqual(3);
   });
 
+  it('Wormak Heir to the Bioliths повышает атаку против биолитов', () => {
+    const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
+    state.board[1][1].unit = { owner: 0, tplId: 'BIOLITH_WORMAK_HEIR', facing: 'N', currentHP: 4 };
+    state.board[0][1].unit = { owner: 1, tplId: 'BIOLITH_BIOLITH_STINGER', facing: 'S', currentHP: 1 };
+    state.board[2][0].unit = { owner: 0, tplId: 'FIRE_FLAME_MAGUS', facing: 'N', currentHP: 1 };
+    state.board[2][2].unit = { owner: 1, tplId: 'EARTH_VERZAR_FOOT_SOLDIER', facing: 'N', currentHP: 2 };
+
+    const res = stagedAttack(state, 1, 1);
+    const fin = res.finish();
+    const target = fin.targets.find(t => t.r === 0 && t.c === 1);
+    expect(target?.dmg).toBe(4);
+  });
+
   it('захваченные существа возвращаются владельцу при гибели источника', () => {
     const state = { board: makeBoard(), players: [{ mana: 0 }, { mana: 0 }], turn: 1 };
     state.board[1][1].element = 'WATER';

--- a/tests/summonCancel.test.js
+++ b/tests/summonCancel.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+const originalGsap = globalThis.gsap;
+
+const noop = () => {};
+
+const createGsapStub = () => ({ then: () => ({ then: () => ({}) }) });
+
+globalThis.window = {
+  gameState: null,
+  updateUI: vi.fn(),
+  addLog: vi.fn(),
+  __ui: {},
+  __fx: {},
+  showNotification: noop,
+};
+
+globalThis.document = { getElementById: () => null };
+globalThis.gsap = {
+  to: createGsapStub,
+  fromTo: createGsapStub,
+};
+
+let interactionState;
+let undoPendingSummonManaGain;
+
+beforeAll(async () => {
+  const mod = await import('../src/scene/interactions.js');
+  interactionState = mod.interactionState;
+  undoPendingSummonManaGain = mod.undoPendingSummonManaGain;
+});
+
+afterAll(() => {
+  globalThis.window = originalWindow;
+  globalThis.document = originalDocument;
+  globalThis.gsap = originalGsap;
+});
+
+beforeEach(() => {
+  window.updateUI.mockClear?.();
+  window.gameState = {
+    players: [
+      { mana: 6 },
+      { mana: 9 },
+    ],
+  };
+  interactionState.pendingSummonManaGain = [
+    { owner: 0, amount: 2 },
+    { owner: 1, amount: 3 },
+  ];
+});
+
+describe('undoPendingSummonManaGain', () => {
+  it('откатывает бонусную ману и очищает состояние', () => {
+    undoPendingSummonManaGain();
+    expect(window.gameState.players[0].mana).toBe(4);
+    expect(window.gameState.players[1].mana).toBe(6);
+    expect(interactionState.pendingSummonManaGain).toBeNull();
+    expect(window.updateUI).toHaveBeenCalledTimes(1);
+    expect(window.updateUI).toHaveBeenCalledWith(window.gameState);
+  });
+
+  it('ничего не делает, если событий нет', () => {
+    interactionState.pendingSummonManaGain = null;
+    undoPendingSummonManaGain();
+    expect(window.gameState.players[0].mana).toBe(6);
+    expect(window.gameState.players[1].mana).toBe(9);
+    expect(window.updateUI).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- track mana-on-summon gain events so they can be rolled back if a summon is cancelled
- cap refunded mana and invoke the rollback when cancelling a summon target selection
- add tests covering the mana rollback helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8df8413e0833089c050540b6f4309