### PR TITLE
Make deck limit alerts auto dismiss

### DIFF
--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -1,8 +1,12 @@
 // База данных всех карт
-
-export const CARDS = {
+const RAW_CARDS = {
   // Fire Set (subset extracted; extend as needed)
   FIRE_FLAME_MAGUS: {
+    cardNumber: 1,
+    race: 'Human',
+    affiliation: 'Church of Parmus',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_FLAME_MAGUS', name: 'Flame Magus', type: 'UNIT', cost: 1, activation: 1,
     element: 'FIRE', atk: 1, hp: 1,
     attackType: 'MAGIC', // магическая атака
@@ -11,6 +15,11 @@ export const CARDS = {
     desc: 'Magic Attack: target any creature; no retaliation.'
   },
   FIRE_HELLFIRE_SPITTER: {
+    cardNumber: 2,
+    race: 'Bug',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_HELLFIRE_SPITTER', name: 'Hellfire Spitter', type: 'UNIT', cost: 1, activation: 1,
     element: 'FIRE', atk: 1, hp: 1,
     attackType: 'STANDARD', firstStrike: true,
@@ -25,6 +34,11 @@ export const CARDS = {
     desc: 'Quickness: always strikes first.'
   },
   FIRE_FREEDONIAN_WANDERER: {
+    cardNumber: 3,
+    race: 'Elemental',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_FREEDONIAN_WANDERER', name: 'Freedonian Wanderer', type: 'UNIT', cost: 2, activation: 1,
     element: 'FIRE', atk: 1, hp: 2,
     attackType: 'STANDARD', pierce: true,
@@ -39,6 +53,11 @@ export const CARDS = {
     desc: 'While Freedonian Wanderer is on a non‑Fire field, you gain 1 mana each time you summon an allied creature.'
   },
   FIRE_PARTMOLE_FLAME_LIZARD: {
+    cardNumber: 4,
+    race: 'Lizard',
+    affiliation: 'Dhees Empire',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_PARTMOLE_FLAME_LIZARD', name: 'Partmole Flame Lizard', type: 'UNIT', cost: 2, activation: 2,
     element: 'FIRE', atk: 2, hp: 2,
     attackType: 'STANDARD', firstStrike: true, activationReduction: 1,
@@ -47,6 +66,11 @@ export const CARDS = {
     desc: 'Quickness. The activation cost to attack is 1 less than listed.'
   },
   FIRE_GREAT_MINOS: {
+    cardNumber: 6,
+    race: 'Titan',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_GREAT_MINOS', name: 'Great Minos of Sciondar', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 2, hp: 1,
     attackType: 'STANDARD', pierce: true,
@@ -57,6 +81,11 @@ export const CARDS = {
     desc: 'Perfect Dodge. The activation cost to attack is 1 less. Destroy Great Minos if he is on a non‑Fire field.'
   },
   FIRE_FLAME_ASCETIC: {
+    cardNumber: 7,
+    race: 'Human',
+    affiliation: 'Cult of Mourning',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_FLAME_ASCETIC', name: 'Flame Ascetic', type: 'UNIT', cost: 3, activation: 3,
     element: 'FIRE', atk: 2, hp: 3,
     attackType: 'STANDARD', activationReduction: 2,
@@ -65,6 +94,11 @@ export const CARDS = {
     desc: 'Adds 2 to its Attack half the time. The activation cost to attack is 2 less than listed.'
   },
   FIRE_TRICEPTAUR_BEHEMOTH: {
+    cardNumber: 11,
+    race: 'Beast',
+    affiliation: 'Dhees Empire',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_TRICEPTAUR_BEHEMOTH', name: 'Triceptaur Behemoth', type: 'UNIT', cost: 5, activation: 5,
     element: 'FIRE', atk: 5, hp: 4,
     attackType: 'STANDARD',
@@ -78,6 +112,11 @@ export const CARDS = {
     desc: 'When Triceptaur Behemoth attacks 2 creatures, subtract 2 from its Attack; when attacking 3 creatures, subtract 4.'
   },
   FIRE_PURSUER_OF_SAINT_DHEES: {
+    cardNumber: 12,
+    race: 'Demon',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_PURSUER_OF_SAINT_DHEES', name: 'Pursuer of Saint Dhees', type: 'UNIT', cost: 6, activation: 6,
     element: 'FIRE', atk: 5, hp: 4,
     attackType: 'STANDARD', activationReduction: 5,
@@ -87,6 +126,11 @@ export const CARDS = {
   },
 
   FIRE_PARTMOLE_FLAME_GUARD: {
+    cardNumber: 8,
+    race: 'Demon',
+    affiliation: 'Dhees Empire',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_PARTMOLE_FLAME_GUARD', name: 'Partmole Flame Guard', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 1, hp: 3,
     attackType: 'STANDARD',
@@ -99,6 +143,11 @@ export const CARDS = {
   },
 
   FIRE_LESSER_GRANVENOA: {
+    cardNumber: 9,
+    race: 'Base',
+    affiliation: 'Cai-Shae',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_LESSER_GRANVENOA', name: 'Lesser Granvenoa', type: 'UNIT', cost: 4, activation: 2,
     element: 'FIRE', atk: 2, hp: 4,
     attackType: 'STANDARD',
@@ -113,6 +162,11 @@ export const CARDS = {
   },
 
   FIRE_PARTMOLE_FIRE_ORACLE: {
+    cardNumber: 10,
+    race: 'Demon',
+    affiliation: 'Church of Parmus',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_PARTMOLE_FIRE_ORACLE', name: 'Partmole Fire Oracle', type: 'UNIT', cost: 4, activation: 2,
     element: 'FIRE', atk: 2, hp: 3,
     attackType: 'MAGIC',
@@ -122,6 +176,11 @@ export const CARDS = {
   },
 
   FIRE_INFERNAL_SCIONDAR_DRAGON: {
+    cardNumber: 13,
+    race: 'Dragon',
+    affiliation: 'Dhees Empire',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_INFERNAL_SCIONDAR_DRAGON', name: 'Infernal Sciondar Dragon', type: 'UNIT', cost: 7, activation: 4,
     element: 'FIRE', atk: 5, hp: 8,
     attackType: 'STANDARD',
@@ -131,6 +190,11 @@ export const CARDS = {
   },
 
   FIRE_DIDI_THE_ENLIGHTENED: {
+    cardNumber: 14,
+    race: 'Hero',
+    affiliation: 'Cai-Shae',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'FIRE_DIDI_THE_ENLIGHTENED', name: 'Didi the Enlightened', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 2, hp: 4,
     attackType: 'STANDARD', firstStrike: true, doubleAttack: true,
@@ -140,6 +204,11 @@ export const CARDS = {
   },
 
   FIRE_WARDEN_HILDA: {
+    cardNumber: 15,
+    race: 'Betrayer',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'FIRE_WARDEN_HILDA', name: 'Warden Hilda', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 2, hp: 4,
     attackType: 'STANDARD',
@@ -151,6 +220,12 @@ export const CARDS = {
   },
 
   FIRE_CRUCIBLE_KING_DIOS_IV: {
+    cardNumber: 16,
+    race: 'Noble',
+    affiliation: 'Dhees Empire',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'FIRE_CRUCIBLE_KING_DIOS_IV', name: 'Crucible King Dios IV', type: 'UNIT', cost: 6, activation: 4,
     element: 'FIRE', atk: 3, hp: 6,
     attackType: 'STANDARD', doubleAttack: true,
@@ -165,6 +240,11 @@ export const CARDS = {
   },
 
   FIRE_RED_CUBIC: {
+    cardNumber: 18,
+    race: 'Egg',
+    affiliation: 'Unknown',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_RED_CUBIC', name: 'Red Cubic', type: 'UNIT', cost: 1, activation: 1,
     element: 'FIRE', atk: 1, hp: 1,
     attackType: 'STANDARD',
@@ -177,6 +257,12 @@ export const CARDS = {
   },
 
   FIRE_SCIONDAR_FIRE_GOD: {
+    cardNumber: 17,
+    race: 'God',
+    affiliation: 'Unknown',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'FIRE_SCIONDAR_FIRE_GOD', name: 'Sciondar Fire God', type: 'UNIT', cost: 9, activation: 5,
     element: 'FIRE', atk: 3, hp: 9,
     attackType: 'MAGIC',
@@ -188,6 +274,12 @@ export const CARDS = {
   },
 
   WATER_GODDESS_TRITONA: {
+    cardNumber: 35,
+    race: 'God',
+    affiliation: 'Unknown',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'WATER_GODDESS_TRITONA', name: 'Goddess Tritona', type: 'UNIT', cost: 9, activation: 5,
     element: 'WATER', atk: 3, hp: 9,
     attackType: 'MAGIC',
@@ -199,6 +291,11 @@ export const CARDS = {
   },
 
   WATER_CLOUD_RUNNER: {
+    cardNumber: 25,
+    race: 'Weapon',
+    affiliation: 'Siam Pirates',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_CLOUD_RUNNER', name: 'Cloud Runner', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 1, hp: 2,
     attackType: 'STANDARD', chooseDir: true,
@@ -212,6 +309,11 @@ export const CARDS = {
   },
 
   WATER_TRITONAN_ICE_GUARD: {
+    cardNumber: 20,
+    race: 'Elemental',
+    affiliation: 'Tritonan Queendom',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_TRITONAN_ICE_GUARD', name: 'Tritonan Ice Guard', type: 'UNIT', cost: 1, activation: 1,
     element: 'WATER', atk: 1, hp: 1,
     attackType: 'STANDARD',
@@ -222,6 +324,11 @@ export const CARDS = {
   },
 
   WATER_MONK_ELDER_OF_OKUNADA: {
+    cardNumber: 19,
+    race: 'Merfolk',
+    affiliation: 'Okunada Monastery',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_MONK_ELDER_OF_OKUNADA', name: 'Monk Elder of Okunada', type: 'UNIT', cost: 1, activation: 1,
     element: 'WATER', atk: 0, hp: 1,
     attackType: 'STANDARD',
@@ -232,6 +339,11 @@ export const CARDS = {
   },
 
   WATER_DRAGON_OF_VOICE_SEA: {
+    cardNumber: 31,
+    race: 'Dragon',
+    affiliation: 'Tritonan Queendom',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_DRAGON_OF_VOICE_SEA', name: 'Dragon of Voice Sea', type: 'UNIT', cost: 7, activation: 4,
     element: 'WATER', atk: 5, hp: 8,
     attackType: 'STANDARD',
@@ -243,6 +355,11 @@ export const CARDS = {
   },
 
   WATER_DON_OF_VENOA: {
+    cardNumber: 30,
+    race: 'Titan',
+    affiliation: 'Corsez Family',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_DON_OF_VENOA', name: 'Don of Venoa', type: 'UNIT', cost: 5, activation: 3,
     element: 'WATER', atk: 2, hp: 3,
     attackType: 'STANDARD',
@@ -275,6 +392,11 @@ export const CARDS = {
   },
 
   WATER_MERCENARY_SAVIOR_LATOO: {
+    cardNumber: 32,
+    race: 'Hero',
+    affiliation: 'Tritonan Queendom',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'WATER_MERCENARY_SAVIOR_LATOO', name: 'Mercenary Savior Latoo', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 2, hp: 3,
     attackType: 'STANDARD',
@@ -286,6 +408,11 @@ export const CARDS = {
   },
 
   WATER_TRITONAN_HARPOONSMAN: {
+    cardNumber: 21,
+    race: 'Merfolk',
+    affiliation: 'Tritonan Queendom',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_TRITONAN_HARPOONSMAN', name: 'Tritonan Harpoonsman', type: 'UNIT', cost: 2, activation: 1,
     element: 'WATER', atk: 1, hp: 2,
     attackType: 'STANDARD',
@@ -295,6 +422,11 @@ export const CARDS = {
   },
 
   WATER_ALUHJA_PRIESTESS: {
+    cardNumber: 22,
+    race: 'Human',
+    affiliation: 'Church of Parmus',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_ALUHJA_PRIESTESS', name: 'Aluhja Priestess', type: 'UNIT', cost: 2, activation: 1,
     element: 'WATER', atk: 1, hp: 1,
     attackType: 'MAGIC',
@@ -305,6 +437,11 @@ export const CARDS = {
   },
 
   WATER_MOVING_ISLE_OF_KADENA: {
+    cardNumber: 29,
+    race: 'Beast',
+    affiliation: 'Tritonan Queendom',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_MOVING_ISLE_OF_KADENA', name: 'Moving Isle of Kadena', type: 'UNIT', cost: 4, activation: 2,
     element: 'WATER', atk: 1, hp: 4,
     attackType: 'STANDARD', chooseDir: true,
@@ -326,6 +463,11 @@ export const CARDS = {
   },
 
   WATER_QUEENS_SERVANT: {
+    cardNumber: 28,
+    race: 'Elemental',
+    affiliation: 'Tritonan Queendom',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_QUEENS_SERVANT', name: "Queen's Servant", type: 'UNIT', cost: 4, activation: 2,
     element: 'WATER', atk: 1, hp: 1,
     attackType: 'MAGIC',
@@ -338,6 +480,11 @@ export const CARDS = {
   },
 
   WATER_DANCING_TEMPTRESS: {
+    cardNumber: 26,
+    race: 'Undead',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_DANCING_TEMPTRESS', name: 'Dancing Temptress', type: 'UNIT', cost: 3, activation: 2,
     element: 'NEUTRAL', atk: 1, hp: 2,
     attackType: 'STANDARD',
@@ -351,6 +498,11 @@ export const CARDS = {
   },
 
   EARTH_ARELAI_THE_PROTECTOR: {
+    cardNumber: 50,
+    race: 'Hero',
+    affiliation: 'Saint Val Devotee',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'EARTH_ARELAI_THE_PROTECTOR', name: 'Arelai the Protector', type: 'UNIT', cost: 3, activation: 2,
     element: 'EARTH', atk: 2, hp: 3,
     attackType: 'STANDARD',
@@ -369,6 +521,11 @@ export const CARDS = {
   },
 
   EARTH_NOVOGUS_GOLEM: {
+    cardNumber: 46,
+    race: 'Beast',
+    affiliation: 'Novogus Dynasty',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_NOVOGUS_GOLEM', name: 'Novogus Golem', type: 'UNIT', cost: 4, activation: 2,
     element: 'EARTH', atk: 2, hp: 3,
     attackType: 'STANDARD',
@@ -379,6 +536,11 @@ export const CARDS = {
     desc: 'Novogus Golem gains Protection equal to the number of empty fields.'
   },
   EARTH_NOVOGUS_CATAPULT: {
+    cardNumber: 43,
+    race: 'Weapon',
+    affiliation: 'Novogus Dynasty',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_NOVOGUS_CATAPULT', name: 'Novogus Catapult', type: 'UNIT', cost: 3, activation: 1,
     element: 'EARTH', atk: 2, hp: 4,
     attackType: 'STANDARD',
@@ -388,6 +550,11 @@ export const CARDS = {
     desc: 'If Novogus Catapult is destroyed, you gain mana equal to the number of Earth fields.'
   },
   EARTH_SKELETON_SOLDIER: {
+    cardNumber: 40,
+    race: 'Undead',
+    affiliation: 'Novogus Dynasty',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_SKELETON_SOLDIER', name: 'Skeleton Soldier', type: 'UNIT', cost: 2, activation: 1,
     element: 'EARTH', atk: 1, hp: 2,
     attackType: 'STANDARD',
@@ -400,6 +567,11 @@ export const CARDS = {
     desc: 'If Skeleton Soldier is destroyed, you gain 1 additional mana.'
   },
   EARTH_UNDEAD_DRAGON: {
+    cardNumber: 49,
+    race: 'Dragon',
+    affiliation: 'Novogus Dynasty',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_UNDEAD_DRAGON', name: 'Undead Dragon', type: 'UNIT', cost: 7, activation: 4,
     element: 'EARTH', atk: 5, hp: 8,
     attackType: 'STANDARD',
@@ -411,6 +583,11 @@ export const CARDS = {
   },
 
   EARTH_SE_HOLLYN_FORTRESS: {
+    cardNumber: 45,
+    race: 'Base',
+    affiliation: 'Val na Vos',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_SE_HOLLYN_FORTRESS', name: 'Se Hollyn Fortress', type: 'UNIT', cost: 4, activation: 2,
     element: 'EARTH', atk: 1, hp: 4,
     attackType: 'STANDARD', chooseDir: true,
@@ -431,6 +608,11 @@ export const CARDS = {
   },
 
   EARTH_GIANT_AXE_DWARF: {
+    cardNumber: 41,
+    race: 'Dwarf',
+    affiliation: 'Hammer Valley',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_GIANT_AXE_DWARF', name: 'Giant Axe Dwarf', type: 'UNIT', cost: 2, activation: 1,
     element: 'EARTH', atk: 1, hp: 3,
     attackType: 'STANDARD',
@@ -442,6 +624,11 @@ export const CARDS = {
   },
 
   EARTH_STONE_WING_DWARF: {
+    cardNumber: 39,
+    race: 'Dwarf',
+    affiliation: 'Hammer Valley',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_STONE_WING_DWARF', name: 'Stone Wing Dwarf', type: 'UNIT', cost: 1, activation: 1,
     element: 'EARTH', atk: 1, hp: 1,
     attackType: 'STANDARD', chooseDir: true,
@@ -458,6 +645,11 @@ export const CARDS = {
   },
 
   EARTH_BLACK_HOOD_DWARF_VULITRA: {
+    cardNumber: 51,
+    race: 'Betrayer',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'EARTH_BLACK_HOOD_DWARF_VULITRA', name: 'Black Hood Dwarf Vulitra', type: 'UNIT', cost: 3, activation: 2,
     element: 'EARTH', atk: 2, hp: 4,
     attackType: 'STANDARD', friendlyFire: true,
@@ -470,6 +662,11 @@ export const CARDS = {
   },
 
   EARTH_VERZAR_FOOT_SOLDIER: {
+    cardNumber: 38,
+    race: 'Human',
+    affiliation: 'Val na Vos',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_VERZAR_FOOT_SOLDIER', name: 'Verzar Foot Soldier', type: 'UNIT', cost: 1, activation: 1,
     element: 'EARTH', atk: 1, hp: 2,
     attackType: 'STANDARD',
@@ -481,6 +678,11 @@ export const CARDS = {
   },
 
   EARTH_VERZAR_CANINE: {
+    cardNumber: 37,
+    race: 'Beast',
+    affiliation: 'Val na Vos',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_VERZAR_CANINE', name: 'Verzar Canine', type: 'UNIT', cost: 1, activation: 1,
     element: 'EARTH', atk: 1, hp: 1,
     attackType: 'STANDARD',
@@ -494,6 +696,12 @@ export const CARDS = {
   },
 
   BIOLITH_MORNING_STAR_WARRIOR: {
+    cardNumber: 77,
+    race: 'Mech',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_MORNING_STAR_WARRIOR', name: 'Morning Star Warrior', type: 'UNIT', cost: 4, activation: 2,
     element: 'BIOLITH', atk: 2, hp: 3,
     attackType: 'STANDARD',
@@ -507,6 +715,12 @@ export const CARDS = {
     desc: 'Morning Star Warrior adds 2 to its Attack if the target creature has 5 or more HPs.\nMorning Star Warrior gains Protection equal to the number of allied Biolith creatures.'
   },
   BIOLITH_BIOLITH_STINGER: {
+    cardNumber: 74,
+    race: 'Bug',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_BIOLITH_STINGER', name: 'Biolith Stinger', type: 'UNIT', cost: 3, activation: 2,
     element: 'BIOLITH', atk: 0, hp: 1,
     attackType: 'STANDARD', chooseDir: true,
@@ -523,6 +737,12 @@ export const CARDS = {
     desc: 'Dodge attempt. If Biolith Stinger damages (but does not destroy) a creature, it switches locations with that creature (which cannot counterattack).'
   },
   BIOLITH_IMPERIAL_BIOLITH_GUARD: {
+    cardNumber: 75,
+    race: 'Mech',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_IMPERIAL_BIOLITH_GUARD', name: 'Imperial Biolith Guard', type: 'UNIT', cost: 3, activation: 2,
     element: 'BIOLITH', atk: 2, hp: 4,
     attackType: 'STANDARD',
@@ -541,6 +761,11 @@ export const CARDS = {
     desc: 'Gain 1 mana each time you summon a creature to a Biolith field.'
   },
   BIOLITH_WORMAK_HEIR: {
+    cardNumber: 86,
+    race: 'Betrayer',
+    affiliation: 'Phantom',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'BIOLITH_WORMAK_HEIR', name: 'Wormak Heir to the Bioliths', type: 'UNIT', cost: 4, activation: 2,
     element: 'BIOLITH', atk: 2, hp: 4,
     attackType: 'STANDARD',
@@ -561,6 +786,12 @@ export const CARDS = {
     desc: "If the target is an enemy Biolith, Wormak's Attack is equal to 2 plus the number of non-Biolith creatures on the board.\nGain 1 mana each time an enemy is summoned."
   },
   BIOLITH_TINO_SON_OF_SCION: {
+    cardNumber: 85,
+    race: 'Hero',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'BIOLITH_TINO_SON_OF_SCION', name: 'Tino, Son of Scion', type: 'UNIT', cost: 4, activation: 3,
     element: 'BIOLITH', atk: 3, hp: 4,
     attackType: 'MAGIC',
@@ -583,6 +814,12 @@ export const CARDS = {
     desc: "Tino's Magic Attack targets all enemies of the same element as the target.\nWhile Tino is on a Biolith field, his Attack is equal to 1 plus the number of other allied Biolith creatures.\nGain 1 mana each time you summon a creature."
   },
   BIOLITH_GUARDIAN_WATCHTOWER: {
+    cardNumber: 88,
+    race: 'Ancient',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'BIOLITH_GUARDIAN_WATCHTOWER', name: 'Guardian Watchtower', type: 'UNIT', cost: 6, activation: 3,
     element: 'BIOLITH', atk: 1, hp: 10,
     attackType: 'MAGIC',
@@ -602,6 +839,12 @@ export const CARDS = {
   },
 
   EARTH_NOVOGUS_GRAVEKEEPER: {
+    cardNumber: 53,
+    race: 'God',
+    affiliation: 'Unknown',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'EARTH_NOVOGUS_GRAVEKEEPER', name: 'Novogus Gravekeeper', type: 'UNIT', cost: 9, activation: 5,
     element: 'EARTH', atk: 3, hp: 9,
     attackType: 'MAGIC',
@@ -613,6 +856,12 @@ export const CARDS = {
   },
 
   FOREST_EXALTED_ELVEN_DEITY: {
+    cardNumber: 71,
+    race: 'God',
+    affiliation: 'Unknown',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'FOREST_EXALTED_ELVEN_DEITY', name: 'Exalted Elven Deity', type: 'UNIT', cost: 9, activation: 5,
     element: 'FOREST', atk: 3, hp: 9,
     attackType: 'MAGIC',
@@ -624,6 +873,12 @@ export const CARDS = {
   },
 
   BIOLITH_PHASEUS: {
+    cardNumber: 89,
+    race: 'God',
+    affiliation: 'Unknown',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'BIOLITH_PHASEUS', name: 'Phaseus, Biolith God', type: 'UNIT', cost: 9, activation: 5,
     element: 'BIOLITH', atk: 3, hp: 9,
     attackType: 'MAGIC',
@@ -635,6 +890,12 @@ export const CARDS = {
   },
 
   BIOLITH_BEHEMOTH_GROUNDBREAKER: {
+    cardNumber: 79,
+    race: 'Weapon',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_BEHEMOTH_GROUNDBREAKER', name: 'Behemoth Groundbreaker', type: 'UNIT', cost: 4, activation: 3,
     element: 'BIOLITH', atk: 1, hp: 4,
     attackType: 'STANDARD',
@@ -645,6 +906,12 @@ export const CARDS = {
     desc: 'When Behemoth Groundbreaker is summoned, fieldquake all adjacent fields.'
   },
   EARTH_UNDEAD_KING_NOVOGUS: {
+    cardNumber: 52,
+    race: 'Noble',
+    affiliation: 'Novogus Dynasty',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'EARTH_UNDEAD_KING_NOVOGUS', name: 'Undead King Novogus', type: 'UNIT', cost: 6, activation: 3,
     element: 'EARTH', atk: 2, hp: 6,
     attackType: 'MAGIC',
@@ -655,6 +922,12 @@ export const CARDS = {
     desc: "Magic Attack. If Undead King Novogus is on a non-Earth field and damages a creature, fieldquake the target creature's field. The target creature cannot counterattack."
   },
   BIOLITH_OUROBOROS_DRAGON: {
+    cardNumber: 84,
+    race: 'Dragon',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_CARD', amount: 1 },
     id: 'BIOLITH_OUROBOROS_DRAGON', name: 'Ouroboros Dragon', type: 'UNIT', cost: 7, activation: 4,
     element: 'BIOLITH', atk: 7, hp: 10,
     attackType: 'STANDARD',
@@ -668,6 +941,11 @@ export const CARDS = {
 
   // Ninja cycle
   FIRE_FIREFLY_NINJA: {
+    cardNumber: 5,
+    race: 'Human',
+    affiliation: 'Yaksha',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FIRE_FIREFLY_NINJA', name: 'Firefly Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'FIRE', atk: 1, hp: 2,
     attackType: 'STANDARD',
@@ -678,6 +956,11 @@ export const CARDS = {
     desc: 'While on a Fire field it gains Perfect Dodge. Gains Invisibility while at least one allied Spider Ninja is on the board.'
   },
   EARTH_SPIDER_NINJA: {
+    cardNumber: 42,
+    race: 'Human',
+    affiliation: 'Yaksha',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_SPIDER_NINJA', name: 'Spider Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'EARTH', atk: 2, hp: 1,
     attackType: 'MAGIC',
@@ -688,6 +971,11 @@ export const CARDS = {
     desc: 'Magic attack. Gains Invisibility while at least one allied Wolf Ninja is on the board. If it damages a creature on an Earth field, it switches places with that creature (which cannot counterattack).'
   },
   EARTH_YELLOW_CUBIC: {
+    cardNumber: 54,
+    race: 'Egg',
+    affiliation: 'Unknown',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_YELLOW_CUBIC', name: 'Yellow Cubic', type: 'UNIT', cost: 1, activation: 1,
     element: 'EARTH', atk: 1, hp: 1,
     attackType: 'STANDARD',
@@ -699,6 +987,11 @@ export const CARDS = {
     desc: 'Sacrifice Yellow Cubic to summon a non‑cubic Earth creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
   EARTH_DARK_YOKOZUNA_SEKIMARU: {
+    cardNumber: 44,
+    race: 'Titan',
+    affiliation: 'Val na Vos',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_DARK_YOKOZUNA_SEKIMARU', name: 'Dark Yokozuna Sekimaru', type: 'UNIT', cost: 3, activation: 2,
     element: 'EARTH', atk: 2, hp: 3,
     attackType: 'STANDARD',
@@ -708,6 +1001,11 @@ export const CARDS = {
     desc: 'If Dark Yokozuna Sekimaru attacks (but does not destroy) a creature, that creature is pushed back one field in the direction of the attack (provided the field is empty) and cannot counterattack.'
   },
   EARTH_VERZAR_ELEPHANT_BRIGADE: {
+    cardNumber: 48,
+    race: 'Elemental',
+    affiliation: 'Val na Vos',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_VERZAR_ELEPHANT_BRIGADE', name: 'Verzar Elephant Brigade', type: 'UNIT', cost: 5, activation: 3,
     element: 'EARTH', atk: 2, hp: 5,
     attackType: 'STANDARD',
@@ -725,6 +1023,11 @@ export const CARDS = {
     desc: 'Verzar Elephant Brigade must use its secondary attack while it is on an Earth field. While Verzar Elephant Brigade is on an Earth field, allied creatures on adjacent fields add 2 to their Attack and 1 to their Activation Cost.'
   },
   EARTH_DUNGEON_OF_TEN_TYRANTS: {
+    cardNumber: 47,
+    race: 'Base',
+    affiliation: 'Val na Vos',
+    fieldLock: false,
+    cardLimit: null,
     id: 'EARTH_DUNGEON_OF_TEN_TYRANTS', name: 'Dungeon of Ten Tyrants', type: 'UNIT', cost: 4, activation: 2,
     element: 'EARTH', atk: 1, hp: 4,
     attackType: 'STANDARD', chooseDir: true,
@@ -741,6 +1044,11 @@ export const CARDS = {
     desc: 'Fortress: cannot attack unless counterattacking. While on a non‑Earth field, its summoner gains 1 mana during their resolution phase. Destroy if on a Forest field.'
   },
   WATER_WOLF_NINJA: {
+    cardNumber: 24,
+    race: 'Human',
+    affiliation: 'Yaksha',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_WOLF_NINJA', name: 'Wolf Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 1, hp: 3,
     attackType: 'STANDARD',
@@ -751,6 +1059,11 @@ export const CARDS = {
     desc: 'Gains Invisibility while at least one allied Swallow Ninja is on the board. If Wolf Ninja damages a creature on a Water field, it switches places with that creature (which cannot counterattack).'
   },
   WATER_BLUE_CUBIC: {
+    cardNumber: 36,
+    race: 'Egg',
+    affiliation: 'Unknown',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_BLUE_CUBIC', name: 'Blue Cubic', type: 'UNIT', cost: 1, activation: 1,
     element: 'WATER', atk: 1, hp: 1,
     attackType: 'STANDARD',
@@ -762,6 +1075,11 @@ export const CARDS = {
     desc: 'Sacrifice Blue Cubic to summon a non‑cubic Water creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
   WATER_SIAM_TRAITOR_OF_SEAS: {
+    cardNumber: 33,
+    race: 'Betrayer',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'WATER_SIAM_TRAITOR_OF_SEAS', name: 'Siam, Traitor of Seas', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 2, hp: 4,
     attackType: 'STANDARD',
@@ -775,6 +1093,11 @@ export const CARDS = {
     desc: 'Siam attacks the same target twice. The counterattack of target creature occurs after second attack. Siam adds 1 Attack if the target creature is a Water creature. All enemies on Water fields subtract 1 from their Attack.'
   },
   WATER_VENOAN_ASSASSIN: {
+    cardNumber: 27,
+    race: 'Human',
+    affiliation: 'Corsez Family',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_VENOAN_ASSASSIN', name: 'Venoan Assassin', type: 'UNIT', cost: 3, activation: 2,
     element: 'WATER', atk: 2, hp: 3,
     attackType: 'STANDARD',
@@ -784,6 +1107,11 @@ export const CARDS = {
     desc: 'Always attacks the back of its target.'
   },
   WATER_TENTACLES_OF_POSSESSION: {
+    cardNumber: 23,
+    race: 'Beast',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
     id: 'WATER_TENTACLES_OF_POSSESSION', name: 'Tentacles of Possession', type: 'UNIT', cost: 2, activation: 1,
     element: 'WATER', atk: 0, hp: 2,
     attackType: 'STANDARD',
@@ -796,6 +1124,12 @@ export const CARDS = {
     desc: 'Tentacles of Possession gain Possession of the enemy directly in front of it.'
   },
   WATER_IMPOSTER_QUEEN_ANFISA: {
+    cardNumber: 34,
+    race: 'Noble',
+    affiliation: 'Tritonan Queendom',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'WATER_IMPOSTER_QUEEN_ANFISA', name: 'Imposter Queen Anfisa', type: 'UNIT', cost: 6, activation: 2,
     element: 'WATER', atk: 2, hp: 5,
     attackType: 'MAGIC',
@@ -808,6 +1142,11 @@ export const CARDS = {
     desc: 'Magic Attack. While on a Water field, Imposter Queen Anfisa gains Possession of all enemies on adjacent fields.'
   },
   FOREST_SWALLOW_NINJA: {
+    cardNumber: 62,
+    race: 'Human',
+    affiliation: 'Yaksha',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_SWALLOW_NINJA', name: 'Swallow Ninja', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 1, hp: 3,
     attackType: 'STANDARD',
@@ -820,6 +1159,11 @@ export const CARDS = {
     desc: 'Gains Invisibility while at least one allied Firefly Ninja is on the board. When Swallow Ninja damages (but does not destroy) a creature, rotate that creature so its back faces Swallow Ninja. The target creature cannot counterattack.'
   },
   FOREST_JUNO_PRISONER_TRAP: {
+    cardNumber: 65,
+    race: 'Plant',
+    affiliation: 'Black Forest',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_JUNO_PRISONER_TRAP', name: 'Juno Prisoner Trap', type: 'UNIT', cost: 4, activation: 2,
     element: 'FOREST', atk: 0, hp: 4,
     attackType: 'STANDARD', chooseDir: true,
@@ -836,6 +1180,11 @@ export const CARDS = {
     desc: 'Fortress: cannot attack unless counterattacking. When an enemy creature is summoned adjacent to it, all other allied creatures gain 1 HP. Destroy if on an Earth field.'
   },
   FOREST_JUNO_TREE_HAUNT: {
+    cardNumber: 63,
+    race: 'Titan',
+    affiliation: 'Northern Forces',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_JUNO_TREE_HAUNT', name: 'Juno Tree Haunt', type: 'UNIT', cost: 3, activation: 1,
     element: 'FOREST', atk: 2, hp: 1,
     attackType: 'STANDARD', chooseDir: true,
@@ -848,6 +1197,11 @@ export const CARDS = {
     desc: 'Perfect Dodge. Destroy if on a non-Forest field.'
   },
   FOREST_EDIN_THE_PERSECUTED: {
+    cardNumber: 68,
+    race: 'Hero',
+    affiliation: 'Northern Forces',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'FOREST_EDIN_THE_PERSECUTED', name: 'Edin the Persecuted', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 2, hp: 3,
     attackType: 'MAGIC',
@@ -858,6 +1212,11 @@ export const CARDS = {
     desc: '+1 Attack while attacking a creature on a Forest field. Allied creatures on Forest fields have Invisibility.'
   },
   FOREST_ELVEN_DEATH_DANCER: {
+    cardNumber: 66,
+    race: 'Elf',
+    affiliation: 'Black Forest',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_ELVEN_DEATH_DANCER', name: 'Elven Death Dancer', type: 'UNIT', cost: 5, activation: 4,
     element: 'FOREST', atk: 1, hp: 3,
     attackType: 'MAGIC',
@@ -868,6 +1227,11 @@ export const CARDS = {
     desc: 'Magic Attack. If Elven Death Dancer damages (but does not destroy) a creature, she switches locations with that creature (which cannot counterattack). Enemies on adjacent fields add 3 to their Activation Cost.'
   },
   FOREST_ELVEN_RIDER: {
+    cardNumber: 64,
+    race: 'Elf',
+    affiliation: 'Til Vorg Monarchy',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_ELVEN_RIDER', name: 'Elven Rider', type: 'UNIT', cost: 4, activation: 2,
     element: 'FOREST', atk: 2, hp: 4,
     attackType: 'STANDARD', friendlyFire: true,
@@ -877,6 +1241,11 @@ export const CARDS = {
     desc: 'If Elven Rider is destroyed on a non-Wood field, your opponent must discard cards equal to the number of Wood fields.'
   },
   FOREST_INQUISITOR_KOOG: {
+    cardNumber: 86,
+    race: 'Betrayer',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'FOREST_INQUISITOR_KOOG', name: 'Inquisitor Koog', type: 'UNIT', cost: 3, activation: 2,
     element: 'FOREST', atk: 2, hp: 4,
     attackType: 'STANDARD', chooseDir: true,
@@ -891,6 +1260,11 @@ export const CARDS = {
     desc: 'Inquisitor Koog adds 1 to his attack if the target creature is a Wood creature. If Inquisitor Koog is destroyed, you gain additional mana equal to the number of enemies.'
   },
   FOREST_JUNO_FOREST_DRAGON: {
+    cardNumber: 67,
+    race: 'Dragon',
+    affiliation: 'Til Vorg Monarchy',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_JUNO_FOREST_DRAGON', name: 'Juno Forest Dragon', type: 'UNIT', cost: 7, activation: 4,
     element: 'FOREST', atk: 5, hp: 8,
     attackType: 'STANDARD',
@@ -903,6 +1277,11 @@ export const CARDS = {
     desc: 'Juno Forest Dragon\'s Attack is equal to 5 plus the number of other Wood creatures on the board. While Juno Forest Dragon is on a Wood field, enemies on adjacent fields add 2 to their Activation Cost.'
   },
   FOREST_SLEEPTRAP: {
+    cardNumber: 58,
+    race: 'Plant',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_SLEEPTRAP', name: 'Sleeptrap', type: 'UNIT', cost: 2, activation: 1,
     element: 'FOREST', atk: 0, hp: 2,
     attackType: 'STANDARD',
@@ -914,6 +1293,11 @@ export const CARDS = {
     desc: 'Enemies on adjacent fields add 1 to their Activation Cost.'
   },
   FOREST_GREEN_LYCANTHROPE: {
+    cardNumber: 56,
+    race: 'Anthromorph',
+    affiliation: 'Til Vorg Monarchy',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_GREEN_LYCANTHROPE', name: 'Green Lycanthrope', type: 'UNIT', cost: 1, activation: 1,
     element: 'FOREST', atk: 0, hp: 1,
     attackType: 'STANDARD',
@@ -925,6 +1309,11 @@ export const CARDS = {
   },
 
   FOREST_BEWITCHING_ELF_ARCHERESS: {
+    cardNumber: 57,
+    race: 'Elf',
+    affiliation: 'Northern Forces',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_BEWITCHING_ELF_ARCHERESS', name: 'Bewitching Elf Archeress', type: 'UNIT', cost: 1, activation: 1,
     element: 'FOREST', atk: 1, hp: 2,
     attackType: 'STANDARD',
@@ -936,6 +1325,11 @@ export const CARDS = {
   },
 
   FOREST_ELVEN_BERSERKER_MAIDEN: {
+    cardNumber: 59,
+    race: 'Elf',
+    affiliation: 'Black Forest',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_ELVEN_BERSERKER_MAIDEN', name: 'Elven Berserker Maiden', type: 'UNIT', cost: 2, activation: 1,
     element: 'FOREST', atk: 1, hp: 3,
     attackType: 'STANDARD',
@@ -947,6 +1341,11 @@ export const CARDS = {
   },
 
   FOREST_GREEN_CUBIC: {
+    cardNumber: 72,
+    race: 'Egg',
+    affiliation: 'Unknown',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_GREEN_CUBIC', name: 'Green Cubic', type: 'UNIT', cost: 1, activation: 1,
     element: 'FOREST', atk: 1, hp: 1,
     attackType: 'STANDARD',
@@ -958,6 +1357,12 @@ export const CARDS = {
     desc: 'Sacrifice Green Cubic to summon a non‑cubic Wood creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
   FOREST_GREEN_ERLKING_ZOMBA: {
+    cardNumber: 70,
+    race: 'Noble',
+    affiliation: 'Green Bandits',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'FOREST_GREEN_ERLKING_ZOMBA', name: 'Green Erlking Zomba', type: 'UNIT', cost: 6, activation: 3,
     element: 'FOREST', atk: 6, hp: 3,
     attackType: 'STANDARD', friendlyFire: true,
@@ -973,6 +1378,11 @@ export const CARDS = {
     desc: 'Zomba must use its secondary attack while it is on a Wood field. While Zomba is on a Wood field, each time an allied creature is destroyed, your opponent must discard a card.'
   },
   FOREST_LEAPFROG_BANDIT: {
+    cardNumber: 55,
+    race: 'Anthromorph',
+    affiliation: 'Green Bandits',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_LEAPFROG_BANDIT', name: 'Leapfrog Bandit', type: 'UNIT', cost: 1, activation: 1,
     element: 'FOREST', atk: 1, hp: 1,
     attackType: 'STANDARD',
@@ -982,6 +1392,11 @@ export const CARDS = {
     desc: 'If Leapfrog Bandit is destroyed on a non-Wood field, your opponent must discard 1 card.'
   },
   SAMURAI_NAGIRASHU: {
+    cardNumber: 60,
+    race: 'Human',
+    affiliation: 'Nagirashu',
+    fieldLock: false,
+    cardLimit: null,
     id: 'SAMURAI_NAGIRASHU', name: 'Samurai Nagirashu', type: 'UNIT', cost: 2, activation: 2,
     element: 'FOREST', atk: 2, hp: 2,
     attackType: 'STANDARD',
@@ -991,6 +1406,11 @@ export const CARDS = {
     desc: 'If Samurai Nagirashu is destroyed on a Wood field, your opponent must discard 1 card.'
   },
   NEUTRAL_WHITE_CUBIC: {
+    cardNumber: 90,
+    race: 'Egg',
+    affiliation: 'Unknown',
+    fieldLock: false,
+    cardLimit: { type: 'PER_CARD', amount: 1 },
     id: 'NEUTRAL_WHITE_CUBIC', name: 'White Cubic', type: 'UNIT', cost: 1, activation: 1,
     element: 'NEUTRAL', atk: 1, hp: 1,
     attackType: 'STANDARD',
@@ -1005,6 +1425,12 @@ export const CARDS = {
   },
 
   BIOLITH_NINJA: {
+    cardNumber: 78,
+    race: 'Mech',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_NINJA', name: 'Biolith Ninja', type: 'UNIT', cost: 4, activation: 2,
     element: 'BIOLITH', atk: 4, hp: 2,
     attackType: 'STANDARD',
@@ -1016,6 +1442,12 @@ export const CARDS = {
   },
 
   BIOLITH_BOMBER: {
+    cardNumber: 73,
+    race: 'Blitz',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_BOMBER', name: 'Biolith Bomber', type: 'UNIT', cost: 3, activation: 2,
     element: 'BIOLITH', atk: 1, hp: 3,
     attackType: 'STANDARD', chooseDir: true,
@@ -1030,6 +1462,12 @@ export const CARDS = {
     desc: 'Adds 2 to its Attack if the target creature has a Summoning Cost of 2 or lower.'
   },
   BIOLITH_SCION_BIOLITH_LORD: {
+    cardNumber: 87,
+    race: 'Noble',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: { type: 'PER_RACE', amount: 1 },
     id: 'BIOLITH_SCION_BIOLITH_LORD', name: 'Scion, Biolith Lord', type: 'UNIT', cost: 6, activation: 3,
     element: 'BIOLITH', atk: 2, hp: 5,
     attackType: 'MAGIC',
@@ -1042,6 +1480,12 @@ export const CARDS = {
     desc: 'Scion\'s Magic Attack targets all enemies of the same element as the target. All other allied Biolith creatures subtract 2 from their Activation Cost.'
   },
   BIOLITH_DRAGOON_DRAGON_CAVALRY: {
+    cardNumber: 80,
+    race: 'Mech',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_DRAGOON_DRAGON_CAVALRY', name: 'Dragoon Dragon Cavalry', type: 'UNIT', cost: 5, activation: 3,
     element: 'BIOLITH', atk: 3, hp: 5,
     attackType: 'STANDARD',
@@ -1052,6 +1496,12 @@ export const CARDS = {
   },
 
   BIOLITH_BATTLE_CHARIOT: {
+    cardNumber: 76,
+    race: 'Weapon',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_BATTLE_CHARIOT', name: 'Biolith Battle Chariot', type: 'UNIT', cost: 4, activation: 4,
     element: 'BIOLITH', atk: 3, hp: 5,
     attackType: 'STANDARD',
@@ -1065,6 +1515,12 @@ export const CARDS = {
   },
 
   BIOLITH_AEGIS_CITADEL: {
+    cardNumber: 82,
+    race: 'Base',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_AEGIS_CITADEL', name: 'Aegis Citadel', type: 'UNIT', cost: 5, activation: 3,
     element: 'BIOLITH', atk: 1, hp: 5,
     attackType: 'STANDARD', chooseDir: true,
@@ -1081,6 +1537,12 @@ export const CARDS = {
   },
 
   BIOLITH_TAURUS_MONOLITH: {
+    cardNumber: 81,
+    race: 'Titan',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_TAURUS_MONOLITH', name: 'Taurus Monolith', type: 'UNIT', cost: 5, activation: 3,
     element: 'BIOLITH', atk: 3, hp: 6,
     attackType: 'STANDARD',
@@ -1094,6 +1556,12 @@ export const CARDS = {
   },
 
   BIOLITH_ARC_SATELLITE_CANNON: {
+    cardNumber: 83,
+    race: 'Blitz',
+    affiliation: 'Biolith Castle',
+    fieldLock: true,
+    locked: true,
+    cardLimit: null,
     id: 'BIOLITH_ARC_SATELLITE_CANNON', name: 'Arc Satellite Cannon', type: 'UNIT', cost: 5, activation: 4,
     element: 'BIOLITH', atk: 4, hp: 5,
     attackType: 'MAGIC', chooseDir: true,
@@ -1108,6 +1576,11 @@ export const CARDS = {
   },
 
   FOREST_TWIN_GOBLINS: {
+    cardNumber: 61,
+    race: 'Goblin',
+    affiliation: 'Green Bandits',
+    fieldLock: false,
+    cardLimit: null,
     id: 'FOREST_TWIN_GOBLINS', name: 'Twin Goblins', type: 'UNIT', cost: 2, activation: 1,
     element: 'FOREST', atk: 1, hp: 3,
     attackType: 'STANDARD',
@@ -1122,14 +1595,107 @@ export const CARDS = {
 
   // Spells (subset)
   SPELL_HEALING_SHOWER: {
-    id: 'SPELL_HEALING_SHOWER', name: 'Healing Shower', type: 'SPELL', element: 'EARTH',
-    spellType: 'CONJURATION', cost: 2,
+    cardNumber: 97,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_HEALING_SHOWER',
+    name: 'Healing Shower',
+    type: 'SPELL',
+    element: 'EARTH',
+    spellType: 'CONJURATION',
+    cost: 2,
     text: 'All allied creatures of a chosen element gain 3 HP. Place this card on an allied creature belonging to the desired element.'
   },
-  SPELL_FISSURES_OF_GOGHLIE: { id: 'SPELL_FISSURES_OF_GOGHLIE', name: 'Fissures of Goghlie', type: 'SPELL', element: 'NEUTRAL', spellType: 'CONJURATION', cost: 2, text: 'Fieldquake any one field.' },
-  SPELL_PARMTETIC_HOLY_FEAST: { id: 'SPELL_PARMTETIC_HOLY_FEAST', name: 'Parmetic Holy Feast', type: 'SPELL', element: 'NEUTRAL', spellType: 'RITUAL', cost: 0, ritualCost: 'discard 1 creature', text: 'Discard a creature from hand and gain 2 mana.' },
-  SPELL_GOGHLIE_ALTAR: { id: 'SPELL_GOGHLIE_ALTAR', name: 'Goghlie Altar', type: 'SPELL', element: 'NEUTRAL', spellType: 'RITUAL', cost: 0, ritualCost: 'none', text: 'Both players gain mana equal to the number of enemy creatures on the board.' },
-  SPELL_BEGUILING_FOG: { id: 'SPELL_BEGUILING_FOG', name: 'Beguiling Fog', type: 'SPELL', element: 'NEUTRAL', spellType: 'CONJURATION', cost: 0, text: 'Rotate any one creature in any direction.' },
-  SPELL_CLARE_WILS_BANNER: { id: 'SPELL_CLARE_WILS_BANNER', name: 'Clare Wil’s Banner', type: 'SPELL', element: 'NEUTRAL', spellType: 'CONJURATION', cost: 1, text: 'Friendly creatures get +1 ATK until end of turn.' },
-  SPELL_SUMMONER_MESMERS_ERRAND: { id: 'SPELL_SUMMONER_MESMERS_ERRAND', name: "Summoner Mesmer's Errand", type: 'SPELL', element: 'NEUTRAL', spellType: 'CONJURATION', cost: 1, text: 'Draw two cards.' },
+  SPELL_FISSURES_OF_GOGHLIE: {
+    cardNumber: 98,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_FISSURES_OF_GOGHLIE',
+    name: 'Fissures of Goghlie',
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'CONJURATION',
+    cost: 2,
+    text: 'Fieldquake any one field.'
+  },
+  SPELL_PARMTETIC_HOLY_FEAST: {
+    cardNumber: 91,
+    race: 'Ritual',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: { type: 'PER_CARD', amount: 1 },
+    id: 'SPELL_PARMTETIC_HOLY_FEAST',
+    name: 'Parmetic Holy Feast',
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'RITUAL',
+    cost: 0,
+    ritualCost: 'discard 1 creature',
+    text: 'Discard a creature from hand and gain 2 mana.'
+  },
+  SPELL_GOGHLIE_ALTAR: {
+    cardNumber: 92,
+    race: 'Ritual',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: { type: 'PER_CARD', amount: 1 },
+    id: 'SPELL_GOGHLIE_ALTAR',
+    name: 'Goghlie Altar',
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'RITUAL',
+    cost: 0,
+    ritualCost: 'none',
+    text: 'Both players gain mana equal to the number of enemy creatures on the board.'
+  },
+  SPELL_BEGUILING_FOG: {
+    cardNumber: 94,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_BEGUILING_FOG',
+    name: 'Beguiling Fog',
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'CONJURATION',
+    cost: 0,
+    text: 'Rotate any one creature in any direction.'
+  },
+  SPELL_CLARE_WILS_BANNER: {
+    cardNumber: 96,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_CLARE_WILS_BANNER',
+    name: 'Clare Wil’s Banner',
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'CONJURATION',
+    cost: 1,
+    text: 'Friendly creatures get +1 ATK until end of turn.'
+  },
+  SPELL_SUMMONER_MESMERS_ERRAND: {
+    cardNumber: 100,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_SUMMONER_MESMERS_ERRAND',
+    name: "Summoner Mesmer's Errand",
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'CONJURATION',
+    cost: 1,
+    text: 'Draw two cards.'
+  },
 };
+
+export const CARDS = Object.fromEntries(
+  Object.entries(RAW_CARDS).map(([id, card]) => [id, { ...card }])
+);

--- a/src/scene/cards.js
+++ b/src/scene/cards.js
@@ -36,6 +36,24 @@ const CARD_FACE_LAYOUT = {
 const CARD_IMAGES = {};
 const CARD_PENDING = {};
 
+// Формирование краткой подписи с ограничением карт (без смешения с логикой рендера)
+function formatLimitLabel(limit) {
+  if (!limit || typeof limit.amount !== 'number' || limit.amount <= 0) {
+    return '';
+  }
+  const amount = limit.amount;
+  if (limit.type === 'PER_CARD') {
+    if (amount >= 3) return '';
+    if (amount === 1) return 'Max 1 card';
+    return `Max ${amount} cards`;
+  }
+  if (limit.type === 'PER_RACE') {
+    if (amount === 1) return 'Max 1 card of this race';
+    return `Max ${amount} cards of this race`;
+  }
+  return '';
+}
+
 // Масштаб для схем атак (15% увеличение относительно базового макета)
 const ATTACK_DIAGRAM_SCALE = 1.15;
 
@@ -123,8 +141,6 @@ export function drawCardFace(ctx, cardData, width, height, hpOverride = null, at
   // Геометрия ключевых зон интерфейса в координатах исходного дизайна
   const layout = CARD_FACE_LAYOUT;
 
-  const elementLabels = { FIRE: 'Fire', WATER: 'Water', EARTH: 'Earth', FOREST: 'Forest', BIOLITH: 'Biolith', NEUTRAL: 'Neutral' };
-
   // Заголовок карты
   ctx.save();
   ctx.textAlign = 'center';
@@ -146,18 +162,18 @@ export function drawCardFace(ctx, cardData, width, height, hpOverride = null, at
   ctx.fillText(displayName, width / 2, py(layout.nameY));
   ctx.restore();
 
-  const typeParts = [];
-  const elementLabel = elementLabels[cardData.element] || elementLabels.NEUTRAL;
-  if (elementLabel) typeParts.push(elementLabel);
-  if (cardData.type === 'UNIT') typeParts.push('Creature');
-  else if (cardData.type === 'SPELL') typeParts.push('Spell');
-  const typeLine = typeParts.join(' · ');
-  if (typeLine) {
+  const metaParts = [];
+  if (cardData.race) metaParts.push(cardData.race);
+  if (cardData.affiliation) metaParts.push(cardData.affiliation);
+  const limitLabel = formatLimitLabel(cardData.cardLimit);
+  if (limitLabel) metaParts.push(limitLabel);
+  const metaLine = metaParts.join(' · ');
+  if (metaLine) {
     ctx.save();
     ctx.textAlign = 'center';
     ctx.fillStyle = 'rgba(226,232,240,0.84)';
     ctx.font = `600 ${Math.max(ps(20), 10)}px "Noto Sans", "Helvetica", sans-serif`;
-    ctx.fillText(typeLine, width / 2, py(layout.typeY));
+    ctx.fillText(metaLine, width / 2, py(layout.typeY));
     ctx.restore();
   }
 

--- a/src/ui/deckBuilder.js
+++ b/src/ui/deckBuilder.js
@@ -43,6 +43,78 @@ const STRIP_OVERRIDES = {
 const PREVIEW_W = 256;
 const PREVIEW_H = 356;
 
+// Простое всплывающее окно с сообщением о превышении лимита
+function createLimitPopup(host) {
+  // Создаём отдельную полосу уведомлений в верхней части панели, не перекрывающую каталога
+  const wrapper = document.createElement('div');
+  wrapper.className = 'flex justify-center mb-2 transition-opacity duration-200';
+  wrapper.style.display = 'none';
+  wrapper.style.opacity = '0';
+
+  const panel = document.createElement('div');
+  panel.className = 'overlay-panel bg-red-700 text-white px-5 py-3 rounded-xl shadow-lg max-w-xl text-center';
+
+  const title = document.createElement('div');
+  title.className = 'text-base font-semibold mb-1';
+  title.textContent = 'Limit reached';
+  panel.appendChild(title);
+
+  const body = document.createElement('div');
+  body.className = 'text-sm leading-relaxed';
+  panel.appendChild(body);
+
+  // Размещаем уведомление в начале панели редактора
+  const firstChild = host.firstChild;
+  if (firstChild) {
+    host.insertBefore(wrapper, firstChild);
+  } else {
+    host.appendChild(wrapper);
+  }
+  wrapper.appendChild(panel);
+
+  let hideTimer = null;
+  const AUTO_HIDE_DELAY = 3200;
+
+  function clearTimer() {
+    if (hideTimer) {
+      clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+  }
+
+  function hide() {
+    clearTimer();
+    wrapper.style.opacity = '0';
+    // Небольшая задержка, чтобы плавно скрыть элемент и освободить место
+    setTimeout(() => {
+      if (wrapper.style.opacity === '0') {
+        wrapper.style.display = 'none';
+      }
+    }, 200);
+  }
+
+  function show(message) {
+    body.textContent = String(message ?? '');
+    clearTimer();
+    wrapper.style.display = 'flex';
+    // Используем requestAnimationFrame для корректного применения анимации непрозрачности
+    const raf = (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function')
+      ? window.requestAnimationFrame.bind(window)
+      : (fn => setTimeout(fn, 16));
+    raf(() => { wrapper.style.opacity = '1'; });
+    hideTimer = setTimeout(() => hide(), AUTO_HIDE_DELAY);
+  }
+
+  return {
+    show,
+    hide,
+    dispose() {
+      clearTimer();
+      try { host.removeChild(wrapper); } catch {}
+    },
+  };
+}
+
 // Настройки адаптивной сетки каталога
 const CATALOG_LAYOUT = {
   maxColumns: 5,
@@ -53,6 +125,19 @@ const CATALOG_LAYOUT = {
   // Стандартный промежуток между колонками (fallback на случай недоступности computed style)
   defaultGap: 16,
 };
+
+// Сортировка карт по карточному номеру с аккуратными запасными условиями
+function compareCardsByNumber(cardA, cardB) {
+  const numA = (typeof cardA?.cardNumber === 'number') ? cardA.cardNumber : Number.POSITIVE_INFINITY;
+  const numB = (typeof cardB?.cardNumber === 'number') ? cardB.cardNumber : Number.POSITIVE_INFINITY;
+  if (numA !== numB) return numA - numB;
+  const costA = cardA?.cost ?? 0;
+  const costB = cardB?.cost ?? 0;
+  if (costA !== costB) return costA - costB;
+  const nameA = cardA?.name || '';
+  const nameB = cardB?.name || '';
+  return nameA.localeCompare(nameB, 'ru');
+}
 
 function setupCatalogResponsiveLayout(catalogEl) {
   if (typeof window === 'undefined' || !catalogEl) {
@@ -161,6 +246,8 @@ export function open(deck = null, onDone) {
   const panel = document.createElement('div');
   panel.className = 'bg-slate-800 mt-2 p-4 rounded-lg w-[92vw] h-[96vh] flex flex-col relative';
   overlay.appendChild(panel);
+
+  const limitPopup = createLimitPopup(panel);
 
   const layout = document.createElement('div');
   layout.className = 'flex flex-1 overflow-hidden';
@@ -537,7 +624,7 @@ export function open(deck = null, onDone) {
     });
 
     Object.values(grouped)
-      .sort((a,b) => (a.card.cost || 0) - (b.card.cost || 0))
+      .sort((a, b) => compareCardsByNumber(a.card, b.card))
       .forEach(({ card, count }) => {
         const row = document.createElement('div');
         row.className = 'relative rounded overflow-hidden cursor-pointer bg-slate-800/60';
@@ -625,10 +712,56 @@ export function open(deck = null, onDone) {
     summary.textContent = `${working.cards.length}/20`;
   }
 
-  function addCard(card) {
+  function describeLimitViolation(card) {
     const copies = working.cards.filter(c => c.id === card.id).length;
+    const limit = card.cardLimit;
+    if (limit && typeof limit.amount === 'number' && limit.amount > 0) {
+      if (limit.type === 'PER_CARD') {
+        if (copies >= limit.amount) {
+          if (limit.amount === 1) {
+            return {
+              code: 'PER_CARD_ONE',
+              message: 'Only 1 copy of this card can be added to a deck.',
+            };
+          }
+          return {
+            code: 'PER_CARD_CUSTOM',
+            message: `Only ${limit.amount} copies of this card can be added to a deck.`,
+          };
+        }
+      } else if (limit.type === 'PER_RACE') {
+        const race = card.race;
+        if (race) {
+          const sameRace = working.cards.filter(c => c.race === race).length;
+          if (sameRace >= limit.amount) {
+            if (limit.amount === 1) {
+              return {
+                code: 'PER_RACE_ONE',
+                message: 'Only 1 card of this race can be added to a deck.',
+              };
+            }
+            return {
+              code: 'PER_RACE_CUSTOM',
+              message: `Only ${limit.amount} cards of this race can be added to a deck.`,
+            };
+          }
+        }
+      }
+    }
     if (copies >= 3) {
-      showNotification('Copy limit reached', 'error');
+      return {
+        code: 'DEFAULT_LIMIT',
+        message: 'You can only add up to 3 copies of the same card.',
+      };
+    }
+    return null;
+  }
+
+  function addCard(card) {
+    limitPopup.hide();
+    const violation = describeLimitViolation(card);
+    if (violation) {
+      limitPopup.show(violation.message);
       return;
     }
     working.cards.push(card);
@@ -650,7 +783,7 @@ export function open(deck = null, onDone) {
       if (!filterState.activation.has(actVal)) return false;
       const text = (c.desc || c.text || '').toLowerCase();
       return c.name.toLowerCase().includes(query) || text.includes(query);
-    });
+    }).sort(compareCardsByNumber);
     cards.forEach(card => {
       const item = document.createElement('div');
       item.className = 'catalog-card cursor-pointer';
@@ -720,6 +853,7 @@ export function open(deck = null, onDone) {
     hiddenEls.forEach(({el, display}) => { el.style.display = display; });
     restoreCardsRedrawBridge();
     try { catalogLayout.dispose(); } catch {}
+    try { limitPopup.dispose(); } catch {}
   }
 
   nameInput.value = working.name;


### PR DESCRIPTION
## Summary
- reposition the deck limit notification bar above the builder content to avoid covering catalog cards
- auto-dismiss limit warnings after a short delay while keeping the message animation smooth

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbcb05bbac833096e527ca5bf9d0f6