### PR TITLE
Restrict summoning to adjacent tiles and add placement highlight

### DIFF
--- a/src/core/placementRules.js
+++ b/src/core/placementRules.js
@@ -1,0 +1,84 @@
+// Логика ограничений на призыв существ.
+// Здесь нет никакой визуальной части, только вычисление допустимых клеток.
+
+const ORTHOGONAL_DIRS = [
+  { dr: -1, dc: 0 },
+  { dr: 1, dc: 0 },
+  { dr: 0, dc: -1 },
+  { dr: 0, dc: 1 },
+];
+
+function isValidCell(board, r, c) {
+  return Array.isArray(board)
+    && r >= 0
+    && c >= 0
+    && r < board.length
+    && Array.isArray(board[r])
+    && c < board[r].length
+    && board[r][c];
+}
+
+export function hasPlayerSummoned(state, playerIndex) {
+  if (!state || !Array.isArray(state.board)) return false;
+  for (let r = 0; r < state.board.length; r++) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c++) {
+      const unit = row[c]?.unit;
+      if (!unit) continue;
+      if (unit.owner === playerIndex) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isAdjacentToAnyUnit(state, r, c) {
+  if (!state || !Array.isArray(state.board)) return false;
+  for (const { dr, dc } of ORTHOGONAL_DIRS) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!isValidCell(state.board, nr, nc)) continue;
+    if (state.board[nr][nc]?.unit) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function canSummonOnCell(state, playerIndex, r, c) {
+  if (!state || !isValidCell(state.board, r, c)) return false;
+  const cell = state.board[r][c];
+  if (!cell || cell.unit) return false;
+  if (!hasPlayerSummoned(state, playerIndex)) {
+    return true;
+  }
+  return isAdjacentToAnyUnit(state, r, c);
+}
+
+export function getAllowedSummonCells(state, playerIndex) {
+  const result = [];
+  if (!state || !Array.isArray(state.board)) return result;
+  for (let r = 0; r < state.board.length; r++) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c++) {
+      if (canSummonOnCell(state, playerIndex, r, c)) {
+        result.push({ r, c });
+      }
+    }
+  }
+  return result;
+}
+
+export function getAdjacentDirs() {
+  return ORTHOGONAL_DIRS.map(({ dr, dc }) => ({ dr, dc }));
+}
+
+export default {
+  hasPlayerSummoned,
+  canSummonOnCell,
+  getAllowedSummonCells,
+  getAdjacentDirs,
+};

--- a/src/scene/placementHighlight.js
+++ b/src/scene/placementHighlight.js
@@ -1,0 +1,122 @@
+// Мягкая подсветка клеток для призыва существ.
+// Здесь только визуальный слой, логика выбора клеток находится в core/placementRules.
+import { getCtx } from './context.js';
+
+const state = {
+  overlays: [],
+  rafId: 0,
+  baseGeometry: null,
+};
+
+function createOverlayMaterial(THREE) {
+  return new THREE.ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    uniforms: {
+      uTime: { value: 0 },
+      uColor: { value: new THREE.Color(0xfcd34d) },
+    },
+    vertexShader: `
+      varying vec2 vUv;
+      void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      varying vec2 vUv;
+      uniform float uTime;
+      uniform vec3 uColor;
+      void main() {
+        vec2 centered = (vUv - 0.5) * 2.0;
+        float dist = max(abs(centered.x), abs(centered.y));
+        float edge = smoothstep(0.25, 0.98, dist);
+        float soft = smoothstep(0.0, 0.4, dist);
+        float shimmer = sin((centered.x + centered.y) * 6.0 + uTime * 1.6) * 0.05;
+        float pulse = sin(uTime * 2.4) * 0.08 + 0.22;
+        float intensity = edge * (0.35 + pulse + shimmer);
+        intensity = max(intensity, 0.12 * (edge - soft));
+        float alpha = clamp(intensity, 0.0, 0.42);
+        if (alpha <= 0.01) discard;
+        vec3 color = uColor * (0.7 + 0.3 * edge);
+        gl_FragColor = vec4(color, alpha);
+      }
+    `,
+  });
+}
+
+function ensureGeometry(THREE) {
+  if (!state.baseGeometry) {
+    state.baseGeometry = new THREE.PlaneGeometry(1, 1, 1, 1);
+  }
+  return state.baseGeometry;
+}
+
+function placeOverlayOnTile({ THREE, tile, effectsGroup }) {
+  const geometry = ensureGeometry(THREE);
+  const material = createOverlayMaterial(THREE);
+  const mesh = new THREE.Mesh(geometry, material);
+  const width = tile?.geometry?.parameters?.width || tile?.scale?.x || 1;
+  const depth = tile?.geometry?.parameters?.depth || tile?.scale?.z || 1;
+  const height = tile?.geometry?.parameters?.height || tile?.scale?.y || 0.1;
+  mesh.scale.set(width, depth, 1);
+  mesh.rotation.x = -Math.PI / 2;
+  const pos = tile.position.clone();
+  pos.y += (height / 2) + 0.02;
+  mesh.position.copy(pos);
+  mesh.renderOrder = 720;
+  effectsGroup.add(mesh);
+  state.overlays.push({ mesh, material, uniform: material.uniforms.uTime });
+}
+
+function startAnimationLoop() {
+  if (state.rafId) return;
+  const start = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+  const step = () => {
+    const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    const t = (now - start) / 1000;
+    for (const entry of state.overlays) {
+      if (entry?.uniform) entry.uniform.value = t;
+    }
+    state.rafId = (typeof requestAnimationFrame !== 'undefined')
+      ? requestAnimationFrame(step)
+      : setTimeout(step, 16);
+  };
+  step();
+}
+
+export function highlightPlacementTiles(cells = []) {
+  const ctx = getCtx();
+  const { THREE, tileMeshes, effectsGroup } = ctx;
+  if (!THREE || !tileMeshes || !effectsGroup) return;
+  clearPlacementHighlights();
+  for (const { r, c } of cells) {
+    const tile = tileMeshes?.[r]?.[c];
+    if (!tile) continue;
+    placeOverlayOnTile({ THREE, tile, effectsGroup });
+  }
+  if (state.overlays.length) {
+    startAnimationLoop();
+  }
+}
+
+export function clearPlacementHighlights() {
+  if (state.rafId) {
+    if (typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(state.rafId);
+    else clearTimeout(state.rafId);
+    state.rafId = 0;
+  }
+  const ctx = getCtx();
+  const { effectsGroup } = ctx;
+  for (const entry of state.overlays) {
+    try { effectsGroup?.remove(entry.mesh); } catch {}
+    try { entry.material?.dispose?.(); } catch {}
+  }
+  state.overlays = [];
+}
+
+export default {
+  highlightPlacementTiles,
+  clearPlacementHighlights,
+};

--- a/src/ui/cancelButton.js
+++ b/src/ui/cancelButton.js
@@ -1,6 +1,7 @@
 // Кнопка отмены действий при установке карты или выборе цели
 import { interactionState, returnCardToHand, undoPendingSummonManaGain } from '../scene/interactions.js';
 import { clearHighlights } from '../scene/highlight.js';
+import { clearPlacementHighlights } from '../scene/placementHighlight.js';
 import { capMana } from '../core/constants.js';
 import { refreshPossessionsUI } from './possessions.js';
 
@@ -84,6 +85,7 @@ export function setupCancelButton() {
       }
     } catch {}
     clearHighlights();
