### PR TITLE
Refine placement highlight visual effect

### DIFF
--- a/src/core/placementRules.js
+++ b/src/core/placementRules.js
@@ -1,0 +1,93 @@
+// Правила размещения существ на поле.
+// Логика вынесена в отдельный модуль, чтобы облегчить перенос на другие движки.
+
+// Проверка принадлежности координат игровому полю 3x3
+function isInBounds(r, c) {
+  return r >= 0 && r < 3 && c >= 0 && c < 3;
+}
+
+// Возвращает true, если у игрока уже есть существа на поле
+export function hasPlayerUnits(gameState, playerIndex) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  for (let r = 0; r < gameState.board.length; r++) {
+    const row = gameState.board[r];
+    if (!row) continue;
+    for (let c = 0; c < row.length; c++) {
+      const unit = row[c]?.unit;
+      if (unit && typeof unit.owner === 'number' && unit.owner === playerIndex) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Проверяет, есть ли хотя бы одно существо рядом (по сторонам) с указанной клеткой
+function hasAdjacentUnits(gameState, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  const dirs = [
+    { dr: -1, dc: 0 },
+    { dr: 1, dc: 0 },
+    { dr: 0, dc: -1 },
+    { dr: 0, dc: 1 },
+  ];
+  for (const { dr, dc } of dirs) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!isInBounds(nr, nc)) continue;
+    const unit = gameState.board?.[nr]?.[nc]?.unit;
+    if (unit) return true;
+  }
+  return false;
+}
+
+// Возвращает true, если указанная клетка занята любым существом
+export function isCellOccupied(gameState, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  return !!gameState.board?.[r]?.[c]?.unit;
+}
+
+// Проверяет возможность постановки существа на пустую клетку с учётом новых ограничений
+export function canSummonOnEmptyCell(gameState, playerIndex, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) {
+    return { allowed: false, reason: 'Game state is unavailable.' };
+  }
+  if (!isInBounds(r, c)) {
+    return { allowed: false, reason: 'Cell is out of bounds.' };
+  }
+  if (isCellOccupied(gameState, r, c)) {
+    return { allowed: false, reason: 'Cell is occupied.' };
+  }
+  if (!hasPlayerUnits(gameState, playerIndex)) {
+    // Первое существо можно ставить в любую пустую клетку
+    return { allowed: true };
+  }
+  if (!hasAdjacentUnits(gameState, r, c)) {
+    return { allowed: false, reason: 'Choose a field next to any creature.' };
+  }
+  return { allowed: true };
+}
+
+// Собирает список пустых клеток, доступных для постановки существа
+export function getAvailableEmptyCells(gameState, playerIndex) {
+  const result = [];
+  if (!gameState || !Array.isArray(gameState.board)) return result;
+  for (let r = 0; r < gameState.board.length; r++) {
+    const row = gameState.board[r];
+    if (!row) continue;
+    for (let c = 0; c < row.length; c++) {
+      const check = canSummonOnEmptyCell(gameState, playerIndex, r, c);
+      if (check.allowed) {
+        result.push({ r, c });
+      }
+    }
+  }
+  return result;
+}
+
+export default {
+  hasPlayerUnits,
+  isCellOccupied,
+  canSummonOnEmptyCell,
+  getAvailableEmptyCells,
+};

