### PR TITLE
Improve multiplayer account UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,40 @@
           if (found) oppDeck = found.cards;
         }
       } catch {}
-      gameState = startGame(myDeck, oppDeck);
+      const fallbackSeatName = (seat) => `Player ${seat + 1}`;
+      const matchPlayersSnapshot = Array.isArray(window.__matchPlayers) ? window.__matchPlayers : [];
+      let playerProfiles;
+      if (matchPlayersSnapshot.length >= 2) {
+        playerProfiles = [0, 1].map(index => {
+          const entry = matchPlayersSnapshot[index] || {};
+          const displayName = typeof entry.displayName === 'string' && entry.displayName.trim()
+            ? entry.displayName.trim()
+            : null;
+          const nickname = typeof entry.nickname === 'string' && entry.nickname.trim()
+            ? entry.nickname.trim()
+            : null;
+          const explicitName = typeof entry.name === 'string' && entry.name.trim()
+            ? entry.name.trim()
+            : null;
+          const resolvedName = displayName || nickname || explicitName || fallbackSeatName(index);
+          const id = typeof entry.id === 'string' && entry.id.trim() ? entry.id.trim() : null;
+          return { id, name: resolvedName, nickname };
+        });
+      } else {
+        const activeUser = (window.__auth && typeof window.__auth.getActiveUser === 'function')
+          ? window.__auth.getActiveUser()
+          : null;
+        const rawNickname = activeUser?.nickname && activeUser.nickname.trim() ? activeUser.nickname.trim() : null;
+        const rawEmail = activeUser?.email && activeUser.email.trim() ? activeUser.email.trim() : null;
+        const myName = rawNickname || rawEmail || fallbackSeatName(0);
+        playerProfiles = [
+          { id: activeUser?.id || null, name: myName, nickname: rawNickname },
+          { id: null, name: fallbackSeatName(1), nickname: null },
+        ];
+      }
+      try { window.__net?.setMatchPlayers?.(playerProfiles); } catch {}
+      try { window.__matchPlayers = playerProfiles.map(p => ({ ...p })); } catch {}
+      gameState = startGame(myDeck, oppDeck, { players: playerProfiles });
       try { window.applyGameState(gameState); } catch {}
       
       // Сразу строим сцену и мета-объекты, без задержки появления
@@ -422,7 +455,8 @@
         }
       } catch {}
       
-      addLog('The game has begun! Player 1 goes first.');
+      const firstPlayerName = playerProfiles[0]?.name || 'Player 1';
+      addLog(`The game has begun! ${firstPlayerName} goes first.`);
       addLog('Drag units to the field, use spells by clicking.');
     }
     

--- a/routes/decks.js
+++ b/routes/decks.js
@@ -7,6 +7,7 @@ import {
   getDeckAccessibleByUser,
   upsertDeckForUser,
   deleteDeckForUser,
+  ensureDefaultDecksForUser,
 } from '../server/repositories/decksRepository.js';
 import { CARDS } from '../src/core/cards.js';
 import { DEFAULT_DECK_BLUEPRINTS } from '../src/core/defaultDecks.js';
