### PR TITLE
Improve Dominion spell cancellation and Riotous Impunity sync

### DIFF
--- a/src/core/cards.js
+++ b/src/core/cards.js
@@ -1765,6 +1765,95 @@ const RAW_CARDS = {
     cost: 3,
     text: 'Switch the locations of two allied creatures without changing their orientations. Place this card over the 1st target, then the 2nd target.'
   },
+  SPELL_SCIONDAR_INFERNO: {
+    cardNumber: 103,
+    race: 'Sorcery',
+    affiliation: 'Dominion',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_SCIONDAR_INFERNO',
+    name: 'Sciondar Inferno',
+    type: 'SPELL',
+    element: 'FIRE',
+    spellType: 'SORCERY',
+    cost: 0,
+    ritualCost: 'discard 2 creatures',
+    text: 'Discard 2 creatures (at least one Fire). Deal magic damage equal to the number of Fire fields to all enemy creatures on and adjacent to a chosen Fire field.'
+  },
+  SPELL_ICE_FLOOD_OF_OKUNADA: {
+    cardNumber: 104,
+    race: 'Sorcery',
+    affiliation: 'Dominion',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_ICE_FLOOD_OF_OKUNADA',
+    name: 'Ice Flood of Okunada',
+    type: 'SPELL',
+    element: 'WATER',
+    spellType: 'SORCERY',
+    cost: 0,
+    ritualCost: 'discard 2 creatures',
+    text: 'Discard 2 creatures (at least one Water). Deal magic damage equal to the number of Water fields to all enemy creatures on and adjacent to a chosen Water field.'
+  },
+  SPELL_FIST_OF_VERZAR: {
+    cardNumber: 105,
+    race: 'Sorcery',
+    affiliation: 'Dominion',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_FIST_OF_VERZAR',
+    name: 'Fist of Verzar',
+    type: 'SPELL',
+    element: 'EARTH',
+    spellType: 'SORCERY',
+    cost: 0,
+    ritualCost: 'discard 2 creatures',
+    text: 'Discard 2 creatures (at least 1 must be an Earth creature). This spell targets all enemies on and adjacent to a selected Earth field. Target creatures are dealt magic damage equal to the number of Earth fields.'
+  },
+  SPELL_WRATHFUL_WINDS_OF_JUNO: {
+    cardNumber: 106,
+    race: 'Sorcery',
+    affiliation: 'Dominion',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_WRATHFUL_WINDS_OF_JUNO',
+    name: 'Wrathful Winds of Juno',
+    type: 'SPELL',
+    element: 'FOREST',
+    spellType: 'SORCERY',
+    cost: 0,
+    ritualCost: 'discard 2 creatures',
+    text: 'Discard 2 creatures (at least 1 must be a Wood creature). This spell targets all enemies on and adjacent to a selected Wood field. Target creatures are dealt magic damage equal to the number of Wood fields.'
+  },
+  SPELL_BLINDING_SKIES: {
+    cardNumber: 107,
+    race: 'Sorcery',
+    affiliation: 'Dominion',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_BLINDING_SKIES',
+    name: 'Blinding Skies',
+    type: 'SPELL',
+    element: 'BIOLITH',
+    spellType: 'SORCERY',
+    cost: 0,
+    ritualCost: 'discard 2 creatures',
+    text: 'Discard 2 creatures (at least 1 must be a Biolith creature). This spell targets all enemies on and adjacent to Biolith fields. Target creatures are dealt magic damage equal to the number of Biolith fields. Each target creature is only affected once.'
+  },
+  SPELL_SCIONS_RIOTOUS_IMPUNITY: {
+    cardNumber: 108,
+    race: 'Sorcery',
+    affiliation: 'Dominion',
+    fieldLock: false,
+    cardLimit: null,
+    id: 'SPELL_SCIONS_RIOTOUS_IMPUNITY',
+    name: "Scion's Riotous Impunity",
+    type: 'SPELL',
+    element: 'NEUTRAL',
+    spellType: 'SORCERY',
+    cost: 2,
+    text: 'Starting from the center field, all creatures engage in battle, clockwise one at a time. Playing this card ends your turn.'
+  },
   SPELL_SEER_VIZAKS_CALAMITY: {
     cardNumber: 109,
     race: 'Sorcery',
@@ -1777,7 +1866,7 @@ const RAW_CARDS = {
     element: 'BIOLITH',
     spellType: 'SORCERY',
     cost: 5,
-    text: 'Fieldquake all fields. Playing this card ends your turn. Offer this card to the Eye.'
+    text: 'Fieldquake all fields. Playing this card ends your turn.'
   },
   SPELL_CALL_OF_TIMELESS_JUNO: {
     cardNumber: 110,
@@ -1791,7 +1880,7 @@ const RAW_CARDS = {
     element: 'NEUTRAL',
     spellType: 'SORCERY',
     cost: 5,
-    text: 'Select two fields to exchange their elements. Creatures stay in place. Playing this card ends your turn.'
+    text: 'Exchange two fields. Creatures remain on the same fields while the fields are exchanged. Playing this card ends your turn.'
   },
 };
 

--- a/src/scene/interactions.js
+++ b/src/scene/interactions.js
@@ -47,6 +47,7 @@ export const interactionState = {
   pendingSpellTelekinesis: null,
   pendingSpellFieldExchange: null,
   pendingSpellLapse: null,
+  pendingSpellElementalDominion: null,
   spellDragHandled: false,
   // флаг для автоматического завершения хода после атаки
   autoEndTurnAfterAttack: false,
@@ -679,6 +680,7 @@ export function resetCardSelection() {
     || interactionState.pendingSpellTelekinesis
     || interactionState.pendingSpellFieldExchange
     || interactionState.pendingSpellLapse
+    || interactionState.pendingSpellElementalDominion
   ) {
     try { window.__ui?.panels?.hidePrompt?.(); } catch {}
   }
@@ -692,6 +694,10 @@ export function resetCardSelection() {
     try { window.__spells?.cancelMesmerLapseSelection?.(); } catch {}
     interactionState.pendingSpellLapse = null;
     interactionState.pendingDiscardSelection = null;
+  }
+  if (interactionState.pendingSpellElementalDominion) {
+    try { window.__spells?.cancelElementalDominionSelection?.(); } catch {}
+    interactionState.pendingSpellElementalDominion = null;
   }
   clearHighlights();
   clearPlacementHighlights();

--- a/src/spells/handlers.js
+++ b/src/spells/handlers.js
@@ -5,6 +5,7 @@
 
 import { spendAndDiscardSpell, offerSpellToEye, burnSpellCard } from '../ui/spellUtils.js';
 import { getCtx } from '../scene/context.js';
+import { normalizeElementName } from '../core/utils/elements.js';
 import {
   interactionState,
   resetCardSelection,
@@ -39,12 +40,516 @@ function getTileMeshAt(r, c) {
   return tileMeshes[r][c] || null;
 }
 
+function waitMs(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, Math.max(0, ms || 0));
+  });
+}
+
 function spawnHpShiftText(r, c, delta) {
   if (!delta) return;
   const mesh = getUnitMeshAt(r, c);
   if (!mesh) return;
   const color = delta > 0 ? '#22c55e' : '#ef4444';
   try { window.__fx.spawnDamageText(mesh, `${delta > 0 ? '+' : ''}${delta}`, color); } catch {}
+}
+
+function playDominionMagicDamageFx(events) {
+  if (!Array.isArray(events) || !events.length) return;
+  for (const entry of events) {
+    if (!entry || !(entry.damage > 0)) continue;
+    const { mesh, r, c, damage } = entry;
+    if (mesh) {
+      try { window.__fx?.shakeMesh?.(mesh, 6, 0.16); } catch {}
+      try {
+        const origin = typeof mesh.position?.clone === 'function'
+          ? mesh.position.clone()
+          : (mesh.position ? { ...mesh.position } : null);
+        if (origin) {
+          if (typeof origin.y === 'number') origin.y += 0.4;
+          window.__fx?.magicBurst?.(origin);
+        }
+      } catch {}
+    }
+    spawnHpShiftText(r, c, -damage);
+  }
+}
+
+// Русские подписи для стихий — используются в сообщениях
+const ELEMENT_TEXT = {
+  FIRE: { field: 'огненное', elementName: 'Огонь' },
+  WATER: { field: 'водное', elementName: 'Вода' },
+  EARTH: { field: 'земляное', elementName: 'Земля' },
+  FOREST: { field: 'лесное', elementName: 'Лес' },
+  BIOLITH: { field: 'биолитовое', elementName: 'Биолит' },
+};
+
+// Утилита для доступа к актуальному состоянию игры
+function getState() {
+  if (typeof gameState !== 'undefined' && gameState) return gameState;
+  if (typeof window !== 'undefined' && window.gameState) return window.gameState;
+  return null;
+}
+
+function normalizeElement(value) {
+  const normalized = normalizeElementName(value);
+  return normalized || null;
+}
+
+function getElementMeta(element) {
+  const key = normalizeElement(element);
+  if (!key || !ELEMENT_TEXT[key]) {
+    return { key: null, field: 'подходящее', elementName: 'Неизвестная стихия' };
+  }
+  return { key, ...ELEMENT_TEXT[key] };
+}
+
+function countFieldsByElement(state, elementKey) {
+  if (!state?.board) return 0;
+  const target = normalizeElement(elementKey);
+  if (!target) return 0;
+  let total = 0;
+  for (let r = 0; r < state.board.length; r += 1) {
+    const row = state.board[r];
+    if (!Array.isArray(row)) continue;
+    for (let c = 0; c < row.length; c += 1) {
+      const cell = row[c];
+      const cellElement = normalizeElement(cell?.element);
+      if (cellElement === target) total += 1;
+    }
+  }
+  return total;
+}
+
+function computeDominionArea(center) {
+  if (!center) return [];
+  const { r, c } = center;
+  if (!Number.isInteger(r) || !Number.isInteger(c)) return [];
+  const area = [{ r, c }];
+  const deltas = [
+    { dr: -1, dc: 0 },
+    { dr: 1, dc: 0 },
+    { dr: 0, dc: -1 },
+    { dr: 0, dc: 1 },
+  ];
+  for (const d of deltas) {
+    const nr = r + d.dr;
+    const nc = c + d.dc;
+    if (nr >= 0 && nr < 3 && nc >= 0 && nc < 3) area.push({ r: nr, c: nc });
+  }
+  return area;
+}
+
+function collectDominionTargets(state, area, ownerIdx) {
+  if (!state?.board || !Array.isArray(area)) return [];
+  const uniq = new Set();
+  const targets = [];
+  for (const pos of area) {
+    if (!pos) continue;
+    const { r, c } = pos;
+    if (!Number.isInteger(r) || !Number.isInteger(c)) continue;
+    const cell = state.board?.[r]?.[c];
+    const unit = cell?.unit;
+    if (!unit) continue;
+    if (ownerIdx != null && unit.owner === ownerIdx) continue;
+    const key = `${r},${c}`;
+    if (uniq.has(key)) continue;
+    uniq.add(key);
+    targets.push({ r, c, unit });
+  }
+  return targets;
+}
+
+function collectUnitHandCards(player) {
+  const res = [];
+  if (!player || !Array.isArray(player.hand)) return res;
+  for (let i = 0; i < player.hand.length; i += 1) {
+    const card = player.hand[i];
+    if (!card || card.type !== 'UNIT') continue;
+    res.push({ index: i, tpl: card, element: normalizeElement(card.element) });
+  }
+  return res;
+}
+
+function resolveSpellHandIndex(player, tpl, fallbackIdx) {
+  if (!player || !tpl) return -1;
+  if (Number.isInteger(fallbackIdx) && player.hand?.[fallbackIdx]?.id === tpl.id) {
+    return fallbackIdx;
+  }
+  if (!Array.isArray(player.hand)) return -1;
+  return player.hand.findIndex(card => card && card.id === tpl.id);
+}
+
+function dominionDiscardFilter(cardTpl) {
+  const pending = interactionState.pendingSpellElementalDominion;
+  if (!pending || pending.discards?.length >= pending.requiredCount) return false;
+  if (!cardTpl || cardTpl.type !== 'UNIT') return false;
+  const element = normalizeElement(cardTpl.element);
+  if ((pending.discards?.length || 0) >= pending.requiredCount - 1 && !pending.hasRequired) {
+    return element === pending.requiredElement;
+  }
+  return true;
+}
+
+function updateDominionPrompt(pending) {
+  if (!pending) return;
+  const remaining = Math.max(0, (pending.requiredCount || 0) - (pending.discards?.length || 0));
+  const meta = getElementMeta(pending.requiredElement);
+  let text = `Сбросьте существо (осталось ${remaining}).`;
+  if (!pending.hasRequired && remaining > 0) {
+    text += ` Нужно существо стихии ${meta.elementName}.`;
+  }
+  try { window.__ui?.panels?.showPrompt?.(text, null, false); } catch {}
+}
+
+function restoreDominionSnapshots(pending) {
+  if (!pending?.player) return;
+  const player = pending.player;
+
+  if (Array.isArray(pending.handSnapshot)) {
+    const hand = Array.isArray(player.hand) ? player.hand : (player.hand = []);
+    hand.length = 0;
+    for (const card of pending.handSnapshot) {
+      hand.push(card);
+    }
+  }
+
+  if (pending.graveyardWasArray) {
+    const grave = Array.isArray(player.graveyard) ? player.graveyard : (player.graveyard = []);
+    grave.length = 0;
+    if (Array.isArray(pending.graveyardSnapshot)) {
+      for (const card of pending.graveyardSnapshot) {
+        grave.push(card);
+      }
+    }
+  } else if (player && Object.prototype.hasOwnProperty.call(player, 'graveyard')) {
+    if (Array.isArray(player.graveyard)) {
+      player.graveyard.length = 0;
+    }
+    try { delete player.graveyard; } catch {}
+  }
+
+  pending.discards = [];
+  pending.hasRequired = false;
+}
+
+function startElementalDominionSpell(params, elementKey) {
+  const { tpl, pl, idx, tileMesh, unitMesh, cardMesh } = params;
+  const state = getState();
+  if (!state) {
+    showNotification('Игра не готова к обработке заклинания', 'error');
+    if (cardMesh) returnCardToHand(cardMesh);
+    return;
+  }
+
+  const meta = getElementMeta(elementKey);
+  const r = tileMesh?.userData?.row ?? unitMesh?.userData?.row ?? null;
+  const c = tileMesh?.userData?.col ?? unitMesh?.userData?.col ?? null;
+  if (r == null || c == null) {
+    showNotification('Нужно выбрать поле на арене', 'error');
+    if (cardMesh) returnCardToHand(cardMesh);
+    return;
+  }
+
+  if (tpl.cost > pl.mana) {
+    showNotification('Недостаточно маны', 'error');
+    if (cardMesh) returnCardToHand(cardMesh);
+    return;
+  }
+
+  const cell = state.board?.[r]?.[c];
+  const cellElement = normalizeElement(cell?.element);
+  if (cellElement !== meta.key) {
+    showNotification(`Нужно выбрать ${meta.field} поле`, 'error');
+    if (cardMesh) returnCardToHand(cardMesh);
+    return;
+  }
+
+  const unitCards = collectUnitHandCards(pl);
+  if (unitCards.length < 2) {
+    showNotification('В руке недостаточно существ для сброса', 'error');
+    if (cardMesh) returnCardToHand(cardMesh);
+    return;
+  }
+
+  const hasRequired = unitCards.some(entry => entry.element === meta.key);
+  if (!hasRequired) {
+    showNotification(`В руке нет существа стихии ${meta.elementName}.`, 'error');
+    if (cardMesh) returnCardToHand(cardMesh);
+    return;
+  }
+
+  const playerIndex = Array.isArray(state.players) ? state.players.indexOf(pl) : state.active;
+  const area = computeDominionArea({ r, c });
+  if (area.length) highlightTiles(area);
+
+  const handSnapshot = Array.isArray(pl.hand) ? pl.hand.slice() : [];
+  const graveyardWasArray = Array.isArray(pl.graveyard);
+  const graveyardSnapshot = graveyardWasArray ? pl.graveyard.slice() : null;
+
+  interactionState.pendingSpellElementalDominion = {
+    spellId: tpl.id,
+    tpl,
+    player: pl,
+    playerIndex,
+    handIndex: idx,
+    target: { r, c },
+    requiredElement: meta.key,
+    requiredCount: 2,
+    discards: [],
+    hasRequired: false,
+    tileMesh: tileMesh || getTileMeshAt(r, c) || null,
+    cardMesh: cardMesh || null,
+    area,
+    handSnapshot,
+    graveyardSnapshot,
+    graveyardWasArray,
+  };
+
+  interactionState.pendingDiscardSelection = {
+    requiredType: 'UNIT',
+    keepAfterPick: true,
+    forced: true,
+    filter: cardTpl => dominionDiscardFilter(cardTpl),
+    invalidMessage: `Нужно выбрать подходящее существо для жертвы стихии ${meta.elementName}.`,
+    onPicked: handIdx => handleDominionDiscard(handIdx),
+  };
+
+  if (cardMesh) returnCardToHand(cardMesh);
+  interactionState.spellDragHandled = true;
+
+  updateDominionPrompt(interactionState.pendingSpellElementalDominion);
+  addLog(`${tpl.name}: подготовьте жертву стихии ${meta.elementName}.`);
+  try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+}
+
+function handleDominionDiscard(handIdx) {
+  const pending = interactionState.pendingSpellElementalDominion;
+  if (!pending) return;
+  const player = pending.player;
+  if (!player) return;
+
+  const chosenTpl = discardHandCard(player, handIdx);
+  if (!chosenTpl) return;
+
+  const normalized = normalizeElement(chosenTpl.element);
+  if (normalized === pending.requiredElement) pending.hasRequired = true;
+  pending.discards.push({ tpl: chosenTpl, element: normalized });
+
+  const creatureName = chosenTpl.name || 'Существо';
+  addLog(`${pending.tpl.name}: ${creatureName} отправлено в сброс.`);
+
+  if (pending.discards.length >= pending.requiredCount) {
+    interactionState.pendingDiscardSelection = null;
+    finalizeDominionSpell();
+    return;
+  }
+
+  updateDominionPrompt(pending);
+}
+
+function finalizeDominionSpell() {
+  const pending = interactionState.pendingSpellElementalDominion;
+  if (!pending) return;
+
+  interactionState.pendingDiscardSelection = null;
+  clearHighlights();
+  try { window.__ui?.panels?.hidePrompt?.(); } catch {}
+
+  const state = getState();
+  if (!state) {
+    cancelElementalDominionSelection();
+    return;
+  }
+
+  const meta = getElementMeta(pending.requiredElement);
+  const area = Array.isArray(pending.area) && pending.area.length
+    ? pending.area
+    : computeDominionArea(pending.target);
+  const ownerIdx = pending.playerIndex != null ? pending.playerIndex : state.active;
+  const fieldCount = countFieldsByElement(state, pending.requiredElement);
+  const damage = fieldCount;
+  const targets = collectDominionTargets(state, area, ownerIdx);
+  const deaths = [];
+  const fxEvents = [];
+
+  let summary = '';
+  if (fieldCount <= 0) {
+    summary = `${pending.tpl.name}: подходящих полей стихии ${meta.elementName} нет.`;
+  } else if (!targets.length) {
+    summary = `${pending.tpl.name}: врагов рядом нет, урон ${damage} не нанесён (полей стихии ${meta.elementName}: ${fieldCount}).`;
+  } else {
+    summary = `${pending.tpl.name}: магический урон ${damage} наносится по ${targets.length} целям (число полей стихии ${meta.elementName}: ${fieldCount}).`;
+  }
+  if (summary) addLog(summary);
+
+  if (damage > 0 && targets.length) {
+    for (const target of targets) {
+      const cell = state.board?.[target.r]?.[target.c];
+      const unitRef = cell?.unit;
+      if (!unitRef) continue;
+      const tplUnit = CARDS?.[unitRef.tplId];
+      if (!tplUnit) continue;
+      const before = Number.isFinite(unitRef.currentHP)
+        ? unitRef.currentHP
+        : Number(tplUnit.hp) || 0;
+      const after = Math.max(0, before - damage);
+      if (after === before) continue;
+      unitRef.currentHP = after;
+
+      const mesh = getUnitMeshAt(target.r, target.c);
+      fxEvents.push({ mesh, r: target.r, c: target.c, damage });
+
+      const unitName = tplUnit.name || 'Существо';
+      addLog(`${unitName} получает ${damage} маг. урона (HP ${before}→${after}).`);
+
+      if (after <= 0) {
+        deaths.push({
+          r: target.r,
+          c: target.c,
+          owner: unitRef.owner,
+          tplId: unitRef.tplId,
+          uid: unitRef.uid ?? null,
+          element: state.board?.[target.r]?.[target.c]?.element || null,
+        });
+      }
+    }
+  }
+
+  if (fxEvents.length) {
+    playDominionMagicDamageFx(fxEvents);
+  }
+
+  const tileMesh = pending.tileMesh || getTileMeshAt(pending.target?.r, pending.target?.c) || null;
+  burnSpellCard(pending.tpl, tileMesh, pending.cardMesh || null);
+
+  const spellIdx = resolveSpellHandIndex(pending.player, pending.tpl, pending.handIndex);
+  if (spellIdx >= 0) {
+    spendAndDiscardSpell(pending.player, spellIdx);
+  } else {
+    showNotification('Карта заклинания уже недоступна', 'error');
+  }
+
+  updateHand();
+
+  refreshPossessionsUI(state);
+  updateUnits();
+  updateUI();
+  if (deaths.length) {
+    processSpellDeaths(deaths);
+  }
+
+  try {
+    if (typeof window !== 'undefined') {
+      window.schedulePush?.('spell-elemental-dominion', { force: true });
+    }
+  } catch {}
+
+  interactionState.pendingSpellElementalDominion = null;
+  try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+}
+
+function cancelElementalDominionSelection() {
+  const pending = interactionState.pendingSpellElementalDominion;
+  if (pending) {
+    restoreDominionSnapshots(pending);
+  }
+  interactionState.pendingDiscardSelection = null;
+  interactionState.pendingSpellElementalDominion = null;
+  clearHighlights();
+  try { window.__ui?.panels?.hidePrompt?.(); } catch {}
+  try { window.__ui?.cancelButton?.refreshCancelButton?.(); } catch {}
+
+  if (pending) {
+    const state = getState();
+    if (state) {
+      try { refreshPossessionsUI(state); } catch {}
+    }
+  }
+
+  try { updateHand(); } catch {}
+  try { updateUI(); } catch {}
+}
+
+function createDominionSpellHandler(elementKey) {
+  return {
+    onBoard(ctx) {
+      startElementalDominionSpell(ctx, elementKey);
+    },
+  };
+}
+
+const RIOTOUS_ORDER = [
+  { r: 1, c: 1 },
+  { r: 0, c: 1 },
+  { r: 0, c: 2 },
+  { r: 1, c: 2 },
+  { r: 2, c: 2 },
+  { r: 2, c: 1 },
+  { r: 2, c: 0 },
+  { r: 1, c: 0 },
+  { r: 0, c: 0 },
+];
+
+async function runRiotousBattles(order = RIOTOUS_ORDER) {
+  const battleFn = (typeof window !== 'undefined') ? window.performBattleSequence : null;
+  if (typeof battleFn !== 'function') {
+    showNotification('Боевой алгоритм недоступен', 'error');
+    return false;
+  }
+
+  for (const pos of order) {
+    const state = getState();
+    if (!state?.board) continue;
+    const cell = state.board?.[pos.r]?.[pos.c];
+    const unitRef = cell?.unit;
+    if (!unitRef) continue;
+    if (typeof unitRef.lastAttackTurn === 'number' && unitRef.lastAttackTurn === state.turn) {
+      unitRef.lastAttackTurn = state.turn - 1;
+    }
+    try {
+      await battleFn(pos.r, pos.c, true, { forced: true, auto: true });
+    } catch (err) {
+      console.warn('[spell] Ошибка принудительного боя Riotous Impunity:', err);
+    }
+  }
+  return true;
+}
+
+async function waitForRiotousResolution({ minDelayMs = 1200, maxDelayMs = 3200, pollMs = 120 } = {}) {
+  const start = Date.now();
+  const w = (typeof window !== 'undefined') ? window : null;
+
+  const isSplashActive = () => {
+    if (!w) return false;
+    try {
+      const bannerState = w.__ui?.banner?.getState?.();
+      if (bannerState && bannerState._splashActive) return true;
+    } catch {}
+    return !!w?.splashActive;
+  };
+
+  const isInputBusy = () => {
+    if (!w) return false;
+    const locked = typeof w.isInputLocked === 'function' ? w.isInputLocked() : false;
+    if (locked) return true;
+    if (w.__endTurnInProgress) return true;
+    const battleQueueBusy = !!w.__battleQueueActive;
+    return battleQueueBusy;
+  };
+
+  while (Date.now() - start < maxDelayMs) {
+    const elapsed = Date.now() - start;
+    if (elapsed >= minDelayMs && !isSplashActive() && !isInputBusy()) {
+      break;
+    }
+    await waitMs(pollMs);
+  }
+
+  const total = Date.now() - start;
+  if (total < minDelayMs) {
+    await waitMs(minDelayMs - total);
+  }
 }
 
 function performFieldquakeAcrossBoard(state, positions, opts = {}) {
@@ -912,6 +1417,11 @@ export function handlePendingBoardClick({ unitMesh = null, tileMesh = null } = {
 }
 
 export const handlers = {
+  SPELL_SCIONDAR_INFERNO: createDominionSpellHandler('FIRE'),
+  SPELL_ICE_FLOOD_OF_OKUNADA: createDominionSpellHandler('WATER'),
+  SPELL_FIST_OF_VERZAR: createDominionSpellHandler('EARTH'),
+  SPELL_WRATHFUL_WINDS_OF_JUNO: createDominionSpellHandler('FOREST'),
+  SPELL_BLINDING_SKIES: createDominionSpellHandler('BIOLITH'),
   SPELL_BEGUILING_FOG: {
     requiresUnitTarget: true,
     onUnit({ cardMesh, unitMesh, tpl }) {
@@ -1571,8 +2081,67 @@ export const handlers = {
     },
   },
 
+  SPELL_SCIONS_RIOTOUS_IMPUNITY: {
+    async onCast({ tpl, pl, idx, cardMesh }) {
+      const state = getState();
+      if (!state) {
+        showNotification('Игра не готова к обработке заклинания', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      if (tpl.cost > pl.mana) {
+        showNotification('Недостаточно маны', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const spellIdx = resolveSpellHandIndex(pl, tpl, idx);
+      if (spellIdx < 0) {
+        showNotification('Карта заклинания уже недоступна', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      const effectTile = getTileMeshAt(1, 1) || null;
+      burnSpellCard(tpl, effectTile, cardMesh || null);
+      spendAndDiscardSpell(pl, spellIdx);
+      resetCardSelection();
+      updateHand();
+
+      addLog(`${tpl.name}: существа начинают поединки по кругу.`);
+      await runRiotousBattles();
+      await waitForRiotousResolution();
+
+      const latest = getState();
+      if (latest) refreshPossessionsUI(latest);
+      updateUnits();
+      updateUI();
+      try {
+        if (typeof window !== 'undefined') {
+          window.schedulePush?.('spell-riotous-impunity', { force: true });
+        }
+      } catch {}
+      requestAutoEndTurn();
+      addLog(`${tpl.name}: ход завершается.`);
+    },
+  },
+
   SPELL_SEER_VIZAKS_CALAMITY: {
     onCast({ tpl, pl, idx, cardMesh }) {
+      const stateCheck = getState();
+      if (!stateCheck) {
+        showNotification('Игра не готова к обработке заклинания', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
+      if (tpl.cost > pl.mana) {
+        showNotification('Недостаточно маны', 'error');
+        if (cardMesh) returnCardToHand(cardMesh);
+        return;
+      }
+
       const positions = [];
       for (let r = 0; r < 3; r += 1) {
         for (let c = 0; c < 3; c += 1) {
@@ -1601,15 +2170,27 @@ export const handlers = {
       }
 
       burnSpellCard(tpl, null, cardMesh);
-      offerSpellToEye(pl, idx);
+      const spellIdx = resolveSpellHandIndex(pl, tpl, idx);
+      if (spellIdx < 0) {
+        showNotification('Карта заклинания уже недоступна', 'error');
+        resetCardSelection();
+        updateUI();
+        return;
+      }
+
+      spendAndDiscardSpell(pl, spellIdx);
       resetCardSelection();
       updateHand();
       updateUI();
-      addLog(`${tpl.name}: карта принесена Оку, ход завершается.`);
 
-      setTimeout(() => {
-        try { window.__ui?.actions?.endTurn?.(); } catch {}
-      }, 350);
+      try {
+        if (typeof window !== 'undefined') {
+          window.schedulePush?.('spell-vizaks-calamity', { force: true });
+        }
+      } catch {}
+
+      requestAutoEndTurn();
+      addLog(`${tpl.name}: ход завершается.`);
     },
   },
 
@@ -1726,6 +2307,7 @@ const api = {
   handlePendingBoardClick,
   cancelFieldExchangeSelection,
   cancelMesmerLapseSelection,
+  cancelElementalDominionSelection,
 };
 try {
   if (typeof window !== 'undefined') {

--- a/src/ui/cancelButton.js
+++ b/src/ui/cancelButton.js
@@ -65,6 +65,7 @@ export function refreshCancelButton() {
     || interactionState.pendingSpellOrientation
     || interactionState.pendingSpellFieldExchange
     || interactionState.pendingSpellLapse
+    || interactionState.pendingSpellElementalDominion
     || interactionState.pendingDiscardSelection
     || interactionState.selectedCard;
   btn.classList.toggle('hidden', !vis);
@@ -91,6 +92,8 @@ export function setupCancelButton() {
         window.__spells?.cancelMesmerLapseSelection?.();
         interactionState.pendingSpellLapse = null;
         interactionState.pendingDiscardSelection = null;
+      } else if (interactionState.pendingSpellElementalDominion) {
+        window.__spells?.cancelElementalDominionSelection?.();
       } else if (interactionState.selectedCard) {
         returnCardToHand(interactionState.selectedCard);
         interactionState.selectedCard = null;


### PR DESCRIPTION
## Summary
- add a battle-settlement wait helper so Riotous Impunity finishes animations and state broadcasts before ending the turn
- trigger spell state resync after the wait to keep both players in sync
- wire Dominion ritual cancellation into the cancel button so mana and cards roll back properly

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68df8948f1f48330be4c7eee30c76e66