+    clearPlacementHighlights();
     refreshCancelButton();
   });
   refreshCancelButton();

--- a/tests/placementRules.test.js
+++ b/tests/placementRules.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getAllowedSummonCells, canSummonOnCell, hasPlayerSummoned } from '../src/core/placementRules.js';
+
+function makeState() {
+  const board = Array.from({ length: 3 }, () => (
+    Array.from({ length: 3 }, () => ({ element: 'FIRE', unit: null }))
+  ));
+  board[1][1].element = 'BIOLITH';
+  return { board, players: [{}, {}], active: 0 };
+}
+
+describe('placementRules', () => {
+  it('первое существо игрока можно поставить на любую пустую клетку', () => {
+    const state = makeState();
+    expect(hasPlayerSummoned(state, 0)).toBe(false);
+    const allowed = getAllowedSummonCells(state, 0);
+    expect(allowed).toHaveLength(9);
+    expect(allowed.every(cell => canSummonOnCell(state, 0, cell.r, cell.c))).toBe(true);
+  });
+
+  it('после первого призыва доступны только клетки рядом с любым существом', () => {
+    const state = makeState();
+    state.board[1][1].unit = { owner: 0, tplId: 'X', facing: 'N' };
+    expect(hasPlayerSummoned(state, 0)).toBe(true);
+    const allowed = getAllowedSummonCells(state, 0);
+    const coords = allowed.map(c => `${c.r},${c.c}`).sort();
+    expect(coords).toEqual(['0,1', '1,0', '1,2', '2,1']);
+    expect(canSummonOnCell(state, 0, 0, 0)).toBe(false);
+  });
+
+  it('вражеские существа тоже расширяют доступную область', () => {
+    const state = makeState();
+    state.board[0][1].unit = { owner: 1, tplId: 'ENEMY', facing: 'S' };
+    state.board[1][1].unit = { owner: 0, tplId: 'ALLY', facing: 'N' };
+    expect(canSummonOnCell(state, 0, 0, 2)).toBe(true);
+  });
+
+  it('первое существо второго игрока игнорирует ограничение, даже если враг уже на поле', () => {
+    const state = makeState();
+    state.board[1][1].unit = { owner: 0, tplId: 'ALLY', facing: 'N' };
+    expect(hasPlayerSummoned(state, 1)).toBe(false);
+    const allowed = getAllowedSummonCells(state, 1);
+    expect(allowed).toHaveLength(8);
+    expect(canSummonOnCell(state, 1, 0, 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable placement rule helpers to compute allowed summon cells per player and guard placements in the scene logic
- show a subtle shader-based overlay for valid summon tiles when dragging a unit card and clear the effect on cancel
- cover the new placement restriction with unit tests for various board states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da144c672c8330a051f4e082ee6f16