### PR TITLE
Restore card templates when starting online matches

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,25 +366,76 @@
         // Взаимодействия с 3D-сценой вынесены в модуль src/scene/interactions.js
     
     async function initGame() {
-      const decks = window.DECKS || [];
+      const decks = Array.isArray(window.DECKS) ? window.DECKS : [];
+      const matchDecks = (typeof window !== 'undefined' && window.__matchDecks)
+        ? window.__matchDecks
+        : null;
+      const isOnlineMatch = typeof window !== 'undefined' && !!window.NET_ACTIVE;
+      const toCardIds = (list) => Array.isArray(list)
+        ? list.map(card => {
+            if (typeof card === 'string') return card;
+            if (card && typeof card === 'object' && typeof card.id === 'string') return card.id;
+            if (card && typeof card === 'object' && typeof card.cardId === 'string') return card.cardId;
+            return null;
+          }).filter(Boolean)
+        : [];
+      const toCardData = (list) => {
+        const cardsDb = (typeof window !== 'undefined' && window.CARDS) || {};
+        if (!Array.isArray(list)) return [];
+        return list
+          .map(card => {
+            if (!card) return null;
+            if (typeof card === 'object' && card.type) return card;
+            if (typeof card === 'object' && typeof card.id === 'string' && cardsDb[card.id]) {
+              return cardsDb[card.id];
+            }
+            if (typeof card === 'object' && typeof card.cardId === 'string' && cardsDb[card.cardId]) {
+              return cardsDb[card.cardId];
+            }
+            if (typeof card === 'string' && cardsDb[card]) return cardsDb[card];
+            return null;
+          })
+          .filter(Boolean);
+      };
+
       let chosen = window.__selectedDeckObj;
       if (!chosen) {
         try {
           const id = localStorage.getItem('selectedDeckId');
-          chosen = decks.find(d => d.id === id) || decks[0];
+          chosen = decks.find(d => d && d.id === id) || decks[0];
         } catch {
           chosen = decks[0];
         }
       }
-      const myDeck = chosen ? chosen.cards : (decks[0]?.cards || []);
-      let oppDeck = myDeck;
-      try {
-        const oppId = window.__opponentDeckId;
-        if (oppId) {
-          const found = decks.find(d => d.id === oppId);
-          if (found) oppDeck = found.cards;
-        }
-      } catch {}
+
+      let myDeckCardIds = isOnlineMatch && Array.isArray(matchDecks?.my?.cards) && matchDecks.my.cards.length
+        ? [...matchDecks.my.cards]
+        : toCardIds(chosen?.cards);
+      if (!myDeckCardIds.length) {
+        myDeckCardIds = toCardIds(decks[0]?.cards || []);
+      }
+
+      let oppDeckCardIds = isOnlineMatch && Array.isArray(matchDecks?.opponent?.cards) && matchDecks.opponent.cards.length
+        ? [...matchDecks.opponent.cards]
+        : [];
+      if (!oppDeckCardIds.length) {
+        oppDeckCardIds = myDeckCardIds.slice();
+        try {
+          const oppId = window.__opponentDeckId;
+          if (oppId) {
+            const found = decks.find(d => d && d.id === oppId);
+            if (found) oppDeckCardIds = toCardIds(found.cards);
+          }
+        } catch {}
+      }
+      let myDeckCards = toCardData(myDeckCardIds);
+      if (!myDeckCards.length) {
+        myDeckCards = toCardData(toCardIds(decks[0]?.cards || []));
+      }
+      let oppDeckCards = toCardData(oppDeckCardIds);
+      if (!oppDeckCards.length) {
+        oppDeckCards = toCardData(myDeckCardIds);
+      }
       const fallbackSeatName = (seat) => `Player ${seat + 1}`;
       const matchPlayersSnapshot = Array.isArray(window.__matchPlayers) ? window.__matchPlayers : [];
       let playerProfiles;
@@ -418,7 +469,7 @@
       }
       try { window.__net?.setMatchPlayers?.(playerProfiles); } catch {}
       try { window.__matchPlayers = playerProfiles.map(p => ({ ...p })); } catch {}
