### PR TITLE
Refine Biolith spell interactions

### DIFF
--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -1622,6 +1622,20 @@ const RAW_CARDS = {
     cost: 2,
     text: 'Fieldquake any one field.'
   },
+  SPELL_GREAT_TOLICORE_QUAKE: {
+    cardNumber: 99,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_GREAT_TOLICORE_QUAKE',
+    name: 'Great Tolicore Quake',
+    type: 'SPELL',
+    element: 'BIOLITH',
+    spellType: 'CONJURATION',
+    cost: 4,
+    text: 'Fieldquake all fields of a chosen element. Place this card on a field of the chosen element.'
+  },
   SPELL_PARMTETIC_HOLY_FEAST: {
     cardNumber: 91,
     race: 'Ritual',
@@ -1693,6 +1707,48 @@ const RAW_CARDS = {
     spellType: 'CONJURATION',
     cost: 1,
     text: 'Draw two cards.'
+  },
+  SPELL_TINOAN_TELEKINESIS: {
+    cardNumber: 101,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_TINOAN_TELEKINESIS',
+    name: 'Tinoan Telekinesis',
+    type: 'SPELL',
+    element: 'BIOLITH',
+    spellType: 'CONJURATION',
+    cost: 2,
+    text: 'Move 1 allied creature to an empty field without changing its orientation. Place this card over the target creature, then select an empty field.'
+  },
+  SPELL_TINOAN_TELEPORTATION: {
+    cardNumber: 102,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_TINOAN_TELEPORTATION',
+    name: 'Tinoan Teleportation',
+    type: 'SPELL',
+    element: 'BIOLITH',
+    spellType: 'CONJURATION',
+    cost: 3,
+    text: 'Switch the locations of two allied creatures without changing their orientations. Place this card over the 1st target, then the 2nd target.'
+  },
+  SPELL_SEER_VIZAKS_CALAMITY: {
+    cardNumber: 109,
+    race: 'Sorcery',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_SEER_VIZAKS_CALAMITY',
+    name: "Seer Vizak's Calamity",
+    type: 'SPELL',
+    element: 'BIOLITH',
+    spellType: 'SORCERY',
+    cost: 5,
+    text: 'Fieldquake all fields. Playing this card ends your turn. Offer this card to the Eye.'
   },
 };
 

--- a/src/ui/spellUtils.js
+++ b/src/ui/spellUtils.js
@@ -15,6 +15,24 @@ export function spendAndDiscardSpell(player, handIndex) {
   }
 }
 
+// «Принесение карты Оку» — карта покидает игру после розыгрыша
+export function offerSpellToEye(player, handIndex) {
+  try {
+    if (!player || typeof handIndex !== 'number') return null;
+    const card = player.hand?.[handIndex];
+    if (!card) return null;
+    player.mana -= card.cost || 0;
+    player.hand.splice(handIndex, 1);
+    try {
+      player.offeredToEye = Array.isArray(player.offeredToEye) ? player.offeredToEye : [];
+      player.offeredToEye.push(card);
+    } catch {}
+    return card;
+  } catch {
+    return null;
+  }
+}
+
 export function burnSpellCard(tpl, tileMesh, cardMesh) {
   try {
     if (typeof window === 'undefined' || !tpl) return;
@@ -35,6 +53,6 @@ export function burnSpellCard(tpl, tileMesh, cardMesh) {
   } catch {}
 }
 
-const api = { spendAndDiscardSpell, burnSpellCard };
+const api = { spendAndDiscardSpell, offerSpellToEye, burnSpellCard };
 try { if (typeof window !== 'undefined') { window.__ui = window.__ui || {}; window.__ui.spellUtils = api; } } catch {}
 export default api;


### PR DESCRIPTION
## Summary
- implement reusable helpers for multi-target Biolith spells including teleportation, telekinesis, and mass fieldquakes
- extend spell interaction state and utilities to support offering spells to the Eye, cancelling multi-step targeting, and finishing teleportation/telekinesis via follow-up clicks
- register the new spell cards in the core catalog with their costs, elements, and descriptions
- allow field-locked hand cards to be selected when forced to discard at hand limit

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd1c9e6ea08330be0b0c52118a68a6