### PR TITLE
Adjust Mesmer Lapse UX and sacrifice lock handling

### DIFF
--- a/src/core/abilityHandlers/sacrifice.js
+++ b/src/core/abilityHandlers/sacrifice.js
@@ -46,6 +46,7 @@ function normalizeSacrificeEntry(entry, tpl) {
     elements,
     allowAnyElement,
     requireNonCubic: entry.requireNonCubic !== false,
+    ignoreSummoningLock: entry.ignoreSummoningLock !== false,
   };
 }
 
@@ -96,6 +97,7 @@ export function collectSacrificeActions(state, context = {}) {
       r,
       c,
       unitUid: unit.uid ?? null,
+      ignoreSummoningLock: config.ignoreSummoningLock !== false,
     });
   }
   return actions;

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -1666,6 +1666,21 @@ const RAW_CARDS = {
     ritualCost: 'none',
     text: 'Both players gain mana equal to the number of enemy creatures on the board.'
   },
+  SPELL_SUMMONER_MESMERS_LAPSE: {
+    cardNumber: 93,
+    race: 'Ritual',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: { type: 'PER_CARD', amount: 1 },
+    id: 'SPELL_SUMMONER_MESMERS_LAPSE',
+    name: "Summoner Mesmer's Lapse",
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'RITUAL',
+    cost: 0,
+    ritualCost: 'discard 1 creature',
+    text: 'Discard a creature from hand. Opponent loses mana equal to its summoning cost.'
+  },
   SPELL_BEGUILING_FOG: {
     cardNumber: 94,
     race: 'Conjuration',
@@ -1679,6 +1694,20 @@ const RAW_CARDS = {
     spellType: 'CONJURATION',
     cost: 0,
     text: 'Rotate any one creature in any direction.'
+  },
+  SPELL_YUGAS_MESMERIZING_FOG: {
+    cardNumber: 95,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_YUGAS_MESMERIZING_FOG',
+    name: "Yuga's Mesmerizing Fog",
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'CONJURATION',
+    cost: 1,
+    text: 'Choose an allied creature. All adjacent enemies rotate so their backs face that creature.'
   },
   SPELL_CLARE_WILS_BANNER: {
     cardNumber: 96,
@@ -1749,6 +1778,20 @@ const RAW_CARDS = {
     spellType: 'SORCERY',
     cost: 5,
     text: 'Fieldquake all fields. Playing this card ends your turn. Offer this card to the Eye.'
+  },
+  SPELL_CALL_OF_TIMELESS_JUNO: {
+    cardNumber: 110,
+    race: 'Sorcery',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_CALL_OF_TIMELESS_JUNO',
+    name: 'Call of Timeless Juno',
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'SORCERY',
+    cost: 5,
+    text: 'Select two fields to exchange their elements. Creatures stay in place. Playing this card ends your turn.'
   },
 };
 

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -45,6 +45,8 @@ export const interactionState = {
   pendingAbilityOrientation: null,
   pendingSpellTeleportation: null,
   pendingSpellTelekinesis: null,
+  pendingSpellFieldExchange: null,
+  pendingSpellLapse: null,
   spellDragHandled: false,
   // флаг для автоматического завершения хода после атаки
   autoEndTurnAfterAttack: false,
@@ -369,7 +371,7 @@ function onMouseDown(event) {
     const card = hitObj.userData?.isInHand ? hitObj : hitObj.parent;
     const cardData = card.userData.cardData;
     const selector = interactionState.pendingDiscardSelection;
-    const ignoreLock = !!selector;
+    const ignoreLock = !!selector && (selector.ignoreSummoningLock || selector.forced);
     if (cardData.locked && !gameState.summoningUnlocked && !ignoreLock) {
       showNotification('Summoning Lock: This card cannot be played until there are at least 4 units on the board at the same time', 'error');
       return;
@@ -401,7 +403,11 @@ function onMouseDown(event) {
   }
 
   let tileForSpell = null;
-  if (interactionState.pendingSpellTeleportation || interactionState.pendingSpellTelekinesis) {
+  if (
+    interactionState.pendingSpellTeleportation
+    || interactionState.pendingSpellTelekinesis
+    || interactionState.pendingSpellFieldExchange
+  ) {
     const flatTiles = Array.isArray(tileMeshes) ? tileMeshes.flat() : [];
     if (flatTiles.length) {
       const tileHits = raycaster.intersectObjects(flatTiles, true);
@@ -668,11 +674,25 @@ export function resetCardSelection() {
     } catch {}
     interactionState.selectedCard = null;
   }
-  if (interactionState.pendingSpellTeleportation || interactionState.pendingSpellTelekinesis) {
+  if (
+    interactionState.pendingSpellTeleportation
+    || interactionState.pendingSpellTelekinesis
+    || interactionState.pendingSpellFieldExchange
+    || interactionState.pendingSpellLapse
+  ) {
     try { window.__ui?.panels?.hidePrompt?.(); } catch {}
   }
   interactionState.pendingSpellTeleportation = null;
   interactionState.pendingSpellTelekinesis = null;
+  if (interactionState.pendingSpellFieldExchange) {
+    try { window.__spells?.cancelFieldExchangeSelection?.(); } catch {}
+    interactionState.pendingSpellFieldExchange = null;
+  }
+  if (interactionState.pendingSpellLapse) {
+    try { window.__spells?.cancelMesmerLapseSelection?.(); } catch {}
+    interactionState.pendingSpellLapse = null;
+    interactionState.pendingDiscardSelection = null;
+  }
   clearHighlights();
   clearPlacementHighlights();
   try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -5,7 +5,12 @@
 
 import { spendAndDiscardSpell, offerSpellToEye, burnSpellCard } from '../ui/spellUtils.js';
 import { getCtx } from '../scene/context.js';
-import { interactionState, resetCardSelection, returnCardToHand } from '../scene/interactions.js';
+import {
+  interactionState,
+  resetCardSelection,
+  returnCardToHand,
+  requestAutoEndTurn,
+} from '../scene/interactions.js';
 import { discardHandCard } from '../scene/discard.js';
 import { computeFieldquakeLockedCells } from '../core/fieldLocks.js';
 import { computeCellBuff, applyFieldTransitionToUnit } from '../core/fieldEffects.js';
@@ -13,9 +18,11 @@ import { refreshPossessionsUI } from '../ui/possessions.js';
 import { applyDeathDiscardEffects } from '../core/abilityHandlers/discard.js';
 import { playFieldquakeFx, playFieldquakeFxBatch } from '../scene/fieldquakeFx.js';
 import { animateManaGainFromWorld } from '../ui/mana.js';
+import { animateManaDrain } from '../ui/manaStealFx.js';
 import { applyFieldquakeToCell, collectFieldquakeDeaths } from '../core/abilityHandlers/fieldquake.js';
 import { applyFieldFatalityCheck, describeFieldFatality } from '../core/abilityHandlers/fieldHazards.js';
 import { highlightTiles, clearHighlights } from '../scene/highlight.js';
+import { createDeathEntry } from '../core/abilityHandlers/deathRecords.js';
 
 // Универсальные хелперы для повторного использования механик заклинаний
 function getUnitMeshAt(r, c) {
@@ -143,6 +150,299 @@ function processSpellDeaths(deaths, { cause = 'SPELL', delayMs = 1000 } = {}) {
 }
 
 
+function buildLockedFieldSet(state) {
+  const locked = computeFieldquakeLockedCells(state) || [];
+  const result = new Set();
+  for (const pos of locked) {
+    if (!pos) continue;
+    const r = Number(pos.r);
+    const c = Number(pos.c);
+    if (!Number.isInteger(r) || !Number.isInteger(c)) continue;
+    result.add(`${r},${c}`);
+  }
+  return result;
+}
+
+function collectExchangeableCells(state, exclude = null) {
+  if (!state?.board) return { cells: [], lockedSet: new Set() };
+  const lockedSet = buildLockedFieldSet(state);
+  const cells = [];
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      if (exclude && r === exclude.r && c === exclude.c) continue;
+      if (lockedSet.has(`${r},${c}`)) continue;
+      const cell = state.board?.[r]?.[c];
+      if (!cell || !cell.element) continue;
+      cells.push({ r, c });
+    }
+  }
+  return { cells, lockedSet };
+}
+
+function cancelFieldExchangeSelection() {
+  interactionState.pendingSpellFieldExchange = null;
+  clearHighlights();
+  try { window.__ui?.panels?.hidePrompt?.(); } catch {}
+  try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+}
+
+function highlightFieldExchangeTargets(exclude) {
+  const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+  if (!state) {
+    clearHighlights();
+    return 0;
+  }
+  const { cells } = collectExchangeableCells(state, exclude);
+  if (cells.length) highlightTiles(cells);
+  else clearHighlights();
+  return cells.length;
+}
+
+function finalizeFieldExchange(targetR, targetC, opts = {}) {
+  const pending = interactionState.pendingSpellFieldExchange;
+  if (!pending) return false;
+
+  const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+  if (!state) {
+    cancelFieldExchangeSelection();
+    return false;
+  }
+
+  const firstPos = pending.first || {};
+  if (!Number.isInteger(firstPos.r) || !Number.isInteger(firstPos.c)) {
+    cancelFieldExchangeSelection();
+    return false;
+  }
+
+  if (firstPos.r === targetR && firstPos.c === targetC) {
+    showNotification('Нужно выбрать другое поле для обмена', 'error');
+    highlightFieldExchangeTargets(firstPos);
+    return true;
+  }
+
+  const { lockedSet } = collectExchangeableCells(state);
+  if (lockedSet.has(`${firstPos.r},${firstPos.c}`) || lockedSet.has(`${targetR},${targetC}`)) {
+    showNotification('Одно из полей защищено от обмена', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  const firstCell = state.board?.[firstPos.r]?.[firstPos.c] || null;
+  const secondCell = state.board?.[targetR]?.[targetC] || null;
+  if (!firstCell || !secondCell || !firstCell.element || !secondCell.element) {
+    showNotification('Поле недоступно для обмена', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  const activeIndex = typeof state.active === 'number' ? state.active : null;
+  const player = opts.pl || (activeIndex != null ? state.players?.[activeIndex] : null);
+  let handIndex = (opts.idx != null) ? opts.idx : pending.handIndex;
+  const spellTpl = opts.tpl || (handIndex != null ? player?.hand?.[handIndex] : pending.tpl) || pending.tpl;
+
+  if (!player || !spellTpl || spellTpl.id !== pending.spellId) {
+    showNotification('Заклинание недоступно', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  const cost = Number(spellTpl.cost) || 0;
+  if (player.mana < cost) {
+    showNotification('Недостаточно маны для обмена полей', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  if (handIndex == null || player.hand?.[handIndex]?.id !== spellTpl.id) {
+    handIndex = Array.isArray(player.hand)
+      ? player.hand.findIndex(card => card && card.id === spellTpl.id)
+      : -1;
+  }
+  if (handIndex < 0) {
+    showNotification('Карта заклинания уже недоступна', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  const prevFirst = firstCell.element;
+  const prevSecond = secondCell.element;
+
+  firstCell.element = prevSecond;
+  secondCell.element = prevFirst;
+
+  const events = [
+    { r: firstPos.r, c: firstPos.c, prevElement: prevFirst, nextElement: prevSecond },
+    { r: targetR, c: targetC, prevElement: prevSecond, nextElement: prevFirst },
+  ];
+
+  const logs = [];
+  const deaths = [];
+
+  const processCell = (r, c, prevElement, nextElement) => {
+    const cell = state.board?.[r]?.[c];
+    const unit = cell?.unit || null;
+    const tplUnit = unit ? CARDS?.[unit.tplId] : null;
+    const fieldLabel = `${r + 1},${c + 1}`;
+    logs.push(`${spellTpl.name}: поле (${fieldLabel}) ${prevElement}→${nextElement}.`);
+
+    if (!unit || !tplUnit) return;
+
+    const hpShift = applyFieldTransitionToUnit(unit, tplUnit, prevElement, nextElement);
+    if (hpShift?.deltaHp) {
+      const delta = hpShift.deltaHp;
+      const before = hpShift.beforeHp;
+      const after = hpShift.afterHp;
+      const unitName = tplUnit.name || 'Существо';
+      const msg = delta > 0
+        ? `${unitName} усиливается на новом поле: HP ${before}→${after}.`
+        : `${unitName} слабеет на новом поле: HP ${before}→${after}.`;
+      logs.push(msg);
+      spawnHpShiftText(r, c, delta);
+    }
+
+    const fatality = applyFieldFatalityCheck(unit, tplUnit, nextElement);
+    if (fatality?.dies) {
+      const fatalLog = describeFieldFatality(tplUnit, fatality, { name: tplUnit.name });
+      if (fatalLog) logs.push(fatalLog);
+    }
+
+    if ((unit.currentHP ?? tplUnit.hp ?? 0) <= 0) {
+      const deathEntry = createDeathEntry(state, unit, r, c) || {
+        r,
+        c,
+        owner: unit.owner,
+        tplId: unit.tplId,
+        uid: unit.uid ?? null,
+        element: nextElement,
+      };
+      deaths.push(deathEntry);
+    }
+  };
+
+  processCell(firstPos.r, firstPos.c, prevFirst, prevSecond);
+  processCell(targetR, targetC, prevSecond, prevFirst);
+
+  cancelFieldExchangeSelection();
+
+  const effectTile = opts.tileMesh || getTileMeshAt(targetR, targetC) || getTileMeshAt(firstPos.r, firstPos.c) || null;
+
+  playFieldquakeFx(events[0]);
+  playFieldquakeFx(events[1]);
+
+  for (const text of logs) addLog(text);
+
+  burnSpellCard(spellTpl, effectTile, opts.cardMesh || pending.cardMesh || null);
+  spendAndDiscardSpell(player, handIndex);
+  updateHand();
+
+  if (deaths.length) {
+    processSpellDeaths(deaths);
+  }
+
+  refreshPossessionsUI(state);
+  updateUnits();
+  updateUI();
+
+  addLog(`${spellTpl.name}: ход завершается.`);
+  requestAutoEndTurn();
+  return true;
+}
+
+function cancelMesmerLapseSelection() {
+  interactionState.pendingSpellLapse = null;
+  interactionState.pendingDiscardSelection = null;
+  clearHighlights();
+  try { window.__ui?.panels?.hidePrompt?.(); } catch {}
+  try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+}
+
+function finalizeMesmerLapseDiscard(handIdx) {
+  const pending = interactionState.pendingSpellLapse;
+  if (!pending) return;
+
+  const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+  if (!state) {
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  const activeIndex = typeof state.active === 'number' ? state.active : null;
+  const player = pending.player || (activeIndex != null ? state.players?.[activeIndex] : null);
+  if (!player) {
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  const opponentIndex = pending.opponentIndex != null ? pending.opponentIndex : (activeIndex === 0 ? 1 : 0);
+  const opponent = Number.isInteger(opponentIndex) ? state.players?.[opponentIndex] : null;
+
+  const spellTpl = pending.tpl || (pending.handIndex != null ? player.hand?.[pending.handIndex] : null);
+  if (!spellTpl || spellTpl.id !== pending.spellId) {
+    showNotification('Заклинание уже отменено', 'error');
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  if (!Number.isInteger(handIdx)) {
+    showNotification('Некорректный выбор карты', 'error');
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  const chosenTpl = discardHandCard(player, handIdx);
+  if (!chosenTpl || chosenTpl.type !== 'UNIT') {
+    showNotification('Нужно выбрать карту существа', 'error');
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  const manaLoss = Math.max(0, Number(chosenTpl.cost) || 0);
+  if (opponent) {
+    const before = Number.isFinite(opponent.mana) ? opponent.mana : 0;
+    const after = Math.max(0, before - manaLoss);
+    opponent.mana = after;
+    if (manaLoss > 0) {
+      try {
+        animateManaDrain({
+          from: opponentIndex,
+          amount: manaLoss,
+          before: { mana: before },
+          after: { mana: after },
+        });
+      } catch {}
+    }
+    if (manaLoss > 0) {
+      addLog(`${spellTpl.name}: противник теряет ${manaLoss} маны.`);
+    } else {
+      addLog(`${spellTpl.name}: существо без стоимости маны не отняло ресурс у противника.`);
+    }
+  }
+
+  let spellHandIndex = pending.handIndex;
+  if (spellHandIndex == null || player.hand?.[spellHandIndex]?.id !== spellTpl.id) {
+    spellHandIndex = Array.isArray(player.hand)
+      ? player.hand.findIndex(card => card && card.id === spellTpl.id)
+      : -1;
+  }
+  if (spellHandIndex < 0) {
+    showNotification('Карта заклинания уже недоступна', 'error');
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  burnSpellCard(spellTpl, pending.tileMesh || null, pending.cardMesh || null);
+  offerSpellToEye(player, spellHandIndex);
+
+  const creatureName = chosenTpl.name || 'Существо';
+  addLog(`${spellTpl.name}: ${creatureName} сброшен(а) для ритуала.`);
+
+  cancelMesmerLapseSelection();
+
+  refreshPossessionsUI(state);
+  updateHand();
+  updateUI();
+}
+
 // Общая реализация ритуала Holy Feast
 function runHolyFeast({ tpl, pl, idx, cardMesh, tileMesh }) {
   const handIndices = pl.hand
@@ -215,6 +515,7 @@ function runHolyFeast({ tpl, pl, idx, cardMesh, tileMesh }) {
   // Ожидаем выбор существа из руки
   interactionState.pendingDiscardSelection = {
     requiredType: 'UNIT',
+    ignoreSummoningLock: true,
     onPicked: handIdx => {
       const toDiscard = discardHandCard(pl, handIdx);
       if (!toDiscard) return;
@@ -541,6 +842,17 @@ function finalizeTelekinesisTarget(targetR, targetC, opts = {}) {
 }
 
 export function handlePendingBoardClick({ unitMesh = null, tileMesh = null } = {}) {
+  if (interactionState.pendingSpellFieldExchange) {
+    const r = tileMesh?.userData?.row ?? unitMesh?.userData?.row ?? null;
+    const c = tileMesh?.userData?.col ?? unitMesh?.userData?.col ?? null;
+    if (r == null || c == null) {
+      showNotification('Нужно выбрать второе поле для обмена', 'error');
+      return true;
+    }
+    const resolvedTile = tileMesh || getTileMeshAt(r, c) || null;
+    finalizeFieldExchange(r, c, { tileMesh: resolvedTile });
+    return true;
+  }
   if (interactionState.pendingSpellTeleportation) {
     const r = unitMesh?.userData?.row ?? null;
     const c = unitMesh?.userData?.col ?? null;
@@ -575,6 +887,68 @@ export const handlers = {
         window.__ui.panels.showOrientationPanel();
         try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
       } catch {}
+    },
+  },
+
+  SPELL_YUGAS_MESMERIZING_FOG: {
+    requiresUnitTarget: true,
+    onUnit({ tpl, pl, idx, r, c, u, cardMesh, unitMesh }) {
+      const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+      if (!state || !u) {
+        showNotification('Цель недоступна', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+      if (u.owner !== state.active) {
+        showNotification('Нужно выбрать союзное существо', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const directions = [
+        { dr: -1, dc: 0 },
+        { dr: 1, dc: 0 },
+        { dr: 0, dc: -1 },
+        { dr: 0, dc: 1 },
+      ];
+      const affected = [];
+      for (const dir of directions) {
+        const nr = r + dir.dr;
+        const nc = c + dir.dc;
+        if (nr < 0 || nr >= 3 || nc < 0 || nc >= 3) continue;
+        const enemy = state.board?.[nr]?.[nc]?.unit || null;
+        if (!enemy || enemy.owner === u.owner) continue;
+        const vectorR = r - nr;
+        const vectorC = c - nc;
+        let away = enemy.facing || 'N';
+        if (vectorR === 1 && vectorC === 0) away = 'N';
+        else if (vectorR === -1 && vectorC === 0) away = 'S';
+        else if (vectorR === 0 && vectorC === 1) away = 'W';
+        else if (vectorR === 0 && vectorC === -1) away = 'E';
+        enemy.facing = away;
+        affected.push({
+          name: CARDS?.[enemy.tplId]?.name || 'Существо',
+          r: nr,
+          c: nc,
+          dir: away,
+        });
+      }
+
+      const targetName = CARDS?.[u.tplId]?.name || 'союзник';
+      if (affected.length) {
+        const parts = affected.map(info => `${info.name} (${info.r + 1},${info.c + 1})`);
+        addLog(`${tpl.name}: ${parts.join(', ')} отворачиваются от ${targetName}.`);
+      } else {
+        addLog(`${tpl.name}: рядом с ${targetName} нет вражеских существ.`);
+      }
+
+      const effectTile = getTileMeshAt(r, c) || (unitMesh ? getTileMeshAt(unitMesh.userData?.row, unitMesh.userData?.col) : null);
+      burnSpellCard(tpl, effectTile, cardMesh);
+      spendAndDiscardSpell(pl, idx);
+      resetCardSelection();
+      updateHand();
+      updateUnits();
+      updateUI();
     },
   },
 
@@ -656,6 +1030,75 @@ export const handlers = {
         addLog(`${tpl.name}: вы добираете 2 карты.`);
         updateUI();
       })();
+    },
+  },
+
+  SPELL_SUMMONER_MESMERS_LAPSE: {
+    onCast({ tpl, pl, idx, cardMesh, tileMesh }) {
+      const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+      if (!state) {
+        showNotification('Игра не готова к розыгрышу заклинания', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+      if (tpl.cost > pl.mana) {
+        showNotification('Недостаточно маны', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+      if (interactionState.pendingSpellLapse) {
+        showNotification('Сначала завершите текущий выбор карты для жертвы', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+      if (interactionState.pendingDiscardSelection) {
+        showNotification('Сначала завершите другой выбор карты', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const hand = Array.isArray(pl.hand) ? pl.hand : [];
+      const unitIndices = hand
+        .map((card, handIdx) => (card && card.type === 'UNIT' ? handIdx : -1))
+        .filter(i => i >= 0);
+      if (!unitIndices.length) {
+        showNotification('В руке нет существ для жертвы', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      interactionState.pendingSpellLapse = {
+        spellId: tpl.id,
+        handIndex: idx,
+        tpl,
+        player: pl,
+        opponentIndex: state.active === 0 ? 1 : 0,
+        cardMesh: cardMesh || null,
+        tileMesh: tileMesh || null,
+      };
+      interactionState.spellDragHandled = true;
+      if (cardMesh) returnCardToHand(cardMesh);
+
+      interactionState.pendingDiscardSelection = {
+        requiredType: 'UNIT',
+        forced: true,
+        ignoreSummoningLock: true,
+        invalidMessage: 'Нужно выбрать карту существа',
+        onPicked: pickedIdx => finalizeMesmerLapseDiscard(pickedIdx),
+      };
+
+      try {
+        window.__ui.panels.showPrompt(
+          'Выберите существо в руке для жертвы',
+          () => {
+            cancelMesmerLapseSelection();
+            updateUI();
+          },
+        );
+      } catch {}
+
+      addLog(`${tpl.name}: выберите существо в руке для жертвы.`);
+      try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
     },
   },
 
@@ -1135,6 +1578,83 @@ export const handlers = {
       }, 350);
     },
   },
+
+  SPELL_CALL_OF_TIMELESS_JUNO: {
+    onBoard({ tpl, pl, idx, tileMesh, unitMesh, cardMesh }) {
+      const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+      if (!state) {
+        showNotification('Игра не готова к обработке заклинания', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const r = tileMesh?.userData?.row ?? unitMesh?.userData?.row ?? null;
+      const c = tileMesh?.userData?.col ?? unitMesh?.userData?.col ?? null;
+      if (r == null || c == null) {
+        showNotification('Нужно выбрать поле на арене', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const pending = interactionState.pendingSpellFieldExchange;
+      if (!pending) {
+        if (tpl.cost > pl.mana) {
+          showNotification('Недостаточно маны', 'error');
+          if (cardMesh) returnCardToHand(cardMesh);
+          return;
+        }
+        const cell = state.board?.[r]?.[c];
+        if (!cell || !cell.element) {
+          showNotification('Поле недоступно', 'error');
+          if (cardMesh) returnCardToHand(cardMesh);
+          return;
+        }
+        const lockedSet = buildLockedFieldSet(state);
+        if (lockedSet.has(`${r},${c}`)) {
+          showNotification('Это поле защищено от обмена', 'error');
+          if (cardMesh) returnCardToHand(cardMesh);
+          return;
+        }
+        const available = highlightFieldExchangeTargets({ r, c });
+        if (!available) {
+          showNotification('Нет доступных полей для обмена', 'error');
+          if (cardMesh) returnCardToHand(cardMesh);
+          clearHighlights();
+          return;
+        }
+        interactionState.pendingSpellFieldExchange = {
+          spellId: tpl.id,
+          handIndex: idx,
+          first: { r, c },
+          tpl,
+          cardMesh: cardMesh || null,
+        };
+        interactionState.spellDragHandled = true;
+        if (cardMesh) returnCardToHand(cardMesh);
+        try {
+          window.__ui.panels.showPrompt(
+            'Выберите второе поле для обмена',
+            () => {
+              cancelFieldExchangeSelection();
+              updateUI();
+            },
+          );
+        } catch {}
+        addLog(`${tpl.name}: выберите второе поле, которое нужно обменять.`);
+        try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+        return;
+      }
+
+      if (pending.spellId !== tpl.id || pending.handIndex !== idx) {
+        showNotification('Сначала завершите текущий обмен полей', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const resolvedTile = tileMesh || (typeof r === 'number' && typeof c === 'number' ? getTileMeshAt(r, c) : null);
+      finalizeFieldExchange(r, c, { tpl, pl, idx, tileMesh: resolvedTile, cardMesh });
+    },
+  },
 };
 
 export function requiresUnitTarget(id) {
@@ -1164,7 +1684,15 @@ export function castSpellByDrag(ctx) {
   return false;
 }
 
-const api = { handlers, castSpellOnUnit, castSpellByDrag, requiresUnitTarget, handlePendingBoardClick };
+const api = {
+  handlers,
+  castSpellOnUnit,
+  castSpellByDrag,
+  requiresUnitTarget,
+  handlePendingBoardClick,
+  cancelFieldExchangeSelection,
+  cancelMesmerLapseSelection,
+};
 try {
   if (typeof window !== 'undefined') {
     window.__spells = api;

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -243,6 +243,7 @@ export function performUnitAbility(unitMesh, actionId) {
         requiredType: 'UNIT',
         filter: (_, idx) => candidates.some(c => c.handIdx === idx),
         invalidMessage: 'This card cannot be used for the sacrifice',
+        ignoreSummoningLock: action.ignoreSummoningLock !== false,
         onPicked: (handIdx) => {
           const ctx = getPendingUnitAbility();
           if (!ctx) return;

--- a/src/ui/cancelButton.js
+++ b/src/ui/cancelButton.js
@@ -59,7 +59,14 @@ function cancelTargetSelection() {
 export function refreshCancelButton() {
   const btn = document.getElementById('cancel-play-btn');
   if (!btn) return;
-  const vis = interactionState.pendingPlacement || interactionState.pendingAttack || interactionState.magicFrom || interactionState.pendingSpellOrientation || interactionState.selectedCard;
+  const vis = interactionState.pendingPlacement
+    || interactionState.pendingAttack
+    || interactionState.magicFrom
+    || interactionState.pendingSpellOrientation
+    || interactionState.pendingSpellFieldExchange
+    || interactionState.pendingSpellLapse
+    || interactionState.pendingDiscardSelection
+    || interactionState.selectedCard;
   btn.classList.toggle('hidden', !vis);
 }
 
@@ -78,6 +85,12 @@ export function setupCancelButton() {
         interactionState.pendingSpellOrientation = null;
         window.__ui?.panels?.hideOrientationPanel?.();
         interactionState.selectedCard && returnCardToHand(interactionState.selectedCard);
+      } else if (interactionState.pendingSpellFieldExchange) {
+        window.__spells?.cancelFieldExchangeSelection?.();
+      } else if (interactionState.pendingSpellLapse) {
+        window.__spells?.cancelMesmerLapseSelection?.();
+        interactionState.pendingSpellLapse = null;
+        interactionState.pendingDiscardSelection = null;
       } else if (interactionState.selectedCard) {
         returnCardToHand(interactionState.selectedCard);
         interactionState.selectedCard = null;

--- a/src/ui/discardManager.js
+++ b/src/ui/discardManager.js
@@ -469,6 +469,7 @@ function prepareSelection() {
     forced: true,
     keepAfterPick: true,
     requestId: req.id,
+    ignoreSummoningLock: true,
     onPicked: (handIdx) => {
       handleDiscard(handIdx, { auto: false });
     },

--- a/src/ui/handLimit.js
+++ b/src/ui/handLimit.js
@@ -17,6 +17,7 @@ export async function enforceHandLimit(player, limit = 7) {
     await new Promise(resolve => {
       interactionState.pendingDiscardSelection = {
         forced: true,
+        ignoreSummoningLock: true,
         onPicked: handIdx => {
           discardHandCard(player, handIdx);
           // синхронизация с сервером, чтобы он знал о сбросе карты

--- a/src/ui/manaStealFx.js
+++ b/src/ui/manaStealFx.js
@@ -1,4 +1,180 @@
-// Анимация визуального эффекта кражи маны
+// Анимация визуальных эффектов для перемещения и утечки маны
+function resolveManaBar(index) {
+  try {
+    if (typeof document === 'undefined') return null;
+    if (!Number.isInteger(index)) return null;
+    return document.getElementById(`mana-display-${index}`);
+  } catch {
+    return null;
+  }
+}
+
+function computeFromSlots(before, amount) {
+  const slots = [];
+  const safeBefore = Number.isFinite(before) ? before : 0;
+  for (let i = 0; i < amount; i += 1) {
+    slots.push(Math.max(0, Math.min(9, safeBefore - 1 - i)));
+  }
+  return slots;
+}
+
+function computeGainSlots(beforeTo, afterTo, amount) {
+  const safeBefore = Number.isFinite(beforeTo) ? beforeTo : 0;
+  const safeAfter = Number.isFinite(afterTo) ? afterTo : safeBefore;
+  const slots = [];
+  for (let idx = safeBefore; idx < safeAfter; idx += 1) {
+    slots.push(Math.max(0, Math.min(9, idx)));
+  }
+  while (slots.length < amount) {
+    const fallback = slots.length
+      ? slots[slots.length - 1]
+      : Math.max(0, Math.min(9, safeAfter - 1));
+    slots.push(fallback);
+  }
+  return slots;
+}
+
+function getSlotRect(barEl, idx) {
+  if (!barEl) return null;
+  const child = barEl.children?.[idx];
+  if (child) return child.getBoundingClientRect();
+  if (barEl.children && barEl.children.length) {
+    const last = barEl.children[Math.min(idx, barEl.children.length - 1)];
+    if (last) return last.getBoundingClientRect();
+  }
+  return barEl.getBoundingClientRect();
+}
+
+function ensureTargetVisible(toBar, toIdx) {
+  if (!toBar) return;
+  const targetEl = toBar.children?.[toIdx];
+  if (targetEl) {
+    targetEl.style.transition = 'opacity 220ms ease';
+    targetEl.style.opacity = '1';
+  }
+}
+
+function playArrivalSpark(toBar, toIdx) {
+  const targetRect = getSlotRect(toBar, toIdx);
+  if (!targetRect) {
+    ensureTargetVisible(toBar, toIdx);
+    return;
+  }
+  const spark = document.createElement('div');
+  spark.className = 'mana-orb--steal-gain';
+  spark.style.position = 'fixed';
+  spark.style.left = `${targetRect.left + targetRect.width / 2}px`;
+  spark.style.top = `${targetRect.top + targetRect.height / 2}px`;
+  spark.style.transform = 'translate(-50%, -50%) scale(0.4)';
+  spark.style.opacity = '0';
+  spark.style.zIndex = '92';
+  document.body.appendChild(spark);
+  const tlGain = window.gsap?.timeline({
+    onComplete: () => {
+      try { if (spark.parentNode) spark.parentNode.removeChild(spark); } catch {}
+      ensureTargetVisible(toBar, toIdx);
+    },
+  });
+  if (tlGain) {
+    tlGain
+      .to(spark, { duration: 0.15, opacity: 1, scale: 0.9, ease: 'power1.out' })
+      .to(spark, { duration: 0.32, opacity: 0, scale: 1.2, ease: 'power2.in' }, '>-0.05');
+  } else {
+    spark.style.transition = 'opacity 180ms ease, transform 180ms ease';
+    requestAnimationFrame(() => {
+      spark.style.opacity = '1';
+      spark.style.transform = 'translate(-50%, -50%) scale(0.9)';
+      setTimeout(() => {
+        spark.style.opacity = '0';
+        spark.style.transform = 'translate(-50%, -50%) scale(1.2)';
+        setTimeout(() => {
+          try { if (spark.parentNode) spark.parentNode.removeChild(spark); } catch {}
+          ensureTargetVisible(toBar, toIdx);
+        }, 200);
+      }, 200);
+    });
+  }
+}
+
+function spawnManaFlight({ fromBar, toBar, fromIdx, toIdx, delayMs, mode }) {
+  if (!fromBar) return;
+  const fromRect = getSlotRect(fromBar, fromIdx);
+  if (!fromRect) return;
+  const orb = document.createElement('div');
+  orb.className = 'mana-orb--steal-fx';
+  orb.style.position = 'fixed';
+  orb.style.left = `${fromRect.left + fromRect.width / 2}px`;
+  orb.style.top = `${fromRect.top + fromRect.height / 2}px`;
+  orb.style.transform = 'translate(-50%, -50%) scale(0.9)';
+  orb.style.opacity = '0';
+  orb.style.zIndex = '90';
+  document.body.appendChild(orb);
+
+  if (mode === 'steal' && toBar && toIdx != null) {
+    const targetEl = toBar.children?.[toIdx];
+    if (targetEl) {
+      targetEl.style.opacity = '0';
+    }
+  }
+
+  const cleanup = () => {
+    try { if (orb.parentNode) orb.parentNode.removeChild(orb); } catch {}
+    if (mode === 'steal' && toBar && toIdx != null) {
+      playArrivalSpark(toBar, toIdx);
+    }
+  };
+
+  const tl = window.gsap?.timeline({ delay: Math.max(0, delayMs) / 1000, onComplete: cleanup });
+  if (tl) {
+    tl
+      .to(orb, { duration: 0.2, opacity: 1, scale: 1.05, ease: 'power2.out' })
+      .to(orb, { duration: 0.36, y: '-32', ease: 'power1.out' }, '>-0.06')
+      .to(orb, { duration: 0.28, opacity: 0, scale: 0.6, ease: 'power2.in' }, '>-0.2');
+  } else {
+    setTimeout(() => {
+      orb.style.transition = 'transform 260ms ease, opacity 260ms ease';
+      requestAnimationFrame(() => {
+        orb.style.opacity = '1';
+        orb.style.transform = 'translate(-50%, -80%) scale(1.05)';
+        setTimeout(() => {
+          orb.style.opacity = '0';
+          orb.style.transform = 'translate(-50%, -110%) scale(0.6)';
+          setTimeout(cleanup, 260);
+        }, 200);
+      });
+    }, Math.max(0, delayMs));
+  }
+}
+
+function animateManaTransfer({ amount, fromIndex, toIndex, beforeFrom, beforeTo, afterTo, mode }) {
+  try {
+    if (amount <= 0) return;
+    const fromBar = resolveManaBar(fromIndex);
+    if (!fromBar) return;
+    const fromSlots = computeFromSlots(beforeFrom, amount);
+    const toBar = mode === 'steal' ? resolveManaBar(toIndex) : null;
+    const toSlots = mode === 'steal'
+      ? computeGainSlots(beforeTo, afterTo, amount)
+      : [];
+    for (let i = 0; i < amount; i += 1) {
+      const fromIdx = fromSlots[i] ?? fromSlots[fromSlots.length - 1] ?? 0;
+      const toIdx = mode === 'steal'
+        ? (toSlots[i] ?? toSlots[toSlots.length - 1] ?? 0)
+        : null;
+      spawnManaFlight({
+        fromBar,
+        toBar,
+        fromIdx,
+        toIdx,
+        delayMs: i * 140,
+        mode,
+      });
+    }
+  } catch (err) {
+    console.warn('[mana] animateManaTransfer failed', err);
+  }
+}
+
 export function animateManaSteal(event) {
   try {
     if (!event) return;
@@ -7,10 +183,6 @@ export function animateManaSteal(event) {
     const fromIndex = Number.isInteger(event.from) ? event.from : null;
     const toIndex = Number.isInteger(event.to) ? event.to : null;
     if (amount <= 0 || fromIndex == null || toIndex == null) return;
-    const fromBar = document.getElementById(`mana-display-${fromIndex}`);
-    const toBar = document.getElementById(`mana-display-${toIndex}`);
-    if (!fromBar || !toBar) return;
-
     const beforeFrom = Number.isFinite(event?.before?.fromMana)
       ? event.before.fromMana
       : (Number(event?.after?.fromMana) || 0) + amount;
@@ -20,137 +192,52 @@ export function animateManaSteal(event) {
     const afterTo = Number.isFinite(event?.after?.toMana)
       ? event.after.toMana
       : Math.min(10, beforeTo + amount);
-
-    const fromSlots = [];
-    for (let i = 0; i < amount; i += 1) {
-      fromSlots.push(Math.max(0, Math.min(9, beforeFrom - 1 - i)));
-    }
-    const newSlots = [];
-    for (let idx = beforeTo; idx < afterTo; idx += 1) {
-      newSlots.push(Math.max(0, Math.min(9, idx)));
-    }
-    while (newSlots.length < amount) {
-      const fallback = newSlots.length ? newSlots[newSlots.length - 1] : Math.max(0, Math.min(9, afterTo - 1));
-      newSlots.push(fallback);
-    }
-
-    const getSlotRect = (barEl, idx) => {
-      if (!barEl) return null;
-      const child = barEl.children?.[idx];
-      if (child) return child.getBoundingClientRect();
-      if (barEl.children && barEl.children.length) {
-        const last = barEl.children[Math.min(idx, barEl.children.length - 1)];
-        if (last) return last.getBoundingClientRect();
-      }
-      return barEl.getBoundingClientRect();
-    };
-
-    const spawnSteal = (fromIdx, toIdx, delayMs) => {
-      const fromRect = getSlotRect(fromBar, fromIdx);
-      if (!fromRect) return;
-      const orb = document.createElement('div');
-      orb.className = 'mana-orb--steal-fx';
-      orb.style.position = 'fixed';
-      orb.style.left = `${fromRect.left + fromRect.width / 2}px`;
-      orb.style.top = `${fromRect.top + fromRect.height / 2}px`;
-      orb.style.transform = 'translate(-50%, -50%) scale(0.9)';
-      orb.style.opacity = '0';
-      orb.style.zIndex = '90';
-      document.body.appendChild(orb);
-
-      const ensureTargetVisible = () => {
-        const targetEl = toBar.children?.[toIdx];
-        if (targetEl) {
-          targetEl.style.transition = 'opacity 220ms ease';
-          targetEl.style.opacity = '1';
-        }
-      };
-
-      const playArrival = () => {
-        const targetRect = getSlotRect(toBar, toIdx);
-        if (!targetRect) { ensureTargetVisible(); return; }
-        const spark = document.createElement('div');
-        spark.className = 'mana-orb--steal-gain';
-        spark.style.position = 'fixed';
-        spark.style.left = `${targetRect.left + targetRect.width / 2}px`;
-        spark.style.top = `${targetRect.top + targetRect.height / 2}px`;
-        spark.style.transform = 'translate(-50%, -50%) scale(0.4)';
-        spark.style.opacity = '0';
-        spark.style.zIndex = '92';
-        document.body.appendChild(spark);
-        const tlGain = window.gsap?.timeline({
-          onComplete: () => {
-            try { if (spark.parentNode) spark.parentNode.removeChild(spark); } catch {}
-            ensureTargetVisible();
-          },
-        });
-        if (tlGain) {
-          tlGain.to(spark, { duration: 0.15, opacity: 1, scale: 0.9, ease: 'power1.out' })
-            .to(spark, { duration: 0.32, opacity: 0, scale: 1.2, ease: 'power2.in' }, '>-0.05');
-        } else {
-          spark.style.transition = 'opacity 180ms ease, transform 180ms ease';
-          requestAnimationFrame(() => {
-            spark.style.opacity = '1';
-            spark.style.transform = 'translate(-50%, -50%) scale(0.9)';
-            setTimeout(() => {
-              spark.style.opacity = '0';
-              spark.style.transform = 'translate(-50%, -50%) scale(1.2)';
-              setTimeout(() => {
-                try { if (spark.parentNode) spark.parentNode.removeChild(spark); } catch {}
-                ensureTargetVisible();
-              }, 200);
-            }, 200);
-          });
-        }
-      };
-
-      const targetEl = toBar.children?.[toIdx];
-      if (targetEl) {
-        targetEl.style.opacity = '0';
-      }
-
-      const cleanup = () => {
-        try { if (orb.parentNode) orb.parentNode.removeChild(orb); } catch {}
-        playArrival();
-      };
-
-      const tl = window.gsap?.timeline({ delay: Math.max(0, delayMs) / 1000, onComplete: cleanup });
-      if (tl) {
-        tl.to(orb, { duration: 0.2, opacity: 1, scale: 1.05, ease: 'power2.out' })
-          .to(orb, { duration: 0.36, y: '-32', ease: 'power1.out' }, '>-0.06')
-          .to(orb, { duration: 0.28, opacity: 0, scale: 0.6, ease: 'power2.in' }, '>-0.2');
-      } else {
-        setTimeout(() => {
-          orb.style.transition = 'transform 260ms ease, opacity 260ms ease';
-          requestAnimationFrame(() => {
-            orb.style.opacity = '1';
-            orb.style.transform = 'translate(-50%, -80%) scale(1.05)';
-            setTimeout(() => {
-              orb.style.opacity = '0';
-              orb.style.transform = 'translate(-50%, -110%) scale(0.6)';
-              setTimeout(cleanup, 260);
-            }, 200);
-          });
-        }, Math.max(0, delayMs));
-      }
-    };
-
-    for (let i = 0; i < amount; i += 1) {
-      const fromIdx = fromSlots[i] ?? fromSlots[fromSlots.length - 1] ?? 0;
-      const toIdx = newSlots[i] ?? newSlots[newSlots.length - 1] ?? 0;
-      spawnSteal(fromIdx, toIdx, i * 140);
-    }
+    animateManaTransfer({
+      amount,
+      fromIndex,
+      toIndex,
+      beforeFrom,
+      beforeTo,
+      afterTo,
+      mode: 'steal',
+    });
   } catch (err) {
     console.warn('[mana] animateManaSteal failed', err);
+  }
+}
+
+export function animateManaDrain(event) {
+  try {
+    if (!event) return;
+    const amountRaw = Number(event.amount || event.count || 0);
+    const amount = Math.max(0, Math.floor(amountRaw));
+    const fromIndex = Number.isInteger(event.from) ? event.from : null;
+    if (amount <= 0 || fromIndex == null) return;
+    const beforeFrom = Number.isFinite(event?.before?.mana)
+      ? event.before.mana
+      : Number.isFinite(event?.before?.fromMana)
+        ? event.before.fromMana
+        : (Number(event?.after?.mana) || Number(event?.after?.fromMana) || 0) + amount;
+    animateManaTransfer({
+      amount,
+      fromIndex,
+      toIndex: null,
+      beforeFrom,
+      mode: 'drain',
+    });
+  } catch (err) {
+    console.warn('[mana] animateManaDrain failed', err);
   }
 }
 
 try {
   if (typeof window !== 'undefined') {
     window.animateManaSteal = window.animateManaSteal || animateManaSteal;
+    window.animateManaDrain = window.animateManaDrain || animateManaDrain;
   }
 } catch {}
 
 export default {
   animateManaSteal,
+  animateManaDrain,
 };


### PR DESCRIPTION
## Summary
- update Summoner Mesmer's Lapse copy and discard flow, including reusing the mana steal FX for opponent mana loss
- allow cubic sacrifice abilities (and other forced discards) to target hand cards even under summoning lock by threading an explicit override flag
- refactor the mana steal animation helper to support reusable drain effects for future cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de637c37bc833083276a90b79b3585