### PR TITLE
Добавлена карта Guardian Watchtower

### DIFF
--- a/src/core/abilityHandlers/manaGain.js
+++ b/src/core/abilityHandlers/manaGain.js
@@ -5,6 +5,11 @@ import { normalizeElementName } from '../utils/elements.js';
 const BOARD_SIZE = 3;
 const capMana = (m) => Math.min(10, m);
 
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);
+}
+
 function normalizeElement(value, fallback = null) {
   const normalized = normalizeElementName(typeof value === 'string' ? value : null);
   if (normalized) return normalized;
@@ -12,6 +17,31 @@ function normalizeElement(value, fallback = null) {
     return normalizeElementName(fallback);
   }
   return null;
+}
+
+function resolveCardId(raw) {
+  if (typeof raw !== 'string') return null;
+  const token = raw.trim();
+  if (!token) return null;
+  const direct = CARDS[token];
+  if (direct?.id) return direct.id;
+  for (const card of Object.values(CARDS)) {
+    if (!card) continue;
+    if (card.id === token) return card.id;
+    if (card.name && card.name.toUpperCase() === token.toUpperCase()) {
+      return card.id;
+    }
+  }
+  return null;
+}
+
+function normalizeTplIdList(value) {
+  const result = new Set();
+  for (const raw of toArray(value)) {
+    const id = resolveCardId(raw);
+    if (id) result.add(id);
+  }
+  return result;
 }
 
 function normalizeManaGainConfig(raw, tpl) {
@@ -59,6 +89,26 @@ function isUnitAlive(unit, tpl) {
   return true;
 }
 
+function countAlliedUnitsOnBoard(state, owner, opts = {}) {
+  if (!state?.board) return 0;
+  const requireAlive = opts.requireAlive !== false;
+  const excludeUid = opts.excludeUid ?? null;
+  let total = 0;
+  for (let r = 0; r < BOARD_SIZE; r += 1) {
+    for (let c = 0; c < BOARD_SIZE; c += 1) {
+      const unit = state.board?.[r]?.[c]?.unit;
+      if (!unit) continue;
+      if (owner != null && unit.owner !== owner) continue;
+      if (excludeUid != null && unit.uid === excludeUid) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      if (requireAlive && !isUnitAlive(unit, tpl)) continue;
+      total += 1;
+    }
+  }
+  return total;
+}
+
 function toPositiveInt(value, fallback = 0) {
   const num = Number(value);
   if (!Number.isFinite(num)) return Math.max(0, Math.floor(fallback));
@@ -104,6 +154,169 @@ function countFieldsOfElement(boardState, element) {
     }
   }
   return total;
+}
+
+function hasRequiredAlliesOnBoard(state, owner, cfg, context = {}) {
+  const required = cfg?.requireAlliedTplIds;
+  if (!required || required.size === 0) return true;
+  const excludeUid = context.selfUid ?? null;
+  const requireAlive = cfg.requireAlive !== false;
+  for (let r = 0; r < BOARD_SIZE; r += 1) {
+    for (let c = 0; c < BOARD_SIZE; c += 1) {
+      const unit = state?.board?.[r]?.[c]?.unit;
+      if (!unit) continue;
+      if (owner != null && unit.owner !== owner) continue;
+      if (excludeUid != null && unit.uid === excludeUid) continue;
+      const tpl = CARDS[unit.tplId];
+      if (!tpl) continue;
+      if (requireAlive && !isUnitAlive(unit, tpl)) continue;
+      const tplId = tpl.id || unit.tplId;
+      if (tplId && required.has(tplId)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function formatTemplateString(template, data = {}) {
+  if (!template) return null;
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const lower = key.toLowerCase();
+    if (lower === 'amount') return String(data.amount ?? '');
+    if (lower === 'allies' || lower === 'count') return String(data.allies ?? data.count ?? '');
+    if (lower === 'name') return data.name ?? '';
+    return match;
+  });
+}
+
+function normalizeResolutionPresenceConfig(raw, tpl) {
+  if (!raw) return null;
+  const cfg = {
+    requireAlliedTplIds: new Set(),
+    includeSelf: true,
+    amountPerAlly: 1,
+    baseAmount: 0,
+    minAmount: null,
+    maxAmount: null,
+    countMode: 'ALLY_UNITS',
+    requireAlive: true,
+    countAlive: true,
+    log: null,
+    reason: 'ALLY_PRESENCE',
+  };
+
+  if (raw === true) {
+    return cfg;
+  }
+  if (typeof raw !== 'object') {
+    return null;
+  }
+
+  const required = normalizeTplIdList(
+    raw.requireTplIds
+      || raw.require
+      || raw.with
+      || raw.allyTplIds
+      || raw.allyCards
+      || raw.allies,
+  );
+  cfg.requireAlliedTplIds = required;
+
+  if (raw.includeSelf === false) cfg.includeSelf = false;
+  if (raw.requireAlive === false) cfg.requireAlive = false;
+  if (raw.countAlive === false) cfg.countAlive = false;
+
+  const perRaw = raw.amountPer ?? raw.per ?? raw.perAlly ?? raw.gainPerAlly ?? raw.amountPerAlly;
+  if (Number.isFinite(perRaw)) {
+    cfg.amountPerAlly = Math.max(0, Math.floor(perRaw));
+  }
+  const baseRaw = raw.baseAmount ?? raw.base ?? raw.plus ?? raw.flat ?? 0;
+  if (Number.isFinite(baseRaw)) {
+    cfg.baseAmount = Math.max(0, Math.floor(baseRaw));
+  }
+  if (Number.isFinite(raw.maxAmount ?? raw.max)) {
+    cfg.maxAmount = Math.max(0, Math.floor(raw.maxAmount ?? raw.max));
+  }
+  if (Number.isFinite(raw.minAmount ?? raw.min)) {
+    cfg.minAmount = Math.max(0, Math.floor(raw.minAmount ?? raw.min));
+  }
+  if (typeof raw.log === 'string') {
+    cfg.log = raw.log;
+  }
+  if (typeof raw.reason === 'string') {
+    cfg.reason = raw.reason;
+  }
+  if (typeof raw.count === 'string') {
+    cfg.countMode = raw.count.toUpperCase();
+  } else if (typeof raw.mode === 'string') {
+    cfg.countMode = raw.mode.toUpperCase();
+  }
+
+  return cfg;
+}
+
+function collectResolutionPresenceConfigs(tpl) {
+  if (!tpl || !tpl.resolutionManaOnAllyPresence) return [];
+  const raw = tpl.resolutionManaOnAllyPresence;
+  const list = Array.isArray(raw) ? raw : [raw];
+  const result = [];
+  for (const item of list) {
+    const cfg = normalizeResolutionPresenceConfig(item, tpl);
+    if (!cfg) continue;
+    result.push(cfg);
+  }
+  return result;
+}
+
+function countAlliesForConfig(state, owner, cfg, context = {}) {
+  const excludeUid = cfg.includeSelf === false ? context.selfUid ?? null : null;
+  const opts = {
+    excludeUid,
+    requireAlive: cfg.countAlive !== false,
+  };
+  const mode = cfg.countMode || 'ALLY_UNITS';
+  if (mode === 'ALLY_UNITS' || mode === 'ALLIES' || mode === 'ALLY_CREATURES') {
+    return countAlliedUnitsOnBoard(state, owner, opts);
+  }
+  return countAlliedUnitsOnBoard(state, owner, opts);
+}
+
+function applyResolutionPresenceMana(state, playerIndex, unit, tpl, r, c, acc) {
+  const configs = collectResolutionPresenceConfigs(tpl);
+  if (!configs.length) return;
+  const context = { selfUid: unit?.uid ?? null };
+  for (const cfg of configs) {
+    if (!hasRequiredAlliesOnBoard(state, playerIndex, cfg, context)) continue;
+    const allies = countAlliesForConfig(state, playerIndex, cfg, context);
+    const baseAmount = cfg.baseAmount || 0;
+    const per = cfg.amountPerAlly || 0;
+    let amount = toPositiveInt(baseAmount + per * allies);
+    if (amount <= 0) continue;
+    amount = clampWithBounds(amount, cfg.minAmount, cfg.maxAmount);
+    if (amount <= 0) continue;
+    const gained = gainMana(state, playerIndex, amount);
+    if (gained <= 0) continue;
+    const data = {
+      amount: gained,
+      allies,
+      count: allies,
+      name: tpl?.name || tpl?.id || 'Существо',
+    };
+    const logText = formatTemplateString(cfg.log, data)
+      || `${data.name}: дополнительная мана +${gained} за союзных существ (всего: ${allies}).`;
+    acc.total += gained;
+    acc.entries.push({
+      r,
+      c,
+      tplId: tpl.id,
+      amount: gained,
+      reason: cfg.reason || 'ALLY_PRESENCE',
+      allies,
+      requiredTplIds: Array.from(cfg.requireAlliedTplIds || []),
+      customLog: logText,
+    });
+  }
 }
 
 function normalizeDeathGainConfig(raw, tpl) {
@@ -263,22 +476,26 @@ export function applyTurnStartManaEffects(state, playerIndex) {
       if (!tpl) continue;
       if (!isUnitAlive(unit, tpl)) continue;
       const cfg = normalizeManaGainConfig(tpl.manaGainOnNonElement, tpl);
-      if (!cfg) continue;
-      const nativeElement = normalizeElement(cfg.element || tpl.element);
-      if (!nativeElement) continue;
-      const cellElement = normalizeElement(cell?.element || null);
-      if (cellElement === nativeElement) continue;
-      const gained = gainMana(state, playerIndex, cfg.amount || 0);
-      if (gained > 0) {
-        result.total += gained;
-        result.entries.push({
-          r,
-          c,
-          tplId: tpl.id,
-          amount: gained,
-          fieldElement: cellElement,
-        });
+      if (cfg) {
+        const nativeElement = normalizeElement(cfg.element || tpl.element);
+        if (nativeElement) {
+          const cellElement = normalizeElement(cell?.element || null);
+          if (cellElement !== nativeElement) {
+            const gained = gainMana(state, playerIndex, cfg.amount || 0);
+            if (gained > 0) {
+              result.total += gained;
+              result.entries.push({
+                r,
+                c,
+                tplId: tpl.id,
+                amount: gained,
+                fieldElement: cellElement,
+              });
+            }
+          }
+        }
       }
+      applyResolutionPresenceMana(state, playerIndex, unit, tpl, r, c, result);
     }
   }
 

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -582,6 +582,23 @@ export const CARDS = {
     },
     desc: "Tino's Magic Attack targets all enemies of the same element as the target.\nWhile Tino is on a Biolith field, his Attack is equal to 1 plus the number of other allied Biolith creatures.\nGain 1 mana each time you summon a creature."
   },
+  BIOLITH_GUARDIAN_WATCHTOWER: {
+    id: 'BIOLITH_GUARDIAN_WATCHTOWER', name: 'Guardian Watchtower', type: 'UNIT', cost: 6, activation: 3,
+    element: 'BIOLITH', atk: 1, hp: 10,
+    attackType: 'MAGIC',
+    attacks: [],
+    blindspots: [],
+    ignoreAlliedBlocking: true,
+    magicTargetsSameElement: true,
+    rotateTargetOnDamage: { mode: 'OPPOSITE' },
+    resolutionManaOnAllyPresence: {
+      requireTplIds: ['BIOLITH_SCION_BIOLITH_LORD'],
+      amountPer: 1,
+      includeSelf: true,
+      log: 'Guardian Watchtower приносит {amount} маны (союзных существ: {allies}).',
+    },
+    desc: "Guardian Watchtower's Magic Attack targets all enemies of the same element as the target.\nWhen Guardian Watchtower damages (but does not destroy) a creature, that creature is rotated 180° and cannot counterattack.\nWhile an allied Scion is on the board, gain mana equal to the number of allied creatures on the board during your Resolution Phase."
+  },
 
   EARTH_NOVOGUS_GRAVEKEEPER: {
     id: 'EARTH_NOVOGUS_GRAVEKEEPER', name: 'Novogus Gravekeeper', type: 'UNIT', cost: 9, activation: 5,

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -687,6 +687,15 @@ export async function endTurn() {
       for (const entry of manaEffects.entries) {
         const tpl = cards[entry.tplId];
         const sourceName = tpl?.name || 'Существо';
+        if (typeof entry.customLog === 'string' && entry.customLog.trim()) {
+          w.addLog?.(entry.customLog);
+          continue;
+        }
+        if (entry.reason === 'ALLY_PRESENCE') {
+          const allies = entry.allies != null ? entry.allies : '?';
+          w.addLog?.(`${sourceName}: дополнительная мана +${entry.amount} за союзных существ (всего: ${allies}).`);
+          continue;
+        }
         const field = entry.fieldElement ? `поле ${entry.fieldElement}` : 'нейтральное поле';
         w.addLog?.(`${sourceName}: дополнительная мана +${entry.amount} (${field}).`);
       }

--- a/tests/abilitiesExtra.test.js
+++ b/tests/abilitiesExtra.test.js
@@ -40,6 +40,50 @@ describe('эффекты начала хода', () => {
     expect(result.total).toBe(0);
     expect(state.players[0].mana).toBe(2);
   });
+
+  it('Guardian Watchtower не генерирует ману без союзного Scion', () => {
+    const state = {
+      board: makeBoard(),
+      players: [{ mana: 0 }, { mana: 0 }],
+    };
+    state.board[0][0].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_GUARDIAN_WATCHTOWER',
+      currentHP: 10,
+    };
+    const result = applyTurnStartManaEffects(state, 0);
+    expect(result.total).toBe(0);
+    expect(state.players[0].mana).toBe(0);
+  });
+
+  it('Guardian Watchtower начисляет ману за всех союзников при присутствии Scion', () => {
+    const state = {
+      board: makeBoard(),
+      players: [{ mana: 1 }, { mana: 0 }],
+    };
+    state.board[0][0].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_GUARDIAN_WATCHTOWER',
+      currentHP: 10,
+    };
+    state.board[1][1].unit = {
+      owner: 0,
+      tplId: 'BIOLITH_SCION_BIOLITH_LORD',
+      currentHP: 6,
+    };
+    state.board[0][1].unit = {
+      owner: 0,
+      tplId: 'FIRE_PARTMOLE_FLAME_LIZARD',
+      currentHP: 2,
+    };
+    const result = applyTurnStartManaEffects(state, 0);
+    expect(result.total).toBe(3);
+    expect(state.players[0].mana).toBe(4);
+    const entry = result.entries.find(e => e.tplId === 'BIOLITH_GUARDIAN_WATCHTOWER');
+    expect(entry).toBeTruthy();
+    expect(entry.amount).toBe(3);
+    expect(entry.allies).toBe(3);
+  });
 });
 
 describe('реакции на призыв врага', () => {


### PR DESCRIPTION
## Summary
- добавлена карта Guardian Watchtower с уникальными эффектами
- расширена логика прироста маны для учёта союзного Scion и обновлены журнальные сообщения
- добавлены тесты, подтверждающие новую механику

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d911de5fd883309302352f23c3269a