### PR TITLE
Add Timeless Juno, Mesmerizing Fog, and Lapse spell mechanics

### DIFF
--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -1666,6 +1666,20 @@ const RAW_CARDS = {
     ritualCost: 'none',
     text: 'Both players gain mana equal to the number of enemy creatures on the board.'
   },
+  SPELL_SUMMONER_MESMERS_LAPSE: {
+    cardNumber: 93,
+    race: 'Ritual',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_SUMMONER_MESMERS_LAPSE',
+    name: "Summoner Mesmer's Lapse",
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'RITUAL',
+    cost: 0,
+    text: 'Discard a creature from your hand. Opponent loses mana equal to that creature\'s cost. Offer both cards to the Eye.'
+  },
   SPELL_BEGUILING_FOG: {
     cardNumber: 94,
     race: 'Conjuration',
@@ -1679,6 +1693,20 @@ const RAW_CARDS = {
     spellType: 'CONJURATION',
     cost: 0,
     text: 'Rotate any one creature in any direction.'
+  },
+  SPELL_YUGAS_MESMERIZING_FOG: {
+    cardNumber: 95,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_YUGAS_MESMERIZING_FOG',
+    name: "Yuga's Mesmerizing Fog",
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'CONJURATION',
+    cost: 1,
+    text: 'Choose a friendly creature. All adjacent enemy creatures rotate so their backs face the target.'
   },
   SPELL_CLARE_WILS_BANNER: {
     cardNumber: 96,
@@ -1749,6 +1777,20 @@ const RAW_CARDS = {
     spellType: 'SORCERY',
     cost: 5,
     text: 'Fieldquake all fields. Playing this card ends your turn. Offer this card to the Eye.'
+  },
+  SPELL_CALL_OF_TIMELESS_JUNO: {
+    cardNumber: 110,
+    race: 'Sorcery',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_CALL_OF_TIMELESS_JUNO',
+    name: 'Call of Timeless Juno',
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'SORCERY',
+    cost: 5,
+    text: 'Exchange two fields. Creatures stay in place. Playing this card ends your turn.'
   },
 };
 

--- a/src/scene/discard.js
+++ b/src/scene/discard.js
@@ -26,12 +26,12 @@ export function discardMesh(mesh, awayVec, duration = 0.9) {
  * @param {number} handIdx - индекс карты в руке.
  * @returns {object|null} - шаблон сброшенной карты или null, если сброс не удался.
  */
-export function discardHandCard(player, handIdx, { skipLogic = false } = {}) {
+export function discardHandCard(player, handIdx, { skipLogic = false, zone = 'graveyard' } = {}) {
   if (!player || typeof handIdx !== 'number' || handIdx < 0) return null;
 
   let cardTpl = null;
   if (!skipLogic) {
-    cardTpl = discardCardFromHand(player, handIdx) || null;
+    cardTpl = discardCardFromHand(player, handIdx, { zone }) || null;
   } else {
     cardTpl = player.hand?.[handIdx] || null;
   }

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -45,6 +45,8 @@ export const interactionState = {
   pendingAbilityOrientation: null,
   pendingSpellTeleportation: null,
   pendingSpellTelekinesis: null,
+  pendingSpellFieldSwap: null,
+  pendingSpellLapse: null,
   spellDragHandled: false,
   // флаг для автоматического завершения хода после атаки
   autoEndTurnAfterAttack: false,
@@ -401,7 +403,11 @@ function onMouseDown(event) {
   }
 
   let tileForSpell = null;
-  if (interactionState.pendingSpellTeleportation || interactionState.pendingSpellTelekinesis) {
+  if (
+    interactionState.pendingSpellTeleportation
+    || interactionState.pendingSpellTelekinesis
+    || interactionState.pendingSpellFieldSwap
+  ) {
     const flatTiles = Array.isArray(tileMeshes) ? tileMeshes.flat() : [];
     if (flatTiles.length) {
       const tileHits = raycaster.intersectObjects(flatTiles, true);
@@ -673,6 +679,8 @@ export function resetCardSelection() {
   }
   interactionState.pendingSpellTeleportation = null;
   interactionState.pendingSpellTelekinesis = null;
+  interactionState.pendingSpellFieldSwap = null;
+  interactionState.pendingSpellLapse = null;
   clearHighlights();
   clearPlacementHighlights();
   try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}


### PR DESCRIPTION
## Summary
- добавлены описания карт Call of Timeless Juno, Yuga's Mesmerizing Fog и Summoner Mesmer's Lapse, чтобы их можно было использовать в колодах
- обновлена система взаимодействий и сброса карт для поддержки новых ритуальных выборов и обмена полями
- реализованы эффекты трёх заклинаний: обмен полей с перерасчётом бонусов, туман, который разворачивает врагов, и ритуал Лапса с жертвованием существа и потерей маны противником

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de637c37bc833083276a90b79b3585