--- a/src/scene/placementHighlight.js
+++ b/src/scene/placementHighlight.js
@@ -1,0 +1,143 @@
+// Мягкая подсветка доступных клеток для призыва существ.
+// Визуальная часть отделена от логики: модуль принимает список клеток и сам управляет мешами-подсветками.
+
+import { getCtx } from './context.js';
+
+const state = {
+  overlays: [],
+  uniforms: [],
+  rafId: 0,
+  geometry: null,
+};
+
+// Создаёт шейдерный материал с плавным затуханием к центру
+function createOverlayMaterial(THREE) {
+  const material = new THREE.ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    side: THREE.DoubleSide,
+    uniforms: {
+      uTime: { value: 0 },
+      uColor: { value: new THREE.Color(0xc5b3ff) },
+    },
+    vertexShader: `
+      varying vec2 vUv;
+      void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      varying vec2 vUv;
+      uniform float uTime;
+      uniform vec3 uColor;
+      void main() {
+        vec2 centered = vUv - vec2(0.5);
+        float dist = length(centered * 1.5);
+        float hollow = smoothstep(0.2, 0.42, dist);
+        float rim = hollow * (1.0 - smoothstep(0.86, 1.1, dist));
+        float ripple = 0.6 + 0.4 * sin(uTime * 1.3 + dist * 8.0);
+        float pulse = 0.7 + 0.3 * sin(uTime * 1.8);
+        float alpha = rim * ripple * pulse * 0.48;
+        vec3 glow = mix(vec3(0.96, 0.93, 1.0), uColor, clamp(rim * 1.25, 0.0, 1.0));
+        gl_FragColor = vec4(glow, alpha);
+        if (gl_FragColor.a <= 0.01) discard;
+      }
+    `,
+  });
+  state.uniforms.push(material.uniforms.uTime);
+  return material;
+}
+
+function ensureGeometry(THREE, tile) {
+  if (state.geometry) return state.geometry;
+  const width = tile?.geometry?.parameters?.width || 6.2;
+  const depth = tile?.geometry?.parameters?.depth || 6.2;
+  state.geometry = new THREE.PlaneGeometry(width * 0.88, depth * 0.88, 1, 1);
+  return state.geometry;
+}
+
+function placeOverlayOnTile(tile, material) {
+  const ctx = getCtx();
+  const { THREE, tileFrames } = ctx;
+  if (!THREE || !tile) return null;
+  const geometry = ensureGeometry(THREE, tile);
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.rotation.x = -Math.PI / 2;
+  mesh.renderOrder = 550;
+  mesh.position.copy(tile.position);
+  try {
+    const frameSegment = tileFrames?.[tile.userData.row]?.[tile.userData.col]?.children?.[0];
+    const baseY = frameSegment?.position?.y ?? (tile.position.y + (tile.geometry?.parameters?.height || 0) / 2);
+    mesh.position.y = baseY + 0.02;
+  } catch {
+    mesh.position.y = tile.position.y + 0.02;
+  }
+  const parent = ctx.effectsGroup || ctx.boardGroup;
+  parent?.add(mesh);
+  return mesh;
+}
+
+function startAnim() {
+  if (state.rafId) return;
+  const start = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+  function tick() {
+    const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    const t = (now - start) / 1000;
+    state.uniforms.forEach(u => { if (u) u.value = t; });
+    state.rafId = (typeof requestAnimationFrame !== 'undefined')
+      ? requestAnimationFrame(tick)
+      : setTimeout(tick, 16);
+  }
+  tick();
+}
+
+function stopAnim() {
+  if (!state.rafId) return;
+  if (typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(state.rafId);
+  else clearTimeout(state.rafId);
+  state.rafId = 0;
+}
+
+function disposeOverlay(mesh) {
+  if (!mesh) return;
+  try { mesh.removeFromParent?.(); } catch {}
+  try { mesh.material?.dispose?.(); } catch {}
+}
+
+export function highlightPlacement(cells = []) {
+  clearPlacementHighlights();
+  const ctx = getCtx();
+  const { THREE, tileMeshes } = ctx;
+  if (!THREE || !Array.isArray(tileMeshes)) return;
+  for (const { r, c } of cells) {
+    const tile = tileMeshes?.[r]?.[c];
+    if (!tile) continue;
+    const material = createOverlayMaterial(THREE);
+    const mesh = placeOverlayOnTile(tile, material);
+    if (!mesh) {
+      try { material.dispose(); } catch {}
+      continue;
+    }
+    state.overlays.push(mesh);
+  }
+  if (state.overlays.length) {
+    startAnim();
+  }
+}
+
+export function clearPlacementHighlights() {
+  stopAnim();
+  state.uniforms = [];
+  state.overlays.forEach(mesh => disposeOverlay(mesh));
+  state.overlays = [];
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__placementHighlight = { highlightPlacement, clearPlacementHighlights };
+  }
+} catch {}
+
+export default { highlightPlacement, clearPlacementHighlights };


### PR DESCRIPTION
## Summary
- retune the placement overlay shader with a lilac edge-focused ripple to keep tile centers visible
- reduce the overlay plane size so the highlight hugs tile borders rather than flooding the whole cell

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da144c672c8330a051f4e082ee6f16