### PR TITLE
Adjust deck selection layout and add cancel option to deck builder

### DIFF
--- a/src/ui/deckBuilder.js
+++ b/src/ui/deckBuilder.js
@@ -286,10 +286,27 @@ export function open(deck = null, onDone) {
   summary.className = 'mt-2 text-center';
   left.appendChild(summary);
 
-  const doneBtn = document.createElement('button');
-  doneBtn.className = 'overlay-panel mt-2 px-3 py-1.5 bg-slate-600 hover:bg-slate-700';
-  doneBtn.textContent = 'Done';
-  left.appendChild(doneBtn);
+  let saving = false;
+
+  const actions = document.createElement('div');
+  actions.className = 'mt-2 flex gap-2';
+  left.appendChild(actions);
+
+  // Кнопка отмены возвращает предыдущее состояние без сохранения
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-700 hover:bg-slate-600';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => {
+    if (saving) return;
+    cleanup();
+    onDone && onDone();
+  });
+  actions.appendChild(cancelBtn);
+
+  const saveBtn = document.createElement('button');
+  saveBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700';
+  saveBtn.textContent = 'Save';
+  actions.appendChild(saveBtn);
 
   // === Каталог карт ===
   const catalog = document.createElement('div');
@@ -661,13 +678,12 @@ export function open(deck = null, onDone) {
 
   searchInput.addEventListener('input', renderCatalog);
 
-  let saving = false;
-  doneBtn.addEventListener('click', async () => {
+  saveBtn.addEventListener('click', async () => {
     if (saving) return;
     saving = true;
-    const prevText = doneBtn.textContent;
-    doneBtn.disabled = true;
-    doneBtn.textContent = 'Saving…';
+    const prevText = saveBtn.textContent;
+    saveBtn.disabled = true;
+    saveBtn.textContent = 'Saving…';
 
     working.name = nameInput.value.trim() || 'Untitled';
 
@@ -691,8 +707,8 @@ export function open(deck = null, onDone) {
       onDone && onDone();
       saving = false;
       try {
-        doneBtn.disabled = false;
-        doneBtn.textContent = prevText;
+        saveBtn.disabled = false;
+        saveBtn.textContent = prevText;
       } catch {}
     }
   });

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -20,10 +20,15 @@ export function open(opts = {}) {
 
   const overlay = document.createElement('div');
   overlay.id = 'deck-select-overlay';
-  overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60';
+  overlay.className = 'fixed inset-0 z-50 flex items-center justify-center overflow-y-auto relative';
+
+  // Фон оверлея скрывает игровые панели и добавляет лёгкое размытие
+  const backdrop = document.createElement('div');
+  backdrop.className = 'deck-select-backdrop';
+  overlay.appendChild(backdrop);
 
   const panel = document.createElement('div');
-  panel.className = 'bg-slate-800 p-4 rounded-lg w-[26rem] max-h-[90vh] flex flex-col shadow-2xl';
+  panel.className = 'relative z-10 bg-slate-800 p-4 rounded-lg w-[26rem] max-h-[90vh] flex flex-col shadow-2xl';
   overlay.appendChild(panel);
 
   const title = document.createElement('div');
@@ -32,7 +37,7 @@ export function open(opts = {}) {
   panel.appendChild(title);
 
   const list = document.createElement('div');
-  list.className = 'flex-1 overflow-y-auto space-y-3 px-2 max-h-64 deck-scroll';
+  list.className = 'flex-1 overflow-y-auto space-y-3 px-2 max-h-96 deck-scroll';
   panel.appendChild(list);
 
   const btnWrap = document.createElement('div');
@@ -153,7 +158,7 @@ export function open(opts = {}) {
 
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
-  cancelBtn.textContent = 'Cancel';
+  cancelBtn.textContent = 'Back';
   cancelBtn.addEventListener('click', () => closeAnd(onCancel));
   rightBtns.appendChild(cancelBtn);
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -78,6 +78,15 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 
 /* Панели */
 .overlay-panel { background: rgba(30, 41, 59, 0.95); backdrop-filter: blur(10px); border: 1px solid rgba(148, 163, 184, 0.3); border-radius: 16px; }
+
+/* Фон меню выбора колоды — отделяем визуал от логики */
+#deck-select-overlay .deck-select-backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(30, 41, 59, 0.98), rgba(15, 23, 42, 0.98));
+  backdrop-filter: blur(12px);
+  pointer-events: none;
+}
 /* Глянцевая кнопка с переливом при наведении */
 .glossy-btn { position: relative; overflow: hidden; }
 .glossy-btn::after {


### PR DESCRIPTION
## Summary
- expand the deck selection overlay with a custom backdrop, taller list, and a Back button
- update the deck builder controls with separate Cancel and Save actions that respect the current saving flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dba1a8dfc08330ac3c980b47f36f30