### PR TITLE
Improve deck selection and builder dialogs

### DIFF
--- a/src/ui/deckBuilder.js
+++ b/src/ui/deckBuilder.js
@@ -286,10 +286,19 @@ export function open(deck = null, onDone) {
   summary.className = 'mt-2 text-center';
   left.appendChild(summary);
 
-  const doneBtn = document.createElement('button');
-  doneBtn.className = 'overlay-panel mt-2 px-3 py-1.5 bg-slate-600 hover:bg-slate-700';
-  doneBtn.textContent = 'Done';
-  left.appendChild(doneBtn);
+  const controlsRow = document.createElement('div');
+  controlsRow.className = 'mt-2 flex gap-2';
+  left.appendChild(controlsRow);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'overlay-panel flex-1 px-3 py-1.5 bg-slate-700/70 hover:bg-slate-700 transition-colors';
+  cancelBtn.textContent = 'Cancel';
+  controlsRow.appendChild(cancelBtn);
+
+  const saveBtn = document.createElement('button');
+  saveBtn.className = 'overlay-panel flex-1 px-3 py-1.5 bg-slate-600 hover:bg-slate-700';
+  saveBtn.textContent = 'Save';
+  controlsRow.appendChild(saveBtn);
 
   // === Каталог карт ===
   const catalog = document.createElement('div');
@@ -662,12 +671,20 @@ export function open(deck = null, onDone) {
   searchInput.addEventListener('input', renderCatalog);
 
   let saving = false;
-  doneBtn.addEventListener('click', async () => {
+  cancelBtn.addEventListener('click', () => {
+    // Отмена закрывает редактор без сохранения текущих изменений
+    if (saving) return;
+    cleanup();
+    onDone && onDone();
+  });
+
+  saveBtn.addEventListener('click', async () => {
     if (saving) return;
     saving = true;
-    const prevText = doneBtn.textContent;
-    doneBtn.disabled = true;
-    doneBtn.textContent = 'Saving…';
+    const prevText = saveBtn.textContent;
+    saveBtn.disabled = true;
+    cancelBtn.disabled = true;
+    saveBtn.textContent = 'Saving…';
 
     working.name = nameInput.value.trim() || 'Untitled';
 
@@ -691,8 +708,9 @@ export function open(deck = null, onDone) {
       onDone && onDone();
       saving = false;
       try {
-        doneBtn.disabled = false;
-        doneBtn.textContent = prevText;
+        saveBtn.disabled = false;
+        cancelBtn.disabled = false;
+        saveBtn.textContent = prevText;
       } catch {}
     }
   });

--- a/src/ui/deckSelect.js
+++ b/src/ui/deckSelect.js
@@ -20,10 +20,10 @@ export function open(opts = {}) {
 
   const overlay = document.createElement('div');
   overlay.id = 'deck-select-overlay';
-  overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60';
+  overlay.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80 backdrop-blur-sm';
 
   const panel = document.createElement('div');
-  panel.className = 'bg-slate-800 p-4 rounded-lg w-[26rem] max-h-[90vh] flex flex-col shadow-2xl';
+  panel.className = 'bg-slate-800 p-4 rounded-lg w-[26rem] max-h-[95vh] min-h-[40rem] flex flex-col shadow-2xl';
   overlay.appendChild(panel);
 
   const title = document.createElement('div');
@@ -32,7 +32,7 @@ export function open(opts = {}) {
   panel.appendChild(title);
 
   const list = document.createElement('div');
-  list.className = 'flex-1 overflow-y-auto space-y-3 px-2 max-h-64 deck-scroll';
+  list.className = 'flex-1 overflow-y-auto space-y-3 px-2 max-h-[30rem] deck-scroll';
   panel.appendChild(list);
 
   const btnWrap = document.createElement('div');
@@ -153,7 +153,7 @@ export function open(opts = {}) {
 
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'overlay-panel px-3 py-1.5 bg-slate-600 hover:bg-slate-700 glossy-btn transition-colors';
-  cancelBtn.textContent = 'Cancel';
+  cancelBtn.textContent = 'Back';
   cancelBtn.addEventListener('click', () => closeAnd(onCancel));
   rightBtns.appendChild(cancelBtn);
 


### PR DESCRIPTION
## Summary
- increase the deck selection dialog capacity further so four decks fit without scrolling
- add a cancel action to the deck builder and rename the save control for clarity

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68dba1a8dfc08330ac3c980b47f36f30