@@ -78,6 +79,7 @@ router.use(requireAuth);
 router.get('/', async (req, res) => {
   try {
     await ensureStoragePrepared();
+    await ensureDefaultDecksForUser(req.user.id, DEFAULT_DECK_BLUEPRINTS);
     const decks = await listDecksForUser(req.user.id, { includeShared: true });
     res.json({ decks });
   } catch (err) {

--- a/src/core/board.js
+++ b/src/core/board.js
@@ -71,12 +71,48 @@ export function randomBoard() {
   return board;
 }
 
-export function startGame(deck0 = DEFAULT_DECK, deck1 = DEFAULT_DECK) {
+export function startGame(deck0 = DEFAULT_DECK, deck1 = DEFAULT_DECK, options = {}) {
+  const playerConfigs = Array.isArray(options.players) ? options.players : [];
+  const fallbackNames = ['Player 1', 'Player 2'];
+  const getPlayerMeta = (index) => {
+    const cfg = playerConfigs[index] || {};
+    const nickname = typeof cfg.nickname === 'string' && cfg.nickname.trim()
+      ? cfg.nickname.trim()
+      : null;
+    const explicitName = typeof cfg.name === 'string' && cfg.name.trim()
+      ? cfg.name.trim()
+      : null;
+    const name = nickname || explicitName || fallbackNames[index] || `Player ${index + 1}`;
+    const userId = typeof cfg.id === 'string' && cfg.id.trim() ? cfg.id.trim() : null;
+    return { name, nickname, userId };
+  };
+  const meta0 = getPlayerMeta(0);
+  const meta1 = getPlayerMeta(1);
   const state = {
     board: randomBoard(),
     players: [
-      { name: 'Player 1', deck: shuffle(deck0.filter(Boolean)), hand: [], discard: [], graveyard: [], mana: 2, maxMana: 10 },
-      { name: 'Player 2', deck: shuffle(deck1.filter(Boolean)), hand: [], discard: [], graveyard: [], mana: 0, maxMana: 10 },
+      {
+        name: meta0.name,
+        nickname: meta0.nickname,
+        userId: meta0.userId,
+        deck: shuffle(deck0.filter(Boolean)),
+        hand: [],
+        discard: [],
+        graveyard: [],
+        mana: 2,
+        maxMana: 10,
+      },
+      {
+        name: meta1.name,
+        nickname: meta1.nickname,
+        userId: meta1.userId,
+        deck: shuffle(deck1.filter(Boolean)),
+        hand: [],
+        discard: [],
+        graveyard: [],
+        mana: 0,
+        maxMana: 10,
+      },
     ],
     active: 0,
     turn: 1,

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -15,7 +15,13 @@ export const A = {
 export function reducer(state, action) {
   switch (action.type) {
     case A.INIT: {
-      const s = startGame(action.deck0, action.deck1);
+      const startOptions = (action && typeof action.options === 'object' && action.options !== null)
+        ? { ...action.options }
+        : {};
+      if (!startOptions.players && Array.isArray(action.players)) {
+        startOptions.players = action.players;
+      }
+      const s = startGame(action.deck0, action.deck1, startOptions);
       s.__ver = (state?.__ver || 0) + 1;
       return s;
     }

--- a/src/ui/authScreen.js
+++ b/src/ui/authScreen.js
@@ -26,6 +26,7 @@ let lastNotifiedUserId = null;
 let optionsRef = {};
 let syncingDecks = false;
 let stylesInjected = false;
+let hideTimer = null;
 
 const BODY_OVERLAY_CLASS = 'auth-overlay-open';
 
@@ -80,6 +81,8 @@ function ensureRoot() {
   root = document.createElement('div');
   root.id = 'auth-overlay';
   root.className = 'auth-layer auth-hidden';
+  root.style.display = 'none';
+  root.style.pointerEvents = 'none';
   document.body.appendChild(root);
 }
 
@@ -318,6 +321,12 @@ async function syncDecksForUser(user) {
 function show() {
   if (!root) return;
   ensureStyles();
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+  root.style.display = 'flex';
+  root.style.pointerEvents = 'auto';
   root.classList.remove('auth-hidden');
   try { document.body.classList.add(BODY_OVERLAY_CLASS); } catch {}
   render();
@@ -325,7 +334,19 @@ function show() {
 
 function hide() {
   if (!root) return;
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
   root.classList.add('auth-hidden');
+  root.style.pointerEvents = 'none';
+  hideTimer = setTimeout(() => {
+    try {
+      if (root && root.classList.contains('auth-hidden')) {
+        root.style.display = 'none';
+      }
+    } catch {}
+  }, 220);
   try { document.body.classList.remove(BODY_OVERLAY_CLASS); } catch {}
 }
 

--- a/src/ui/mainMenu.js
+++ b/src/ui/mainMenu.js
@@ -7,6 +7,10 @@ let firstOpen = true;
 export function open(initial = false) {
   if (typeof document === 'undefined') return;
   if (initial) firstOpen = true;
+  const existing = document.getElementById('main-menu-overlay');
+  if (existing) {
+    try { document.body.removeChild(existing); } catch {}
+  }
   const overlay = document.createElement('div');
   overlay.id = 'main-menu-overlay';
   // На стартовом экране фон полностью непрозрачный, чтобы скрыть игровое поле
@@ -27,6 +31,7 @@ export function open(initial = false) {
     name.className = 'font-semibold text-slate-100';
     name.textContent = user.nickname || user.email || 'Player';
     const logoutBtn = document.createElement('button');
+    logoutBtn.type = 'button';
     logoutBtn.className = 'text-red-300 hover:text-red-200';
     logoutBtn.textContent = 'Log Out';
     logoutBtn.addEventListener('click', (evt) => {

--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -54,6 +54,15 @@ export function updateUI(gameState) {
     const t0 = doc.getElementById('player-title-0');
     const t1 = doc.getElementById('player-title-1');
     if (leftSide && rightSide && t0 && t1) {
+      const fallbackTitles = ['Игрок 1', 'Игрок 2'];
+      const name0 = typeof state.players?.[0]?.name === 'string' && state.players[0].name.trim()
+        ? state.players[0].name.trim()
+        : fallbackTitles[0];
+      const name1 = typeof state.players?.[1]?.name === 'string' && state.players[1].name.trim()
+        ? state.players[1].name.trim()
+        : fallbackTitles[1];
+      t0.textContent = name0;
+      t1.textContent = name1;
       leftSide.querySelectorAll('.overlay-panel').forEach(el => el.classList.remove('active-player-panel'));
       rightSide.querySelectorAll('.overlay-panel').forEach(el => el.classList.remove('active-player-panel'));
       t0.classList.remove('title-pulse');
@@ -89,11 +98,19 @@ export function updateUI(gameState) {
   const ci0 = doc.getElementById('control-info-0'); if (ci0) ci0.textContent = `Контроль: ${controlA}`;
   const ci1 = doc.getElementById('control-info-1'); if (ci1) ci1.textContent = `Контроль: ${controlB}`;
 
+  const playerNames = [
+    (typeof state.players?.[0]?.name === 'string' && state.players[0].name.trim()) ? state.players[0].name.trim() : 'Player 1',
+    (typeof state.players?.[1]?.name === 'string' && state.players[1].name.trim()) ? state.players[1].name.trim() : 'Player 2',
+  ];
   if (controlA >= 5) {
-    try { window.__ui && window.__ui.notifications && window.__ui.notifications.show('Player 1 wins!', 'success'); } catch {}
+    try {
+      window.__ui && window.__ui.notifications && window.__ui.notifications.show(`${playerNames[0]} wins!`, 'success');
+    } catch {}
     state.winner = 0;
   } else if (controlB >= 5) {
-    try { window.__ui && window.__ui.notifications && window.__ui.notifications.show('Player 2 wins!', 'success'); } catch {}
+    try {
+      window.__ui && window.__ui.notifications && window.__ui.notifications.show(`${playerNames[1]} wins!`, 'success');
+    } catch {}
     state.winner = 1;
   }
 }


### PR DESCRIPTION
## Summary
- ensure the authentication overlay releases pointer events and the main menu overlay is recreated cleanly so buttons (including Log Out) stay clickable
- propagate real player profiles through game setup, UI updates, and networking so nicknames appear in countdowns, HUD, and logs instead of generic labels
- seed personal copies of the default decks for new accounts on first sync while exposing helpers to reset or inspect current match players from the networking layer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d90ab018a483308f2624e3da75f6a1