-      gameState = startGame(myDeck, oppDeck, { players: playerProfiles });
+      gameState = startGame(myDeckCards, oppDeckCards, { players: playerProfiles });
       try { window.applyGameState(gameState); } catch {}
       
       // Сразу строим сцену и мета-объекты, без задержки появления

--- a/src/net/client.js
+++ b/src/net/client.js
@@ -49,6 +49,8 @@ import { playFieldquakeFx } from '../scene/fieldquakeFx.js';
   }));
   try { window.__matchPlayers = matchPlayers.map(p => ({ ...p })); } catch {}
 
+  let currentMatchDecks = { seat: null, decks: [], my: { id: null, name: '', description: '', cards: [] }, opponent: { id: null, name: '', description: '', cards: [] } };
+
   function sanitizePlayerEntry(entry, index) {
     const fallback = FALLBACK_SEAT_NAMES[index] || `Player ${index + 1}`;
     if (!entry || typeof entry !== 'object') {
@@ -105,7 +107,86 @@ import { playFieldquakeFx } from '../scene/fieldquakeFx.js';
 
   function resetMatchPlayers() {
     setMatchPlayers([]);
+    currentMatchDecks = { seat: null, decks: [], my: { id: null, name: '', description: '', cards: [] }, opponent: { id: null, name: '', description: '', cards: [] } };
+    updateMatchDecksOnWindow();
   }
+
+  function extractCardId(card) {
+    if (typeof card === 'string') return card;
+    if (card && typeof card === 'object') {
+      if (typeof card.id === 'string') return card.id;
+      if (typeof card.cardId === 'string') return card.cardId;
+    }
+    return null;
+  }
+
+  function normalizeDeckInfo(entry) {
+    if (!entry) return { id: null, name: '', description: '', cards: [] };
+    if (Array.isArray(entry)) {
+      return {
+        id: null,
+        name: '',
+        description: '',
+        cards: entry.map(extractCardId).filter(Boolean),
+      };
+    }
+    if (typeof entry === 'object') {
+      const id = typeof entry.id === 'string' ? entry.id : null;
+      const name = typeof entry.name === 'string' ? entry.name : '';
+      const description = typeof entry.description === 'string' ? entry.description : '';
+      const cardsSource = Array.isArray(entry.cards) ? entry.cards : [];
+      const cards = cardsSource.map(extractCardId).filter(Boolean);
+      return { id, name, description, cards };
+    }
+    return { id: null, name: '', description: '', cards: [] };
+  }
+
+  function cloneDeckInfo(info) {
+    if (!info || typeof info !== 'object') {
+      return { id: null, name: '', description: '', cards: [] };
+    }
+    return {
+      id: typeof info.id === 'string' ? info.id : null,
+      name: typeof info.name === 'string' ? info.name : '',
+      description: typeof info.description === 'string' ? info.description : '',
+      cards: Array.isArray(info.cards) ? info.cards.slice() : [],
+    };
+  }
+
+  // Возвращает массив шаблонов карт по списку идентификаторов/объектов
+  function resolveDeckCards(cardsSource) {
+    const cardsDb = (typeof window !== 'undefined' && window.CARDS) || {};
+    if (!Array.isArray(cardsSource)) return [];
+    return cardsSource
+      .map(card => {
+        if (!card) return null;
+        if (typeof card === 'object' && card.type) return card;
+        if (typeof card === 'object' && typeof card.id === 'string' && cardsDb[card.id]) {
+          return cardsDb[card.id];
+        }
+        if (typeof card === 'object' && typeof card.cardId === 'string' && cardsDb[card.cardId]) {
+          return cardsDb[card.cardId];
+        }
+        if (typeof card === 'string' && cardsDb[card]) {
+          return cardsDb[card];
+        }
+        return null;
+      })
+      .filter(Boolean);
+  }
+
+  function updateMatchDecksOnWindow() {
+    try {
+      window.__matchDecks = {
+        seat: currentMatchDecks.seat,
+        decks: currentMatchDecks.decks.map(cloneDeckInfo),
+        my: cloneDeckInfo(currentMatchDecks.my),
+        opponent: cloneDeckInfo(currentMatchDecks.opponent),
+      };
+    } catch {}
+  }
+
+  updateMatchDecksOnWindow();
 
   // ===== 3) Queue modal + countdown =====
   let queueModal=null, startModal=null;
@@ -916,24 +997,61 @@ import { playFieldquakeFx } from '../scene/fieldquakeFx.js';
       hideQueueModal();
     }
   });
