### PR TITLE
Add vertical wave frame placement highlight

### DIFF
--- a/src/core/placementRules.js
+++ b/src/core/placementRules.js
@@ -1,0 +1,93 @@
+// Правила размещения существ на поле.
+// Логика вынесена в отдельный модуль, чтобы облегчить перенос на другие движки.
+
+// Проверка принадлежности координат игровому полю 3x3
+function isInBounds(r, c) {
+  return r >= 0 && r < 3 && c >= 0 && c < 3;
+}
+
+// Возвращает true, если у игрока уже есть существа на поле
+export function hasPlayerUnits(gameState, playerIndex) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  for (let r = 0; r < gameState.board.length; r++) {
+    const row = gameState.board[r];
+    if (!row) continue;
+    for (let c = 0; c < row.length; c++) {
+      const unit = row[c]?.unit;
+      if (unit && typeof unit.owner === 'number' && unit.owner === playerIndex) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Проверяет, есть ли хотя бы одно существо рядом (по сторонам) с указанной клеткой
+function hasAdjacentUnits(gameState, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  const dirs = [
+    { dr: -1, dc: 0 },
+    { dr: 1, dc: 0 },
+    { dr: 0, dc: -1 },
+    { dr: 0, dc: 1 },
+  ];
+  for (const { dr, dc } of dirs) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!isInBounds(nr, nc)) continue;
+    const unit = gameState.board?.[nr]?.[nc]?.unit;
+    if (unit) return true;
+  }
+  return false;
+}
+
+// Возвращает true, если указанная клетка занята любым существом
+export function isCellOccupied(gameState, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  return !!gameState.board?.[r]?.[c]?.unit;
+}
+
+// Проверяет возможность постановки существа на пустую клетку с учётом новых ограничений
+export function canSummonOnEmptyCell(gameState, playerIndex, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) {
+    return { allowed: false, reason: 'Game state is unavailable.' };
+  }
+  if (!isInBounds(r, c)) {
+    return { allowed: false, reason: 'Cell is out of bounds.' };
+  }
+  if (isCellOccupied(gameState, r, c)) {
+    return { allowed: false, reason: 'Cell is occupied.' };
+  }
+  if (!hasPlayerUnits(gameState, playerIndex)) {
+    // Первое существо можно ставить в любую пустую клетку
+    return { allowed: true };
+  }
+  if (!hasAdjacentUnits(gameState, r, c)) {
+    return { allowed: false, reason: 'Choose a field next to any creature.' };
+  }
+  return { allowed: true };
+}
+
+// Собирает список пустых клеток, доступных для постановки существа
+export function getAvailableEmptyCells(gameState, playerIndex) {
+  const result = [];
+  if (!gameState || !Array.isArray(gameState.board)) return result;
+  for (let r = 0; r < gameState.board.length; r++) {
+    const row = gameState.board[r];
+    if (!row) continue;
+    for (let c = 0; c < row.length; c++) {
+      const check = canSummonOnEmptyCell(gameState, playerIndex, r, c);
+      if (check.allowed) {
+        result.push({ r, c });
+      }
+    }
+  }
+  return result;
+}
+
+export default {
+  hasPlayerUnits,
+  isCellOccupied,
+  canSummonOnEmptyCell,
+  getAvailableEmptyCells,
+};

