### PR TITLE
Clamp mana sync for Summoner Lapse

### DIFF
--- a/src/core/abilityHandlers/manaGain.js
+++ b/src/core/abilityHandlers/manaGain.js
@@ -1,10 +1,9 @@
 // Модуль обработки эффектов прироста маны (чистая игровая логика)
 import { CARDS } from '../cards.js';
 import { normalizeElementName } from '../utils/elements.js';
+import { capMana } from '../constants.js';
 
 const BOARD_SIZE = 3;
-const capMana = (m) => Math.min(10, m);
-
 function toArray(value) {
   if (value == null) return [];
   return Array.isArray(value) ? value.filter(Boolean) : [value].filter(Boolean);

--- a/src/core/abilityHandlers/manaSteal.js
+++ b/src/core/abilityHandlers/manaSteal.js
@@ -1,15 +1,8 @@
 // Логика способности "mana steal" (кража маны)
 import { CARDS } from '../cards.js';
+import { capMana } from '../constants.js';
 
 const ROLE_FRONT_OWNER = 'FRONT_OWNER';
-
-const capMana = (value) => {
-  const num = Math.floor(Number(value) || 0);
-  if (!Number.isFinite(num)) return 0;
-  if (num < 0) return 0;
-  if (num > 10) return 10;
-  return num;
-};
 
 function ensureQueue(state) {
   if (!state) return null;

--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -251,7 +251,7 @@ const RAW_CARDS = {
     attacks: [ { dir: 'N', ranges: [1] } ],
     blindspots: ['E', 'S', 'W'],
     unitActions: [
-      { key: 'SACRIFICE_TRANSFORM', element: 'FIRE', label: 'Sacrifice', requireNonCubic: true },
+      { key: 'SACRIFICE_TRANSFORM', element: 'FIRE', label: 'Sacrifice', requireNonCubic: true, allowLockedTargets: true },
     ],
     desc: 'Sacrifice Red Cubic to summon a non‑cubic Fire creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
@@ -982,7 +982,7 @@ const RAW_CARDS = {
     attacks: [ { dir: 'N', ranges: [1] } ],
     blindspots: ['E', 'S', 'W'],
     unitActions: [
-      { key: 'SACRIFICE_TRANSFORM', element: 'EARTH', label: 'Sacrifice', requireNonCubic: true },
+      { key: 'SACRIFICE_TRANSFORM', element: 'EARTH', label: 'Sacrifice', requireNonCubic: true, allowLockedTargets: true },
     ],
     desc: 'Sacrifice Yellow Cubic to summon a non‑cubic Earth creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
@@ -1070,7 +1070,7 @@ const RAW_CARDS = {
     attacks: [ { dir: 'N', ranges: [1] } ],
     blindspots: ['E', 'S', 'W'],
     unitActions: [
-      { key: 'SACRIFICE_TRANSFORM', element: 'WATER', label: 'Sacrifice', requireNonCubic: true },
+      { key: 'SACRIFICE_TRANSFORM', element: 'WATER', label: 'Sacrifice', requireNonCubic: true, allowLockedTargets: true },
     ],
     desc: 'Sacrifice Blue Cubic to summon a non‑cubic Water creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
@@ -1352,7 +1352,7 @@ const RAW_CARDS = {
     attacks: [ { dir: 'N', ranges: [1] } ],
     blindspots: ['E', 'S', 'W'],
     unitActions: [
-      { key: 'SACRIFICE_TRANSFORM', element: 'FOREST', label: 'Sacrifice', requireNonCubic: true },
+      { key: 'SACRIFICE_TRANSFORM', element: 'FOREST', label: 'Sacrifice', requireNonCubic: true, allowLockedTargets: true },
     ],
     desc: 'Sacrifice Green Cubic to summon a non‑cubic Wood creature in its place (facing any direction) without paying the summoning cost. The summoned creature cannot attack on this turn.'
   },
@@ -1419,7 +1419,7 @@ const RAW_CARDS = {
     keywords: ['DODGE_ATTEMPT'],
     dodge: { chance: 0.5, attempts: 1 },
     unitActions: [
-      { key: 'SACRIFICE_TRANSFORM', label: 'Sacrifice', allowAnyElement: true, requireNonCubic: false },
+      { key: 'SACRIFICE_TRANSFORM', label: 'Sacrifice', allowAnyElement: true, requireNonCubic: false, allowLockedTargets: true },
     ],
     desc: 'White Cubic does not belong to any element. Sacrifice White Cubic to summon any creature in its place (facing any direction) without paying the Summoning Cost. The summoned creature cannot attack this turn. Dodge attempt.'
   },
@@ -1666,6 +1666,21 @@ const RAW_CARDS = {
     ritualCost: 'none',
     text: 'Both players gain mana equal to the number of enemy creatures on the board.'
   },
+  SPELL_SUMMONER_MESMERS_LAPSE: {
+    cardNumber: 93,
+    race: 'Ritual',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: { type: 'PER_CARD', amount: 1 },
+    id: 'SPELL_SUMMONER_MESMERS_LAPSE',
+    name: "Summoner Mesmer's Lapse",
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'RITUAL',
+    cost: 0,
+    ritualCost: 'discard 1 creature',
+    text: 'Discard a creature from hand. Opponent loses mana equal to its summoning cost.'
+  },
   SPELL_BEGUILING_FOG: {
     cardNumber: 94,
     race: 'Conjuration',
@@ -1679,6 +1694,20 @@ const RAW_CARDS = {
     spellType: 'CONJURATION',
     cost: 0,
     text: 'Rotate any one creature in any direction.'
+  },
+  SPELL_YUGAS_MESMERIZING_FOG: {
+    cardNumber: 95,
+    race: 'Conjuration',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_YUGAS_MESMERIZING_FOG',
+    name: "Yuga's Mesmerizing Fog",
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'CONJURATION',
+    cost: 1,
+    text: 'Choose an allied creature. All adjacent enemies rotate so their backs face that creature.'
   },
   SPELL_CLARE_WILS_BANNER: {
     cardNumber: 96,
@@ -1749,6 +1778,20 @@ const RAW_CARDS = {
     spellType: 'SORCERY',
     cost: 5,
     text: 'Fieldquake all fields. Playing this card ends your turn. Offer this card to the Eye.'
+  },
+  SPELL_CALL_OF_TIMELESS_JUNO: {
+    cardNumber: 110,
+    race: 'Sorcery',
+    affiliation: 'None',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_CALL_OF_TIMELESS_JUNO',
+    name: 'Call of Timeless Juno',
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'SORCERY',
+    cost: 5,
+    text: 'Select two fields to exchange their elements. Creatures stay in place. Playing this card ends your turn.'
   },
 };
 

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -29,7 +29,15 @@ export const facingDeg = { N: 0, E: -90, S: 180, W: 90 };
 // Helpers
 export const uid = () => Math.random().toString(36).slice(2, 9);
 export const inBounds = (r, c) => r >= 0 && r < 3 && c >= 0 && c < 3;
-export const capMana = (m) => Math.min(10, m);
+// Ограничение значения маны в допустимых границах (0..10) с приведением к целому числу
+export const capMana = (value) => {
+  const raw = Number(value);
+  if (!Number.isFinite(raw)) return 0;
+  const normalized = Math.round(raw);
+  if (normalized <= 0) return 0;
+  if (normalized >= 10) return 10;
+  return normalized;
+};
 
 import { activationCost, rotateCost as rawRotateCost } from './abilities.js';
 

--- a/src/core/mana.js
+++ b/src/core/mana.js
@@ -24,4 +24,22 @@ export function grantManaToAllPlayers(state, amount = 0) {
   return result;
 }
 
-export default { grantManaToAllPlayers };
+// Принудительное ограничение маны всех игроков (например, при получении состояния с сервера)
+export function clampAllPlayersMana(state) {
+  if (!state || !Array.isArray(state.players)) {
+    return state;
+  }
+  state.players.forEach((player) => {
+    if (!player) return;
+    const capped = capMana(player.mana);
+    if (player.mana !== capped) {
+      player.mana = capped;
+    }
+    if (typeof player._beforeMana === 'number') {
+      player._beforeMana = capMana(player._beforeMana);
+    }
+  });
+  return state;
+}
+
+export default { grantManaToAllPlayers, clampAllPlayersMana };

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,6 +1,7 @@
 ﻿// Game state: reducer + helpers
 import { capMana } from './constants.js';
 import { shuffle, drawOne, drawOneNoAdd, countControlled, countUnits, randomBoard, startGame } from './board.js';
+import { clampAllPlayersMana } from './mana.js';
 import { applyTurnStartManaEffects } from './abilities.js';
 
 export { shuffle, drawOne, drawOneNoAdd, countControlled, countUnits, randomBoard, startGame };
@@ -22,6 +23,7 @@ export function reducer(state, action) {
         startOptions.players = action.players;
       }
       const s = startGame(action.deck0, action.deck1, startOptions);
+      clampAllPlayersMana(s);
       s.__ver = (state?.__ver || 0) + 1;
       return s;
     }
@@ -30,7 +32,9 @@ export function reducer(state, action) {
       const incomingVer = Number(incoming?.__ver) || 0;
       const currentVer = Number(state?.__ver) || 0;
       if (incomingVer < currentVer) return state;
-      return { ...incoming };
+      const nextState = { ...incoming };
+      clampAllPlayersMana(nextState);
+      return nextState;
     }
     case A.END_TURN: {
       if (!state || state.winner != null) return state;
@@ -50,6 +54,7 @@ export function reducer(state, action) {
       // Optional draw: only enqueue for animation elsewhere; here push straight for logic
       const drawn = drawOneNoAdd(s, s.active);
       if (drawn) pl.hand.push(drawn);
+      clampAllPlayersMana(s);
       s.__ver = (s.__ver || 0) + 1;
       return s;
     }

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -827,6 +827,40 @@ import { playFieldquakeFx } from '../scene/fieldquakeFx.js';
     }
   });
 
+  socket.on('manaDrainFx', (payload = {}) => {
+    try {
+      const bySeat = (typeof payload?.bySeat === 'number') ? payload.bySeat : null;
+      if (typeof MY_SEAT === 'number' && bySeat != null && MY_SEAT === bySeat) {
+        return;
+      }
+    } catch {}
+
+    try {
+      const fxModule = window.__ui?.manaStealFx || {};
+      if (typeof fxModule.playManaDrainFx === 'function') {
+        fxModule.playManaDrainFx(payload, { broadcast: false });
+        return;
+      }
+      const animate = fxModule.animateManaSteal
+        || window.animateManaSteal
+        || window.__ui?.mana?.animateManaSteal;
+      if (typeof animate === 'function') {
+        animate(payload);
+      }
+      const notify = fxModule.showManaDrainMessage
+        || window.__ui?.mana?.showManaDrainMessage;
+      const amount = Math.max(0, Math.floor(Number(payload?.amount) || 0));
+      const ownerIdx = Number.isInteger(payload?.toastOwnerIndex)
+        ? payload.toastOwnerIndex
+        : (Number.isInteger(payload?.from) ? payload.from : null);
+      if (typeof notify === 'function' && amount > 0 && ownerIdx != null) {
+        notify(ownerIdx, amount, payload?.toastOptions || {});
+      }
+    } catch (err) {
+      console.warn('[net] Ошибка показа удалённого эффекта потери маны:', err);
+    }
+  });
+
   // ===== 5) Queue / start =====
   function onFindMatchClick(deckId){
     const hasToken = connectWithCurrentToken({ refresh: true });

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -45,6 +45,8 @@ export const interactionState = {
   pendingAbilityOrientation: null,
   pendingSpellTeleportation: null,
   pendingSpellTelekinesis: null,
+  pendingSpellFieldExchange: null,
+  pendingSpellLapse: null,
   spellDragHandled: false,
   // флаг для автоматического завершения хода после атаки
   autoEndTurnAfterAttack: false,
@@ -401,7 +403,11 @@ function onMouseDown(event) {
   }
 
   let tileForSpell = null;
-  if (interactionState.pendingSpellTeleportation || interactionState.pendingSpellTelekinesis) {
+  if (
+    interactionState.pendingSpellTeleportation
+    || interactionState.pendingSpellTelekinesis
+    || interactionState.pendingSpellFieldExchange
+  ) {
     const flatTiles = Array.isArray(tileMeshes) ? tileMeshes.flat() : [];
     if (flatTiles.length) {
       const tileHits = raycaster.intersectObjects(flatTiles, true);
@@ -668,11 +674,25 @@ export function resetCardSelection() {
     } catch {}
     interactionState.selectedCard = null;
   }
-  if (interactionState.pendingSpellTeleportation || interactionState.pendingSpellTelekinesis) {
+  if (
+    interactionState.pendingSpellTeleportation
+    || interactionState.pendingSpellTelekinesis
+    || interactionState.pendingSpellFieldExchange
+    || interactionState.pendingSpellLapse
+  ) {
     try { window.__ui?.panels?.hidePrompt?.(); } catch {}
   }
   interactionState.pendingSpellTeleportation = null;
   interactionState.pendingSpellTelekinesis = null;
+  if (interactionState.pendingSpellFieldExchange) {
+    try { window.__spells?.cancelFieldExchangeSelection?.(); } catch {}
+    interactionState.pendingSpellFieldExchange = null;
+  }
+  if (interactionState.pendingSpellLapse) {
+    try { window.__spells?.cancelMesmerLapseSelection?.(); } catch {}
+    interactionState.pendingSpellLapse = null;
+    interactionState.pendingDiscardSelection = null;
+  }
   clearHighlights();
   clearPlacementHighlights();
   try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -5,7 +5,12 @@
 
 import { spendAndDiscardSpell, offerSpellToEye, burnSpellCard } from '../ui/spellUtils.js';
 import { getCtx } from '../scene/context.js';
-import { interactionState, resetCardSelection, returnCardToHand } from '../scene/interactions.js';
+import {
+  interactionState,
+  resetCardSelection,
+  returnCardToHand,
+  requestAutoEndTurn,
+} from '../scene/interactions.js';
 import { discardHandCard } from '../scene/discard.js';
 import { computeFieldquakeLockedCells } from '../core/fieldLocks.js';
 import { computeCellBuff, applyFieldTransitionToUnit } from '../core/fieldEffects.js';
@@ -16,6 +21,8 @@ import { animateManaGainFromWorld } from '../ui/mana.js';
 import { applyFieldquakeToCell, collectFieldquakeDeaths } from '../core/abilityHandlers/fieldquake.js';
 import { applyFieldFatalityCheck, describeFieldFatality } from '../core/abilityHandlers/fieldHazards.js';
 import { highlightTiles, clearHighlights } from '../scene/highlight.js';
+import { createDeathEntry } from '../core/abilityHandlers/deathRecords.js';
+import { capMana } from '../core/constants.js';
 
 // Универсальные хелперы для повторного использования механик заклинаний
 function getUnitMeshAt(r, c) {
@@ -142,6 +149,335 @@ function processSpellDeaths(deaths, { cause = 'SPELL', delayMs = 1000 } = {}) {
   }, delayMs);
 }
 
+
+function buildLockedFieldSet(state) {
+  const locked = computeFieldquakeLockedCells(state) || [];
+  const result = new Set();
+  for (const pos of locked) {
+    if (!pos) continue;
+    const r = Number(pos.r);
+    const c = Number(pos.c);
+    if (!Number.isInteger(r) || !Number.isInteger(c)) continue;
+    result.add(`${r},${c}`);
+  }
+  return result;
+}
+
+function collectExchangeableCells(state, exclude = null) {
+  if (!state?.board) return { cells: [], lockedSet: new Set() };
+  const lockedSet = buildLockedFieldSet(state);
+  const cells = [];
+  for (let r = 0; r < 3; r += 1) {
+    for (let c = 0; c < 3; c += 1) {
+      if (exclude && r === exclude.r && c === exclude.c) continue;
+      if (lockedSet.has(`${r},${c}`)) continue;
+      const cell = state.board?.[r]?.[c];
+      if (!cell || !cell.element) continue;
+      cells.push({ r, c });
+    }
+  }
+  return { cells, lockedSet };
+}
+
+function cancelFieldExchangeSelection() {
+  interactionState.pendingSpellFieldExchange = null;
+  clearHighlights();
+  try { window.__ui?.panels?.hidePrompt?.(); } catch {}
+  try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+}
+
+function highlightFieldExchangeTargets(exclude) {
+  const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+  if (!state) {
+    clearHighlights();
+    return 0;
+  }
+  const { cells } = collectExchangeableCells(state, exclude);
+  if (cells.length) highlightTiles(cells);
+  else clearHighlights();
+  return cells.length;
+}
+
+function finalizeFieldExchange(targetR, targetC, opts = {}) {
+  const pending = interactionState.pendingSpellFieldExchange;
+  if (!pending) return false;
+
+  const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+  if (!state) {
+    cancelFieldExchangeSelection();
+    return false;
+  }
+
+  const firstPos = pending.first || {};
+  if (!Number.isInteger(firstPos.r) || !Number.isInteger(firstPos.c)) {
+    cancelFieldExchangeSelection();
+    return false;
+  }
+
+  if (firstPos.r === targetR && firstPos.c === targetC) {
+    showNotification('Нужно выбрать другое поле для обмена', 'error');
+    highlightFieldExchangeTargets(firstPos);
+    return true;
+  }
+
+  const { lockedSet } = collectExchangeableCells(state);
+  if (lockedSet.has(`${firstPos.r},${firstPos.c}`) || lockedSet.has(`${targetR},${targetC}`)) {
+    showNotification('Одно из полей защищено от обмена', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  const firstCell = state.board?.[firstPos.r]?.[firstPos.c] || null;
+  const secondCell = state.board?.[targetR]?.[targetC] || null;
+  if (!firstCell || !secondCell || !firstCell.element || !secondCell.element) {
+    showNotification('Поле недоступно для обмена', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  const activeIndex = typeof state.active === 'number' ? state.active : null;
+  const player = opts.pl || (activeIndex != null ? state.players?.[activeIndex] : null);
+  let handIndex = (opts.idx != null) ? opts.idx : pending.handIndex;
+  const spellTpl = opts.tpl || (handIndex != null ? player?.hand?.[handIndex] : pending.tpl) || pending.tpl;
+
+  if (!player || !spellTpl || spellTpl.id !== pending.spellId) {
+    showNotification('Заклинание недоступно', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  const cost = Number(spellTpl.cost) || 0;
+  if (player.mana < cost) {
+    showNotification('Недостаточно маны для обмена полей', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  if (handIndex == null || player.hand?.[handIndex]?.id !== spellTpl.id) {
+    handIndex = Array.isArray(player.hand)
+      ? player.hand.findIndex(card => card && card.id === spellTpl.id)
+      : -1;
+  }
+  if (handIndex < 0) {
+    showNotification('Карта заклинания уже недоступна', 'error');
+    cancelFieldExchangeSelection();
+    return true;
+  }
+
+  const prevFirst = firstCell.element;
+  const prevSecond = secondCell.element;
+
+  firstCell.element = prevSecond;
+  secondCell.element = prevFirst;
+
+  const events = [
+    { r: firstPos.r, c: firstPos.c, prevElement: prevFirst, nextElement: prevSecond },
+    { r: targetR, c: targetC, prevElement: prevSecond, nextElement: prevFirst },
+  ];
+
+  const logs = [];
+  const deaths = [];
+
+  const processCell = (r, c, prevElement, nextElement) => {
+    const cell = state.board?.[r]?.[c];
+    const unit = cell?.unit || null;
+    const tplUnit = unit ? CARDS?.[unit.tplId] : null;
+    const fieldLabel = `${r + 1},${c + 1}`;
+    logs.push(`${spellTpl.name}: поле (${fieldLabel}) ${prevElement}→${nextElement}.`);
+
+    if (!unit || !tplUnit) return;
+
+    const hpShift = applyFieldTransitionToUnit(unit, tplUnit, prevElement, nextElement);
+    if (hpShift?.deltaHp) {
+      const delta = hpShift.deltaHp;
+      const before = hpShift.beforeHp;
+      const after = hpShift.afterHp;
+      const unitName = tplUnit.name || 'Существо';
+      const msg = delta > 0
+        ? `${unitName} усиливается на новом поле: HP ${before}→${after}.`
+        : `${unitName} слабеет на новом поле: HP ${before}→${after}.`;
+      logs.push(msg);
+      spawnHpShiftText(r, c, delta);
+    }
+
+    const fatality = applyFieldFatalityCheck(unit, tplUnit, nextElement);
+    if (fatality?.dies) {
+      const fatalLog = describeFieldFatality(tplUnit, fatality, { name: tplUnit.name });
+      if (fatalLog) logs.push(fatalLog);
+    }
+
+    if ((unit.currentHP ?? tplUnit.hp ?? 0) <= 0) {
+      const deathEntry = createDeathEntry(state, unit, r, c) || {
+        r,
+        c,
+        owner: unit.owner,
+        tplId: unit.tplId,
+        uid: unit.uid ?? null,
+        element: nextElement,
+      };
+      deaths.push(deathEntry);
+    }
+  };
+
+  processCell(firstPos.r, firstPos.c, prevFirst, prevSecond);
+  processCell(targetR, targetC, prevSecond, prevFirst);
+
+  cancelFieldExchangeSelection();
+
+  const effectTile = opts.tileMesh || getTileMeshAt(targetR, targetC) || getTileMeshAt(firstPos.r, firstPos.c) || null;
+
+  playFieldquakeFx(events[0]);
+  playFieldquakeFx(events[1]);
+
+  for (const text of logs) addLog(text);
+
+  burnSpellCard(spellTpl, effectTile, opts.cardMesh || pending.cardMesh || null);
+  spendAndDiscardSpell(player, handIndex);
+  updateHand();
+
+  if (deaths.length) {
+    processSpellDeaths(deaths);
+  }
+
+  refreshPossessionsUI(state);
+  updateUnits();
+  updateUI();
+
+  addLog(`${spellTpl.name}: ход завершается.`);
+  requestAutoEndTurn();
+  return true;
+}
+
+function cancelMesmerLapseSelection() {
+  interactionState.pendingSpellLapse = null;
+  interactionState.pendingDiscardSelection = null;
+  clearHighlights();
+  try { window.__ui?.panels?.hidePrompt?.(); } catch {}
+  try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+}
+
+function finalizeMesmerLapseDiscard(handIdx) {
+  const pending = interactionState.pendingSpellLapse;
+  if (!pending) return;
+
+  const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+  if (!state) {
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  const activeIndex = typeof state.active === 'number' ? state.active : null;
+  const player = pending.player || (activeIndex != null ? state.players?.[activeIndex] : null);
+  if (!player) {
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  const opponentIndex = pending.opponentIndex != null ? pending.opponentIndex : (activeIndex === 0 ? 1 : 0);
+  const opponent = Number.isInteger(opponentIndex) ? state.players?.[opponentIndex] : null;
+
+  const spellTpl = pending.tpl || (pending.handIndex != null ? player.hand?.[pending.handIndex] : null);
+  if (!spellTpl || spellTpl.id !== pending.spellId) {
+    showNotification('Заклинание уже отменено', 'error');
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  if (!Number.isInteger(handIdx)) {
+    showNotification('Некорректный выбор карты', 'error');
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  const chosenTpl = discardHandCard(player, handIdx);
+  if (!chosenTpl || chosenTpl.type !== 'UNIT') {
+    showNotification('Нужно выбрать карту существа', 'error');
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  const manaLoss = Math.max(0, Number(chosenTpl.cost) || 0);
+  if (opponent) {
+    const beforeRaw = Number.isFinite(opponent.mana) ? opponent.mana : 0;
+    const before = capMana(beforeRaw);
+    if (before !== beforeRaw) {
+      opponent.mana = before;
+    }
+    const after = capMana(before - manaLoss);
+    opponent.mana = after;
+    const actualLoss = Math.max(0, before - after);
+    if (actualLoss > 0) {
+      addLog(`${spellTpl.name}: противник теряет ${actualLoss} маны.`);
+      try {
+        if (typeof window !== 'undefined') {
+          const drainEvent = {
+            amount: actualLoss,
+            from: opponentIndex,
+            before: { fromMana: before },
+            after: { fromMana: after },
+            drainOnly: true,
+            toastOwnerIndex: opponentIndex,
+            toastOptions: { source: 'MESMER_LAPSE' },
+            reason: 'MESMER_LAPSE',
+          };
+          const manaFx = window.__ui?.manaStealFx || {};
+          const netActive = (typeof NET_ON === 'function')
+            ? NET_ON()
+            : (typeof window.NET_ACTIVE !== 'undefined' ? !!window.NET_ACTIVE : false);
+          const seatMatches = (typeof MY_SEAT === 'number' && typeof gameState?.active === 'number')
+            ? (MY_SEAT === gameState.active)
+            : true;
+          const broadcastFx = netActive && seatMatches;
+          if (typeof manaFx.playManaDrainFx === 'function') {
+            manaFx.playManaDrainFx(drainEvent, { broadcast: broadcastFx });
+          } else {
+            const animate = window.animateManaSteal || window.__ui?.mana?.animateManaSteal;
+            if (typeof animate === 'function') animate(drainEvent);
+            const notifyDrain = manaFx.showManaDrainMessage || window.__ui?.mana?.showManaDrainMessage;
+            if (typeof notifyDrain === 'function') {
+              notifyDrain(opponentIndex, actualLoss, { source: 'MESMER_LAPSE' });
+            }
+          }
+        }
+      } catch (err) {
+        console.warn('[spell] Не удалось обработать визуализацию потери маны:', err);
+      }
+    } else if (manaLoss > 0) {
+      addLog(`${spellTpl.name}: у противника не осталось маны для потери.`);
+    } else {
+      addLog(`${spellTpl.name}: существо без стоимости маны не отняло ресурс у противника.`);
+    }
+  }
+
+  let spellHandIndex = pending.handIndex;
+  if (spellHandIndex == null || player.hand?.[spellHandIndex]?.id !== spellTpl.id) {
+    spellHandIndex = Array.isArray(player.hand)
+      ? player.hand.findIndex(card => card && card.id === spellTpl.id)
+      : -1;
+  }
+  if (spellHandIndex < 0) {
+    showNotification('Карта заклинания уже недоступна', 'error');
+    cancelMesmerLapseSelection();
+    return;
+  }
+
+  burnSpellCard(spellTpl, pending.tileMesh || null, pending.cardMesh || null);
+  spendAndDiscardSpell(player, spellHandIndex);
+
+  const creatureName = chosenTpl.name || 'Существо';
+  addLog(`${spellTpl.name}: ${creatureName} отправлено в сброс.`);
+
+  cancelMesmerLapseSelection();
+
+  refreshPossessionsUI(state);
+  updateHand();
+  updateUI();
+  try {
+    if (typeof window !== 'undefined') {
+      window.schedulePush?.('spell-mesmer-lapse', { force: true });
+    }
+  } catch {}
+}
 
 // Общая реализация ритуала Holy Feast
 function runHolyFeast({ tpl, pl, idx, cardMesh, tileMesh }) {
@@ -541,6 +877,17 @@ function finalizeTelekinesisTarget(targetR, targetC, opts = {}) {
 }
 
 export function handlePendingBoardClick({ unitMesh = null, tileMesh = null } = {}) {
+  if (interactionState.pendingSpellFieldExchange) {
+    const r = tileMesh?.userData?.row ?? unitMesh?.userData?.row ?? null;
+    const c = tileMesh?.userData?.col ?? unitMesh?.userData?.col ?? null;
+    if (r == null || c == null) {
+      showNotification('Нужно выбрать второе поле для обмена', 'error');
+      return true;
+    }
+    const resolvedTile = tileMesh || getTileMeshAt(r, c) || null;
+    finalizeFieldExchange(r, c, { tileMesh: resolvedTile });
+    return true;
+  }
   if (interactionState.pendingSpellTeleportation) {
     const r = unitMesh?.userData?.row ?? null;
     const c = unitMesh?.userData?.col ?? null;
@@ -575,6 +922,68 @@ export const handlers = {
         window.__ui.panels.showOrientationPanel();
         try { window.__ui?.cancelButton?.refreshCancelButton(); } catch {}
       } catch {}
+    },
+  },
+
+  SPELL_YUGAS_MESMERIZING_FOG: {
+    requiresUnitTarget: true,
+    onUnit({ tpl, pl, idx, r, c, u, cardMesh, unitMesh }) {
+      const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+      if (!state || !u) {
+        showNotification('Цель недоступна', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+      if (u.owner !== state.active) {
+        showNotification('Нужно выбрать союзное существо', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const directions = [
+        { dr: -1, dc: 0 },
+        { dr: 1, dc: 0 },
+        { dr: 0, dc: -1 },
+        { dr: 0, dc: 1 },
+      ];
+      const affected = [];
+      for (const dir of directions) {
+        const nr = r + dir.dr;
+        const nc = c + dir.dc;
+        if (nr < 0 || nr >= 3 || nc < 0 || nc >= 3) continue;
+        const enemy = state.board?.[nr]?.[nc]?.unit || null;
+        if (!enemy || enemy.owner === u.owner) continue;
+        const vectorR = r - nr;
+        const vectorC = c - nc;
+        let away = enemy.facing || 'N';
+        if (vectorR === 1 && vectorC === 0) away = 'N';
+        else if (vectorR === -1 && vectorC === 0) away = 'S';
+        else if (vectorR === 0 && vectorC === 1) away = 'W';
+        else if (vectorR === 0 && vectorC === -1) away = 'E';
+        enemy.facing = away;
+        affected.push({
+          name: CARDS?.[enemy.tplId]?.name || 'Существо',
+          r: nr,
+          c: nc,
+          dir: away,
+        });
+      }
+
+      const targetName = CARDS?.[u.tplId]?.name || 'союзник';
+      if (affected.length) {
+        const parts = affected.map(info => `${info.name} (${info.r + 1},${info.c + 1})`);
+        addLog(`${tpl.name}: ${parts.join(', ')} отворачиваются от ${targetName}.`);
+      } else {
+        addLog(`${tpl.name}: рядом с ${targetName} нет вражеских существ.`);
+      }
+
+      const effectTile = getTileMeshAt(r, c) || (unitMesh ? getTileMeshAt(unitMesh.userData?.row, unitMesh.userData?.col) : null);
+      burnSpellCard(tpl, effectTile, cardMesh);
+      spendAndDiscardSpell(pl, idx);
+      resetCardSelection();
+      updateHand();
+      updateUnits();
+      updateUI();
     },
   },
 
@@ -656,6 +1065,74 @@ export const handlers = {
         addLog(`${tpl.name}: вы добираете 2 карты.`);
         updateUI();
       })();
+    },
+  },
+
+  SPELL_SUMMONER_MESMERS_LAPSE: {
+    onCast({ tpl, pl, idx, cardMesh, tileMesh }) {
+      const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+      if (!state) {
+        showNotification('Игра не готова к розыгрышу заклинания', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+      if (tpl.cost > pl.mana) {
+        showNotification('Недостаточно маны', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+      if (interactionState.pendingSpellLapse) {
+        showNotification('Сначала завершите текущий выбор карты для жертвы', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+      if (interactionState.pendingDiscardSelection) {
+        showNotification('Сначала завершите другой выбор карты', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const hand = Array.isArray(pl.hand) ? pl.hand : [];
+      const unitIndices = hand
+        .map((card, handIdx) => (card && card.type === 'UNIT' ? handIdx : -1))
+        .filter(i => i >= 0);
+      if (!unitIndices.length) {
+        showNotification('В руке нет существ для сброса', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      interactionState.pendingSpellLapse = {
+        spellId: tpl.id,
+        handIndex: idx,
+        tpl,
+        player: pl,
+        opponentIndex: state.active === 0 ? 1 : 0,
+        cardMesh: cardMesh || null,
+        tileMesh: tileMesh || null,
+      };
+      interactionState.spellDragHandled = true;
+      if (cardMesh) returnCardToHand(cardMesh);
+
+      interactionState.pendingDiscardSelection = {
+        requiredType: 'UNIT',
+        forced: true,
+        invalidMessage: 'Нужно выбрать карту существа',
+        onPicked: pickedIdx => finalizeMesmerLapseDiscard(pickedIdx),
+      };
+
+      try {
+        window.__ui.panels.showPrompt(
+          'Выберите существо в руке для сброса',
+          () => {
+            cancelMesmerLapseSelection();
+            updateUI();
+          },
+        );
+      } catch {}
+
+      addLog(`${tpl.name}: выберите существо в руке для жертвы.`);
+      try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
     },
   },
 
@@ -1135,6 +1612,83 @@ export const handlers = {
       }, 350);
     },
   },
+
+  SPELL_CALL_OF_TIMELESS_JUNO: {
+    onBoard({ tpl, pl, idx, tileMesh, unitMesh, cardMesh }) {
+      const state = typeof gameState !== 'undefined' ? gameState : (typeof window !== 'undefined' ? window.gameState : null);
+      if (!state) {
+        showNotification('Игра не готова к обработке заклинания', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const r = tileMesh?.userData?.row ?? unitMesh?.userData?.row ?? null;
+      const c = tileMesh?.userData?.col ?? unitMesh?.userData?.col ?? null;
+      if (r == null || c == null) {
+        showNotification('Нужно выбрать поле на арене', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const pending = interactionState.pendingSpellFieldExchange;
+      if (!pending) {
+        if (tpl.cost > pl.mana) {
+          showNotification('Недостаточно маны', 'error');
+          if (cardMesh) returnCardToHand(cardMesh);
+          return;
+        }
+        const cell = state.board?.[r]?.[c];
+        if (!cell || !cell.element) {
+          showNotification('Поле недоступно', 'error');
+          if (cardMesh) returnCardToHand(cardMesh);
+          return;
+        }
+        const lockedSet = buildLockedFieldSet(state);
+        if (lockedSet.has(`${r},${c}`)) {
+          showNotification('Это поле защищено от обмена', 'error');
+          if (cardMesh) returnCardToHand(cardMesh);
+          return;
+        }
+        const available = highlightFieldExchangeTargets({ r, c });
+        if (!available) {
+          showNotification('Нет доступных полей для обмена', 'error');
+          if (cardMesh) returnCardToHand(cardMesh);
+          clearHighlights();
+          return;
+        }
+        interactionState.pendingSpellFieldExchange = {
+          spellId: tpl.id,
+          handIndex: idx,
+          first: { r, c },
+          tpl,
+          cardMesh: cardMesh || null,
+        };
+        interactionState.spellDragHandled = true;
+        if (cardMesh) returnCardToHand(cardMesh);
+        try {
+          window.__ui.panels.showPrompt(
+            'Выберите второе поле для обмена',
+            () => {
+              cancelFieldExchangeSelection();
+              updateUI();
+            },
+          );
+        } catch {}
+        addLog(`${tpl.name}: выберите второе поле, которое нужно обменять.`);
+        try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+        return;
+      }
+
+      if (pending.spellId !== tpl.id || pending.handIndex !== idx) {
+        showNotification('Сначала завершите текущий обмен полей', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const resolvedTile = tileMesh || (typeof r === 'number' && typeof c === 'number' ? getTileMeshAt(r, c) : null);
+      finalizeFieldExchange(r, c, { tpl, pl, idx, tileMesh: resolvedTile, cardMesh });
+    },
+  },
 };
 
 export function requiresUnitTarget(id) {
@@ -1164,7 +1718,15 @@ export function castSpellByDrag(ctx) {
   return false;
 }
 
-const api = { handlers, castSpellOnUnit, castSpellByDrag, requiresUnitTarget, handlePendingBoardClick };
+const api = {
+  handlers,
+  castSpellOnUnit,
+  castSpellByDrag,
+  requiresUnitTarget,
+  handlePendingBoardClick,
+  cancelFieldExchangeSelection,
+  cancelMesmerLapseSelection,
+};
 try {
   if (typeof window !== 'undefined') {
     window.__spells = api;

--- a/src/ui/cancelButton.js
+++ b/src/ui/cancelButton.js
@@ -59,7 +59,14 @@ function cancelTargetSelection() {
 export function refreshCancelButton() {
   const btn = document.getElementById('cancel-play-btn');
   if (!btn) return;
-  const vis = interactionState.pendingPlacement || interactionState.pendingAttack || interactionState.magicFrom || interactionState.pendingSpellOrientation || interactionState.selectedCard;
+  const vis = interactionState.pendingPlacement
+    || interactionState.pendingAttack
+    || interactionState.magicFrom
+    || interactionState.pendingSpellOrientation
+    || interactionState.pendingSpellFieldExchange
+    || interactionState.pendingSpellLapse
+    || interactionState.pendingDiscardSelection
+    || interactionState.selectedCard;
   btn.classList.toggle('hidden', !vis);
 }
 
@@ -78,6 +85,12 @@ export function setupCancelButton() {
         interactionState.pendingSpellOrientation = null;
         window.__ui?.panels?.hideOrientationPanel?.();
         interactionState.selectedCard && returnCardToHand(interactionState.selectedCard);
+      } else if (interactionState.pendingSpellFieldExchange) {
+        window.__spells?.cancelFieldExchangeSelection?.();
+      } else if (interactionState.pendingSpellLapse) {
+        window.__spells?.cancelMesmerLapseSelection?.();
+        interactionState.pendingSpellLapse = null;
+        interactionState.pendingDiscardSelection = null;
       } else if (interactionState.selectedCard) {
         returnCardToHand(interactionState.selectedCard);
         interactionState.selectedCard = null;

--- a/src/ui/manaStealFx.js
+++ b/src/ui/manaStealFx.js
@@ -1,3 +1,269 @@
+// Активные уведомления о потере маны по индексам игроков
+const activeDrainToasts = [null, null];
+
+function clearActiveDrainToast(ownerIndex) {
+  if (!Number.isInteger(ownerIndex)) return;
+  const current = activeDrainToasts[ownerIndex];
+  if (!current) return;
+  if (current.fadeTimeout) {
+    try { clearTimeout(current.fadeTimeout); } catch {}
+  }
+  if (current.removeTimeout) {
+    try { clearTimeout(current.removeTimeout); } catch {}
+  }
+  const el = current.el;
+  if (el && el.parentNode) {
+    try { el.parentNode.removeChild(el); } catch {}
+  }
+  activeDrainToasts[ownerIndex] = null;
+}
+
+function formatManaLossWord(amount) {
+  const value = Math.abs(Number(amount) || 0);
+  const mod100 = value % 100;
+  if (mod100 >= 11 && mod100 <= 19) return 'маны';
+  const mod10 = mod100 % 10;
+  if (mod10 === 1) return 'мана';
+  if (mod10 >= 2 && mod10 <= 4) return 'маны';
+  return 'маны';
+}
+
+// Временное сообщение о потере маны для конкретного игрока
+export function showManaDrainMessage(ownerIndex, amount, opts = {}) {
+  try {
+    if (!Number.isInteger(ownerIndex)) return;
+    const positiveAmount = Math.max(0, Math.floor(Number(amount) || 0));
+    if (positiveAmount <= 0) return;
+    const manaBar = document.getElementById(`mana-display-${ownerIndex}`);
+    if (!manaBar) return;
+    const rect = manaBar.getBoundingClientRect?.();
+    if (!rect) return;
+
+    clearActiveDrainToast(ownerIndex);
+
+    const toast = document.createElement('div');
+    toast.className = 'mana-drain-toast';
+    const unit = formatManaLossWord(positiveAmount);
+    toast.textContent = `У вас забрали ${positiveAmount} ${unit}`;
+    toast.style.position = 'fixed';
+    toast.style.left = `${rect.left + rect.width / 2}px`;
+
+    const viewportHeight = (typeof window !== 'undefined' && Number.isFinite(window.innerHeight))
+      ? window.innerHeight
+      : 0;
+    const preferAbove = viewportHeight ? (rect.top > viewportHeight / 2) : (ownerIndex === 0);
+    const verticalOffset = Math.max(8, Math.min(64, Number(opts.offsetY) || 24));
+    if (preferAbove) {
+      toast.style.top = `${rect.top - verticalOffset}px`;
+      toast.dataset.manaToastDirection = 'up';
+    } else {
+      toast.style.top = `${rect.bottom + verticalOffset}px`;
+      toast.dataset.manaToastDirection = 'down';
+    }
+
+    toast.style.opacity = '0';
+    toast.style.transform = preferAbove
+      ? 'translate(-50%, -6px) scale(0.88)'
+      : 'translate(-50%, 6px) scale(0.88)';
+    toast.style.pointerEvents = 'none';
+    toast.style.zIndex = '95';
+
+    const root = document.body || document.getElementById('ui') || null;
+    if (!root) return;
+    root.appendChild(toast);
+
+    const animateIn = () => {
+      try {
+        toast.style.transition = 'transform 280ms ease, opacity 280ms ease';
+        toast.style.opacity = '1';
+        toast.style.transform = preferAbove
+          ? 'translate(-50%, -22px) scale(1)'
+          : 'translate(-50%, 22px) scale(1)';
+      } catch {}
+    };
+
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(animateIn);
+    } else {
+      setTimeout(animateIn, 16);
+    }
+
+    const duration = Math.max(900, Number(opts.duration) || 2400);
+    const fadeTimeout = setTimeout(() => {
+      try {
+        toast.style.opacity = '0';
+        toast.style.transform = preferAbove
+          ? 'translate(-50%, -48px) scale(0.9)'
+          : 'translate(-50%, 48px) scale(0.9)';
+      } catch {}
+    }, duration);
+
+    const removeTimeout = setTimeout(() => {
+      clearActiveDrainToast(ownerIndex);
+    }, duration + 360);
+
+    activeDrainToasts[ownerIndex] = { el: toast, fadeTimeout, removeTimeout };
+  } catch (err) {
+    console.warn('[mana] showManaDrainMessage failed', err);
+  }
+}
+
+function canBroadcastManaFx() {
+  try {
+    if (typeof window === 'undefined') return false;
+    const netActive = typeof window.NET_ON === 'function'
+      ? window.NET_ON()
+      : !!window.NET_ACTIVE;
+    if (!netActive) return false;
+    if (!window.socket) return false;
+    const seat = (typeof window.MY_SEAT === 'number') ? window.MY_SEAT : null;
+    const active = (typeof window.gameState?.active === 'number') ? window.gameState.active : null;
+    if (seat != null && active != null && seat !== active) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeDrainEvent(event = {}) {
+  const amount = Math.max(0, Math.floor(Number(event.amount ?? event.count ?? 0)));
+  const fromIndex = Number.isInteger(event.from) ? event.from : null;
+  const toIndexRaw = Number.isInteger(event.to) ? event.to : null;
+  if (amount <= 0 || fromIndex == null) return null;
+
+  const drainOnly = event.drainOnly === true || event.drain === true
+    || event.mode === 'DRAIN' || toIndexRaw == null;
+
+  const beforeFrom = Number.isFinite(event?.before?.fromMana)
+    ? event.before.fromMana
+    : (Number.isFinite(event?.after?.fromMana) ? event.after.fromMana + amount : null);
+  const afterFrom = Number.isFinite(event?.after?.fromMana)
+    ? event.after.fromMana
+    : (beforeFrom != null ? Math.max(0, beforeFrom - amount) : null);
+
+  const beforeTo = (!drainOnly && Number.isFinite(event?.before?.toMana))
+    ? event.before.toMana
+    : (!drainOnly && Number.isFinite(event?.after?.toMana)
+      ? Math.max(0, event.after.toMana - amount)
+      : null);
+  const afterTo = (!drainOnly && Number.isFinite(event?.after?.toMana))
+    ? event.after.toMana
+    : (!drainOnly && beforeTo != null
+      ? Math.min(10, beforeTo + amount)
+      : null);
+
+  const normalized = {
+    amount,
+    from: fromIndex,
+    drainOnly,
+    mode: drainOnly ? 'DRAIN' : (event.mode || undefined),
+    before: {},
+    after: {},
+  };
+
+  if (!drainOnly && toIndexRaw != null) {
+    normalized.to = toIndexRaw;
+  }
+
+  if (beforeFrom != null) normalized.before.fromMana = beforeFrom;
+  if (afterFrom != null) normalized.after.fromMana = afterFrom;
+  if (!drainOnly && beforeTo != null) {
+    normalized.before.toMana = beforeTo;
+  }
+  if (!drainOnly && afterTo != null) {
+    normalized.after.toMana = afterTo;
+  }
+
+  if (event.reason) normalized.reason = event.reason;
+  if (event.source) normalized.source = event.source;
+  if (event.position) normalized.position = event.position;
+  if (event.frontOwner != null) normalized.frontOwner = event.frontOwner;
+
+  const toastOwner = Number.isInteger(event.toastOwnerIndex) ? event.toastOwnerIndex : null;
+  normalized.toastOwnerIndex = toastOwner != null ? toastOwner : fromIndex;
+  normalized.toast = event.toast === false ? false : true;
+  normalized.toastOptions = typeof event.toastOptions === 'object' && event.toastOptions
+    ? { ...event.toastOptions }
+    : (typeof event.toastOpts === 'object' && event.toastOpts ? { ...event.toastOpts } : {});
+
+  if (event.__id) normalized.__id = event.__id;
+
+  return normalized;
+}
+
+function broadcastManaDrain(event = {}) {
+  try {
+    if (!canBroadcastManaFx()) return false;
+    const socket = window.socket;
+    if (!socket) return false;
+    const payload = {
+      amount: event.amount,
+      from: event.from,
+      drainOnly: event.drainOnly !== false,
+      toast: event.toast !== false,
+      toastOwnerIndex: Number.isInteger(event.toastOwnerIndex) ? event.toastOwnerIndex : event.from,
+    };
+    if (!payload.drainOnly && Number.isInteger(event.to)) {
+      payload.to = event.to;
+    }
+    if (event.before && typeof event.before === 'object') {
+      const before = {};
+      if (Number.isFinite(event.before.fromMana)) before.fromMana = event.before.fromMana;
+      if (Number.isFinite(event.before.toMana)) before.toMana = event.before.toMana;
+      if (Object.keys(before).length) payload.before = before;
+    }
+    if (event.after && typeof event.after === 'object') {
+      const after = {};
+      if (Number.isFinite(event.after.fromMana)) after.fromMana = event.after.fromMana;
+      if (Number.isFinite(event.after.toMana)) after.toMana = event.after.toMana;
+      if (Object.keys(after).length) payload.after = after;
+    }
+    if (event.reason) payload.reason = event.reason;
+    if (event.source) payload.source = event.source;
+    if (event.position) payload.position = event.position;
+    if (event.frontOwner != null) payload.frontOwner = event.frontOwner;
+    if (event.toastOptions && Object.keys(event.toastOptions).length) {
+      payload.toastOptions = { ...event.toastOptions };
+    }
+    payload.__id = event.__id || `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    payload.bySeat = (typeof window.MY_SEAT === 'number') ? window.MY_SEAT : null;
+    socket.emit('manaDrainFx', payload);
+    return true;
+  } catch (err) {
+    console.warn('[mana] broadcastManaDrain failed', err);
+    return false;
+  }
+}
+
+export function playManaDrainFx(event = {}, opts = {}) {
+  try {
+    const normalized = sanitizeDrainEvent(event);
+    if (!normalized) return;
+
+    animateManaSteal(normalized);
+
+    const shouldToast = normalized.toast !== false && opts.toast !== false;
+    if (shouldToast) {
+      const ownerIdx = Number.isInteger(normalized.toastOwnerIndex)
+        ? normalized.toastOwnerIndex
+        : normalized.from;
+      if (Number.isInteger(ownerIdx)) {
+        try {
+          showManaDrainMessage(ownerIdx, normalized.amount, normalized.toastOptions);
+        } catch (err) {
+          console.warn('[mana] showManaDrainMessage via playManaDrainFx failed', err);
+        }
+      }
+    }
+
+    if (opts.broadcast) {
+      broadcastManaDrain(normalized);
+    }
+  } catch (err) {
+    console.warn('[mana] playManaDrainFx failed', err);
+  }
+}
+
 // Анимация визуального эффекта кражи маны
 export function animateManaSteal(event) {
   try {
@@ -5,33 +271,39 @@ export function animateManaSteal(event) {
     const amountRaw = Number(event.amount || event.count || 0);
     const amount = Math.max(0, Math.floor(amountRaw));
     const fromIndex = Number.isInteger(event.from) ? event.from : null;
-    const toIndex = Number.isInteger(event.to) ? event.to : null;
-    if (amount <= 0 || fromIndex == null || toIndex == null) return;
+    const toIndexRaw = Number.isInteger(event.to) ? event.to : null;
+    const drainOnly = event?.drainOnly === true || event?.mode === 'DRAIN' || event?.drain === true;
+    if (amount <= 0 || fromIndex == null) return;
     const fromBar = document.getElementById(`mana-display-${fromIndex}`);
-    const toBar = document.getElementById(`mana-display-${toIndex}`);
-    if (!fromBar || !toBar) return;
+    if (!fromBar) return;
+    const toBar = (!drainOnly && toIndexRaw != null)
+      ? document.getElementById(`mana-display-${toIndexRaw}`)
+      : null;
+    if (!drainOnly && (!toBar || toIndexRaw == null)) return;
 
     const beforeFrom = Number.isFinite(event?.before?.fromMana)
       ? event.before.fromMana
       : (Number(event?.after?.fromMana) || 0) + amount;
-    const beforeTo = Number.isFinite(event?.before?.toMana)
+    const beforeTo = (!drainOnly && Number.isFinite(event?.before?.toMana))
       ? event.before.toMana
-      : Math.max(0, (Number(event?.after?.toMana) || 0) - amount);
-    const afterTo = Number.isFinite(event?.after?.toMana)
+      : (!drainOnly ? Math.max(0, (Number(event?.after?.toMana) || 0) - amount) : 0);
+    const afterTo = (!drainOnly && Number.isFinite(event?.after?.toMana))
       ? event.after.toMana
-      : Math.min(10, beforeTo + amount);
+      : (!drainOnly ? Math.min(10, beforeTo + amount) : 0);
 
     const fromSlots = [];
     for (let i = 0; i < amount; i += 1) {
       fromSlots.push(Math.max(0, Math.min(9, beforeFrom - 1 - i)));
     }
     const newSlots = [];
-    for (let idx = beforeTo; idx < afterTo; idx += 1) {
-      newSlots.push(Math.max(0, Math.min(9, idx)));
-    }
-    while (newSlots.length < amount) {
-      const fallback = newSlots.length ? newSlots[newSlots.length - 1] : Math.max(0, Math.min(9, afterTo - 1));
-      newSlots.push(fallback);
+    if (!drainOnly) {
+      for (let idx = beforeTo; idx < afterTo; idx += 1) {
+        newSlots.push(Math.max(0, Math.min(9, idx)));
+      }
+      while (newSlots.length < amount) {
+        const fallback = newSlots.length ? newSlots[newSlots.length - 1] : Math.max(0, Math.min(9, afterTo - 1));
+        newSlots.push(fallback);
+      }
     }
 
     const getSlotRect = (barEl, idx) => {
@@ -43,6 +315,54 @@ export function animateManaSteal(event) {
         if (last) return last.getBoundingClientRect();
       }
       return barEl.getBoundingClientRect();
+    };
+
+    const spawnDrain = (fromIdx, delayMs) => {
+      const fromRect = getSlotRect(fromBar, fromIdx);
+      if (!fromRect) return;
+      const orb = document.createElement('div');
+      orb.className = 'mana-orb--steal-fx';
+      orb.style.position = 'fixed';
+      orb.style.left = `${fromRect.left + fromRect.width / 2}px`;
+      orb.style.top = `${fromRect.top + fromRect.height / 2}px`;
+      orb.style.transform = 'translate(-50%, -50%) scale(0.9)';
+      orb.style.opacity = '0';
+      orb.style.zIndex = '90';
+      document.body.appendChild(orb);
+
+      const slotEl = fromBar.children?.[fromIdx];
+      if (slotEl) {
+        slotEl.style.transition = 'opacity 220ms ease';
+        slotEl.style.opacity = '0';
+        const restoreDelay = Math.max(260, delayMs + 260);
+        setTimeout(() => {
+          try { slotEl.style.opacity = '1'; } catch {}
+        }, restoreDelay);
+      }
+
+      const cleanup = () => {
+        try { if (orb.parentNode) orb.parentNode.removeChild(orb); } catch {}
+      };
+
+      const tl = window.gsap?.timeline({ delay: Math.max(0, delayMs) / 1000, onComplete: cleanup });
+      if (tl) {
+        tl.to(orb, { duration: 0.2, opacity: 1, scale: 1.05, ease: 'power2.out' })
+          .to(orb, { duration: 0.36, y: '-42', ease: 'power1.out' }, '>-0.06')
+          .to(orb, { duration: 0.28, opacity: 0, scale: 0.6, ease: 'power2.in' }, '>-0.2');
+      } else {
+        setTimeout(() => {
+          orb.style.transition = 'transform 260ms ease, opacity 260ms ease';
+          requestAnimationFrame(() => {
+            orb.style.opacity = '1';
+            orb.style.transform = 'translate(-50%, -80%) scale(1.05)';
+            setTimeout(() => {
+              orb.style.opacity = '0';
+              orb.style.transform = 'translate(-50%, -118%) scale(0.6)';
+              setTimeout(cleanup, 260);
+            }, 200);
+          });
+        }, Math.max(0, delayMs));
+      }
     };
 
     const spawnSteal = (fromIdx, toIdx, delayMs) => {
@@ -137,8 +457,12 @@ export function animateManaSteal(event) {
 
     for (let i = 0; i < amount; i += 1) {
       const fromIdx = fromSlots[i] ?? fromSlots[fromSlots.length - 1] ?? 0;
-      const toIdx = newSlots[i] ?? newSlots[newSlots.length - 1] ?? 0;
-      spawnSteal(fromIdx, toIdx, i * 140);
+      if (drainOnly) {
+        spawnDrain(fromIdx, i * 140);
+      } else {
+        const toIdx = newSlots[i] ?? newSlots[newSlots.length - 1] ?? 0;
+        spawnSteal(fromIdx, toIdx, i * 140);
+      }
     }
   } catch (err) {
     console.warn('[mana] animateManaSteal failed', err);
@@ -148,9 +472,16 @@ export function animateManaSteal(event) {
 try {
   if (typeof window !== 'undefined') {
     window.animateManaSteal = window.animateManaSteal || animateManaSteal;
+    window.__ui = window.__ui || {};
+    window.__ui.manaStealFx = window.__ui.manaStealFx || {};
+    window.__ui.manaStealFx.animateManaSteal = animateManaSteal;
+    window.__ui.manaStealFx.showManaDrainMessage = showManaDrainMessage;
+    window.__ui.manaStealFx.playManaDrainFx = playManaDrainFx;
   }
 } catch {}
 
 export default {
   animateManaSteal,
+  showManaDrainMessage,
+  playManaDrainFx,
 };

--- a/styles/main.css
+++ b/styles/main.css
@@ -32,6 +32,21 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
   background: radial-gradient(circle at 40% 40%, rgba(224,242,254,0.95), rgba(14,165,233,0.85) 55%, rgba(37,99,235,0.65) 85%);
   box-shadow: 0 0 12px rgba(56,189,248,0.9);
 }
+.mana-drain-toast {
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.55);
+  color: #fecaca;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-size: 13px;
+  text-shadow: 0 1px 2px rgba(15, 23, 42, 0.7);
+  pointer-events: none;
+  user-select: none;
+  will-change: transform, opacity;
+}
 /* Кнопка завершения хода с круговым таймером **/
 .end-turn-btn {
   position: relative; width: 84px; height: 84px; border-radius: 50%;


### PR DESCRIPTION
## Summary
- нормализовал снапшоты на сервере: перед сохранением состояния теперь обрезаем ману игроков и при первом приёме, и при последующих обновлениях, а также после серверных операций
- после разрешения Summoner Mesmer's Lapse клиент принудительно отправляет свежий снапшот, чтобы сервер и второй игрок видели уменьшенную ману

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de637c37bc833083276a90b79b3585