-  socket.on('matchFound', ({ matchId, seat, decks, players })=>{
+  socket.on('matchFound', ({ matchId, seat, decks, deckLists, players })=>{
     hideQueueModal();
     setMatchPlayers(players);
     try { updateIndicator(); } catch {}
     try {
-      const all = window.DECKS || [];
-      if (Array.isArray(decks) && decks.length === 2) {
-        const myId = decks[seat];
-        const oppId = decks[1 - seat];
-        window.__opponentDeckId = oppId;
-        const myDeck = all.find(d => d.id === myId) || all[0];
-        window.__selectedDeckObj = myDeck;
+      const seatIndex = seat === 1 ? 1 : 0;
+      const opponentIndex = seatIndex === 0 ? 1 : 0;
+      const providedLists = Array.isArray(deckLists) ? deckLists : [];
+      const announcedDecks = Array.isArray(decks) ? decks : [];
+      const localDecks = Array.isArray(window.DECKS) ? window.DECKS : [];
+
+      const normalizedDecks = [0, 1].map(index => {
+        const provided = providedLists[index];
+        const normalized = normalizeDeckInfo(provided);
+        if (normalized.cards.length) return normalized;
+        const deckId = announcedDecks[index];
+        if (!deckId) return normalized;
+        const local = localDecks.find(d => d && d.id === deckId);
+        return local ? normalizeDeckInfo(local) : normalized;
+      });
+
+      currentMatchDecks = {
+        seat: seatIndex,
+        decks: normalizedDecks.map(cloneDeckInfo),
+        my: cloneDeckInfo(normalizedDecks[seatIndex]),
+        opponent: cloneDeckInfo(normalizedDecks[opponentIndex]),
+      };
+      updateMatchDecksOnWindow();
+
+      const myId = announcedDecks[seatIndex] || currentMatchDecks.my.id;
+      const oppId = announcedDecks[opponentIndex] || currentMatchDecks.opponent.id;
+      if (oppId) window.__opponentDeckId = oppId;
+
+      const resolvedMyCards = resolveDeckCards(normalizedDecks[seatIndex]?.cards);
+      const preferredLocal = localDecks.find(d => d && d.id === myId);
+      if (preferredLocal) {
+        window.__selectedDeckObj = {
+          ...preferredLocal,
+          cards: resolvedMyCards.length ? resolvedMyCards : resolveDeckCards(preferredLocal.cards),
+        };
+      } else if (resolvedMyCards.length) {
+        window.__selectedDeckObj = {
+          id: currentMatchDecks.my.id || myId || null,
+          name: currentMatchDecks.my.name || 'Selected deck',
+          description: currentMatchDecks.my.description || '',
+          cards: resolvedMyCards,
+        };
+      } else if (localDecks.length) {
+        window.__selectedDeckObj = localDecks[0];
       }
     } catch {}
     console.log('[MATCH] Match found, setting MY_SEAT to:', seat, 'matchId:', matchId, 'decks:', decks, 'players:', players);
     // Логирование для отладки
     try { (window.socket || socket).emit('debugLog', { event: 'matchFound_received', seat, matchId, decks }); } catch {}
-    
+
     // Полный сброс локального состояния предыдущего матча перед стартом нового
     try { if (window.__pendingBattleFlushTimer) { clearInterval(window.__pendingBattleFlushTimer); window.__pendingBattleFlushTimer = null; } } catch {}
     try { PENDING_BATTLE_ANIMS = []; PENDING_RETALIATIONS = []; } catch {}


### PR DESCRIPTION
## Summary
- resolve server-provided deck card identifiers into full card templates on the client
- ensure selected deck snapshots keep card data when matchmaking assigns them
- fall back to local card templates when resolving identifiers fails

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0b322696883308cd604b8e121b5b6