--- a/src/scene/placementHighlight.js
+++ b/src/scene/placementHighlight.js
@@ -1,0 +1,209 @@
+// Световые рамки для обозначения доступных клеток призыва.
+// Логика подсветки и её шейдер вынесены в отдельный модуль для упрощения замены движка.
+
+import { getCtx } from './context.js';
+
+const state = {
+  overlays: [],
+  materials: [],
+  timeUniforms: [],
+  rafId: 0,
+  geometryCache: new Map(),
+};
+
+function createWaveMaterial(THREE) {
+  const seed = Math.random();
+  const material = new THREE.ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+    uniforms: {
+      uTime: { value: 0 },
+      uSeed: { value: seed },
+      uColor: { value: new THREE.Color(0xffffff) },
+    },
+    vertexShader: `
+      varying vec2 vUv;
+      void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      varying vec2 vUv;
+      uniform float uTime;
+      uniform float uSeed;
+      uniform vec3 uColor;
+
+      float wave(float shift) {
+        float center = fract(shift);
+        float dist = abs(vUv.y - center);
+        float band = smoothstep(0.22, 0.0, dist);
+        return band;
+      }
+
+      void main() {
+        float speed = mix(0.85, 1.45, fract(uSeed * 17.0));
+        float envelope = smoothstep(0.0, 0.08, vUv.y) * (1.0 - smoothstep(0.68, 1.0, vUv.y));
+        float pulses = wave(uTime * speed) + wave(uTime * speed + 0.5);
+        float baseGlow = smoothstep(0.0, 0.02, vUv.y) * 0.7;
+        float lateralFade = smoothstep(0.0, 0.12, vUv.x) * smoothstep(0.0, 0.12, 1.0 - vUv.x);
+        float intensity = (pulses * envelope + baseGlow) * lateralFade;
+        intensity = clamp(intensity, 0.0, 1.0);
+        vec3 color = uColor * (0.9 + 0.1 * smoothstep(0.0, 0.2, vUv.y));
+        float alpha = pow(intensity, 0.72);
+        gl_FragColor = vec4(color, alpha);
+        if (gl_FragColor.a < 0.02) discard;
+      }
+    `,
+  });
+
+  state.timeUniforms.push(material.uniforms.uTime);
+  state.materials.push(material);
+  return material;
+}
+
+function getTileMetrics(tile) {
+  const width = tile?.geometry?.parameters?.width || 6.2;
+  const depth = tile?.geometry?.parameters?.depth || 6.2;
+  const frameHeight = Math.max(width, depth) * 0.72;
+  return { width, depth, frameHeight };
+}
+
+function ensureGeometries(THREE, metrics) {
+  const key = `${metrics.width.toFixed(3)}|${metrics.depth.toFixed(3)}|${metrics.frameHeight.toFixed(3)}`;
+  if (state.geometryCache.has(key)) return state.geometryCache.get(key);
+
+  const geoX = new THREE.PlaneGeometry(metrics.width, metrics.frameHeight, 1, 1);
+  const geoZ = new THREE.PlaneGeometry(metrics.depth, metrics.frameHeight, 1, 1);
+  const cached = { geoX, geoZ };
+  state.geometryCache.set(key, cached);
+  return cached;
+}
+
+function resolveBaseY(tile) {
+  try {
+    const ctx = getCtx();
+    const frameSegment = ctx.tileFrames?.[tile.userData.row]?.[tile.userData.col]?.children?.[0];
+    const frameY = frameSegment?.position?.y;
+    if (typeof frameY === 'number') return frameY;
+  } catch {}
+  const tileHeight = tile?.geometry?.parameters?.height || 0;
+  return tile.position.y + tileHeight / 2;
+}
+
+function buildFrameGroup(THREE, tile, material) {
+  if (!tile) return null;
+  const metrics = getTileMetrics(tile);
+  const { geoX, geoZ } = ensureGeometries(THREE, metrics);
+
+  const group = new THREE.Group();
+  group.renderOrder = 560;
+
+  const margin = Math.min(metrics.width, metrics.depth) * 0.04;
+  const lift = 0.03;
+  const halfHeight = metrics.frameHeight / 2;
+  const halfWidth = metrics.width / 2;
+  const halfDepth = metrics.depth / 2;
+
+  const edges = [
+    { geometry: geoX, position: [0, halfHeight, halfDepth + margin], rotation: [0, 0, 0] },
+    { geometry: geoX, position: [0, halfHeight, -halfDepth - margin], rotation: [0, Math.PI, 0] },
+    { geometry: geoZ, position: [halfWidth + margin, halfHeight, 0], rotation: [0, Math.PI / 2, 0] },
+    { geometry: geoZ, position: [-halfWidth - margin, halfHeight, 0], rotation: [0, -Math.PI / 2, 0] },
+  ];
+
+  for (const edge of edges) {
+    const mesh = new THREE.Mesh(edge.geometry, material);
+    mesh.position.set(...edge.position);
+    mesh.rotation.set(...edge.rotation);
+    group.add(mesh);
+  }
+
+  group.position.copy(tile.position);
+  group.position.y = resolveBaseY(tile) + lift;
+  return group;
+}
+
+function placeOverlayOnTile(tile, material) {
+  const ctx = getCtx();
+  const { THREE } = ctx;
+  if (!THREE) return null;
+
+  const group = buildFrameGroup(THREE, tile, material);
+  if (!group) return null;
+
+  const parent = ctx.effectsGroup || ctx.boardGroup;
+  parent?.add(group);
+  return group;
+}
+
+function startAnim() {
+  if (state.rafId) return;
+  const start = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+  function tick() {
+    const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    const t = (now - start) / 1000;
+    state.timeUniforms.forEach(u => { if (u) u.value = t; });
+    state.rafId = (typeof requestAnimationFrame !== 'undefined')
+      ? requestAnimationFrame(tick)
+      : setTimeout(tick, 16);
+  }
+  tick();
+}
+
+function stopAnim() {
+  if (!state.rafId) return;
+  if (typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(state.rafId);
+  else clearTimeout(state.rafId);
+  state.rafId = 0;
+}
+
+function disposeOverlay(group) {
+  if (!group) return;
+  try { group.removeFromParent?.(); } catch {}
+}
+
+export function highlightPlacement(cells = []) {
+  clearPlacementHighlights();
+  const ctx = getCtx();
+  const { THREE, tileMeshes } = ctx;
+  if (!THREE || !Array.isArray(tileMeshes)) return;
+
+  for (const { r, c } of cells) {
+    const tile = tileMeshes?.[r]?.[c];
+    if (!tile) continue;
+    const material = createWaveMaterial(THREE);
+    const group = placeOverlayOnTile(tile, material);
+    if (!group) {
+      state.timeUniforms.pop();
+      const disposed = state.materials.pop();
+      try { (disposed || material).dispose(); } catch {}
+      continue;
+    }
+    state.overlays.push(group);
+  }
+
+  if (state.overlays.length) {
+    startAnim();
+  }
+}
+
+export function clearPlacementHighlights() {
+  stopAnim();
+  state.timeUniforms = [];
+  state.overlays.forEach(group => disposeOverlay(group));
+  state.overlays = [];
+  state.materials.forEach(mat => { try { mat.dispose(); } catch {} });
+  state.materials = [];
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__placementHighlight = { highlightPlacement, clearPlacementHighlights };
+  }
+} catch {}
+
+export default { highlightPlacement, clearPlacementHighlights };


### PR DESCRIPTION
## Summary
- replace the summon placement overlay with a vertical wave-frame effect that sends white pulses upward from tile edges
- cache frame geometries per tile size and manage shader lifecycles to keep the highlight module self-contained

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68da144c672c8330a051f4e082ee6f16