### PR TITLE
Tweak placement highlight height and transparency

### DIFF
--- a/src/core/placementRules.js
+++ b/src/core/placementRules.js
@@ -1,0 +1,93 @@
+// Правила размещения существ на поле.
+// Логика вынесена в отдельный модуль, чтобы облегчить перенос на другие движки.
+
+// Проверка принадлежности координат игровому полю 3x3
+function isInBounds(r, c) {
+  return r >= 0 && r < 3 && c >= 0 && c < 3;
+}
+
+// Возвращает true, если у игрока уже есть существа на поле
+export function hasPlayerUnits(gameState, playerIndex) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  for (let r = 0; r < gameState.board.length; r++) {
+    const row = gameState.board[r];
+    if (!row) continue;
+    for (let c = 0; c < row.length; c++) {
+      const unit = row[c]?.unit;
+      if (unit && typeof unit.owner === 'number' && unit.owner === playerIndex) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Проверяет, есть ли хотя бы одно существо рядом (по сторонам) с указанной клеткой
+function hasAdjacentUnits(gameState, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  const dirs = [
+    { dr: -1, dc: 0 },
+    { dr: 1, dc: 0 },
+    { dr: 0, dc: -1 },
+    { dr: 0, dc: 1 },
+  ];
+  for (const { dr, dc } of dirs) {
+    const nr = r + dr;
+    const nc = c + dc;
+    if (!isInBounds(nr, nc)) continue;
+    const unit = gameState.board?.[nr]?.[nc]?.unit;
+    if (unit) return true;
+  }
+  return false;
+}
+
+// Возвращает true, если указанная клетка занята любым существом
+export function isCellOccupied(gameState, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) return false;
+  return !!gameState.board?.[r]?.[c]?.unit;
+}
+
+// Проверяет возможность постановки существа на пустую клетку с учётом новых ограничений
+export function canSummonOnEmptyCell(gameState, playerIndex, r, c) {
+  if (!gameState || !Array.isArray(gameState.board)) {
+    return { allowed: false, reason: 'Game state is unavailable.' };
+  }
+  if (!isInBounds(r, c)) {
+    return { allowed: false, reason: 'Cell is out of bounds.' };
+  }
+  if (isCellOccupied(gameState, r, c)) {
+    return { allowed: false, reason: 'Cell is occupied.' };
+  }
+  if (!hasPlayerUnits(gameState, playerIndex)) {
+    // Первое существо можно ставить в любую пустую клетку
+    return { allowed: true };
+  }
+  if (!hasAdjacentUnits(gameState, r, c)) {
+    return { allowed: false, reason: 'Choose a field next to any creature.' };
+  }
+  return { allowed: true };
+}
+
+// Собирает список пустых клеток, доступных для постановки существа
+export function getAvailableEmptyCells(gameState, playerIndex) {
+  const result = [];
+  if (!gameState || !Array.isArray(gameState.board)) return result;
+  for (let r = 0; r < gameState.board.length; r++) {
+    const row = gameState.board[r];
+    if (!row) continue;
+    for (let c = 0; c < row.length; c++) {
+      const check = canSummonOnEmptyCell(gameState, playerIndex, r, c);
+      if (check.allowed) {
+        result.push({ r, c });
+      }
+    }
+  }
+  return result;
+}
+
+export default {
+  hasPlayerUnits,
+  isCellOccupied,
+  canSummonOnEmptyCell,
+  getAvailableEmptyCells,
+};

--- a/src/scene/placementHighlight.js
+++ b/src/scene/placementHighlight.js
@@ -1,0 +1,189 @@
+// Волновая подсветка доступных клеток для призыва существ.
+// Модуль остаётся самостоятельным: логика передаёт только координаты, визуальный эффект управляется здесь.
+
+import { getCtx } from './context.js';
+
+const state = {
+  overlays: [],
+  uniforms: [],
+  rafId: 0,
+  edgeGeometry: null,
+};
+
+// Создаёт шейдерный материал с белой рамкой и пульсирующими волнами, уходящими вверх.
+function createOverlayMaterial(THREE) {
+  const material = new THREE.ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    depthTest: true,
+    side: THREE.DoubleSide,
+    blending: THREE.AdditiveBlending,
+    uniforms: {
+      uTime: { value: 0 },
+      uSeed: { value: Math.random() * 10 },
+    },
+    vertexShader: `
+      varying vec2 vUv;
+      void main() {
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      varying vec2 vUv;
+      uniform float uTime;
+      uniform float uSeed;
+
+      float wavePulse(float offset) {
+        float speed = 0.8;
+        float density = 2.1;
+        float pos = fract(vUv.y * density - uTime * speed + offset + uSeed);
+        float front = smoothstep(0.0, 0.12, 1.0 - pos);
+        float tail = smoothstep(0.36, 0.16, pos);
+        return front * tail;
+      }
+
+      void main() {
+        float baseGlow = smoothstep(1.0, 0.78, vUv.y);
+        float wave = wavePulse(0.0) + 0.55 * wavePulse(0.37);
+        float fadeTop = smoothstep(1.0, 0.45, vUv.y);
+        float lateral = smoothstep(0.0, 0.02, vUv.x) * smoothstep(0.0, 0.02, 1.0 - vUv.x);
+        // Чуть повышаем прозрачность за счёт коэффициента 0.8.
+        float intensity = (baseGlow * 0.6 + wave * 1.5) * fadeTop * lateral * 0.8;
+        float alpha = clamp(intensity, 0.0, 1.0);
+        if (alpha <= 0.01) discard;
+        gl_FragColor = vec4(vec3(1.0), alpha);
+      }
+    `,
+  });
+  material.toneMapped = false;
+  return material;
+}
+
+function ensureEdgeGeometry(THREE) {
+  if (!state.edgeGeometry) {
+    state.edgeGeometry = new THREE.PlaneGeometry(1, 1, 1, 48);
+  }
+  return state.edgeGeometry;
+}
+
+// Формирует группу из четырёх вертикальных граней-рамок вокруг клетки.
+function createFrameGroup(tile, material) {
+  const ctx = getCtx();
+  const { THREE, tileFrames } = ctx;
+  if (!THREE || !tile) return null;
+
+  const geometry = ensureEdgeGeometry(THREE);
+  const group = new THREE.Group();
+  group.renderOrder = 580;
+
+  const width = tile?.geometry?.parameters?.width || 6.2;
+  const depth = tile?.geometry?.parameters?.depth || 6.2;
+  const tileHeight = tile?.geometry?.parameters?.height || 0;
+  const frameHeight = Math.max(width, depth) * 0.13;
+
+  let baseY = tile.position.y + tileHeight / 2;
+  try {
+    const frameSegment = tileFrames?.[tile.userData.row]?.[tile.userData.col]?.children?.[0];
+    if (frameSegment?.position?.y !== undefined) {
+      baseY = frameSegment.position.y;
+    }
+  } catch {}
+
+  group.position.set(tile.position.x, baseY + 0.02, tile.position.z);
+
+  const createEdge = (length) => {
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.scale.set(length, frameHeight, 1);
+    mesh.position.y = frameHeight / 2;
+    mesh.frustumCulled = false;
+    return mesh;
+  };
+
+  const north = createEdge(width);
+  north.position.z = depth / 2;
+
+  const south = createEdge(width);
+  south.position.z = -depth / 2;
+  south.rotation.y = Math.PI;
+
+  const east = createEdge(depth);
+  east.position.x = width / 2;
+  east.rotation.y = -Math.PI / 2;
+
+  const west = createEdge(depth);
+  west.position.x = -width / 2;
+  west.rotation.y = Math.PI / 2;
+
+  group.add(north, south, east, west);
+
+  const parent = ctx.effectsGroup || ctx.boardGroup;
+  parent?.add(group);
+  return group;
+}
+
+function startAnim() {
+  if (state.rafId) return;
+  const start = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+  function tick() {
+    const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    const t = (now - start) / 1000;
+    state.uniforms.forEach(u => { if (u) u.value = t; });
+    state.rafId = (typeof requestAnimationFrame !== 'undefined')
+      ? requestAnimationFrame(tick)
+      : setTimeout(tick, 16);
+  }
+  tick();
+}
+
+function stopAnim() {
+  if (!state.rafId) return;
+  if (typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(state.rafId);
+  else clearTimeout(state.rafId);
+  state.rafId = 0;
+}
+
+function disposeOverlay(entry) {
+  if (!entry) return;
+  const { group, material } = entry;
+  try { group.removeFromParent?.(); } catch {}
+  try { group.clear?.(); } catch {}
+  try { material?.dispose?.(); } catch {}
+}
+
+export function highlightPlacement(cells = []) {
+  clearPlacementHighlights();
+  const ctx = getCtx();
+  const { THREE, tileMeshes } = ctx;
+  if (!THREE || !Array.isArray(tileMeshes)) return;
+  for (const { r, c } of cells) {
+    const tile = tileMeshes?.[r]?.[c];
+    if (!tile) continue;
+    const material = createOverlayMaterial(THREE);
+    const group = createFrameGroup(tile, material);
+    if (!group) {
+      try { material.dispose(); } catch {}
+      continue;
+    }
+    state.uniforms.push(material.uniforms.uTime);
+    state.overlays.push({ group, material });
+  }
+  if (state.overlays.length) {
+    startAnim();
+  }
+}
+
+export function clearPlacementHighlights() {
+  stopAnim();
+  state.uniforms = [];
+  state.overlays.forEach(entry => disposeOverlay(entry));
+  state.overlays = [];
+}
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__placementHighlight = { highlightPlacement, clearPlacementHighlights };
+  }
+} catch {}
+
+export default { highlightPlacement, clearPlacementHighlights };


### PR DESCRIPTION
## Summary
- reduce the placement frame height to one fifth of its previous value for a subtler effect
- lower the shader intensity by 20% to keep the highlight more transparent and unobtrusive

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68da144c672c8330a051f4e082ee6f16