### PR TITLE
Add check splash alert, auto end-turn timer, and card return fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,13 @@
 
     <!-- Левый нижний угол: отладочные действия -->
     <div id="corner-left" class="ui-panel fixed left-4 bottom-24 z-30">
-      <button id="debug-mana-btn" class="overlay-panel px-3 py-1.5 text-xs bg-emerald-700 hover:bg-emerald-600 transition-colors">+10 маны всем</button>
+      <div class="flex flex-col gap-2">
+        <button id="debug-mana-btn" class="overlay-panel px-3 py-1.5 text-xs bg-emerald-700 hover:bg-emerald-600 transition-colors">+10 маны всем</button>
+        <label id="auto-turn-toggle-wrap" class="overlay-panel timer-toggle px-3 py-1.5 text-xs bg-slate-700/80 hover:bg-slate-700 transition-colors cursor-pointer">
+          <input type="checkbox" id="auto-turn-toggle" class="timer-toggle-input" checked>
+          <span>Timer on/off</span>
+        </label>
+      </div>
     </div>
 
     <!-- Правый нижний угол: сервисные кнопки -->
@@ -141,6 +147,7 @@
 
     <!-- Баннеры: Turn и Battle -->
     <div id="turn-banner" class="banner fixed inset-0 hidden items-center justify-center z-40"></div>
+    <div id="check-banner" class="banner fixed inset-0 hidden items-center justify-center z-40"></div>
     <div id="battle-banner" class="banner fixed inset-0 hidden items-center justify-center z-40">
       <div class="battlePop text-5xl font-extrabold bg-gradient-to-br from-red-600/80 to-yellow-500/80 px-10 py-5 rounded-3xl shadow-2xl ring-4 ring-yellow-400/40">BATTLE</div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -50,6 +50,8 @@ import * as CancelButton from './ui/cancelButton.js';
 import { initDebugControls } from './ui/debugControls.js';
 import { initDiscardManager, syncWithState as syncDiscardManager } from './ui/discardManager.js';
 import { initAuthScreen } from './ui/authScreen.js';
+import * as CheckAlert from './ui/checkAlert.js';
+import * as TurnTimerAuto from './ui/turnTimerAuto.js';
 import { initSessionStore, onSessionChange, getStateSnapshot } from './auth/sessionStore.js';
 import { playFieldquakeFx, playFieldquakeFxBatch } from './scene/fieldquakeFx.js';
 
@@ -243,6 +245,8 @@ try {
   window.__ui.inputLock = InputLock;
   window.__ui.summonLock = SummonLock;
   window.__ui.cancelButton = CancelButton;
+  window.__ui.checkAlert = CheckAlert;
+  window.__ui.turnTimerAuto = TurnTimerAuto;
   window.__ui.deckSelect = DeckSelect;
   window.__ui.discardManager = window.__ui.discardManager || { initDiscardManager, syncWithState: syncDiscardManager };
   window.__ui.deckBuilder = DeckBuilder;
@@ -270,4 +274,5 @@ try { UISync.attachSocketUIRefresh(); if (typeof window !== 'undefined') { windo
 
 try { initDebugControls(); } catch {}
 try { initDiscardManager(); } catch {}
+try { TurnTimerAuto.initAutoTurnTimer(); } catch {}
 

--- a/src/ui/checkAlert.js
+++ b/src/ui/checkAlert.js
@@ -1,0 +1,95 @@
+// Координатор оповещений "CHECK": запускает заставку и подсветку панелей
+import { showCheckSplash } from './checkSplash.js';
+
+const CONTROL_WARNING_CLASS = 'control-warning';
+const _warningState = [false, false];
+const _controlCounts = [0, 0];
+let _lastTriggerTs = 0;
+const MIN_TRIGGER_INTERVAL = 400; // мс
+
+function getControlElement(playerIndex) {
+  if (typeof document === 'undefined') return null;
+  return document.getElementById(`control-info-${playerIndex}`);
+}
+
+function normalizePlayerName(playerIndex, fallback) {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const gs = window.gameState;
+    const raw = gs?.players?.[playerIndex]?.name;
+    if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  } catch {}
+  return fallback;
+}
+
+function applyWarning(playerIndex, enabled) {
+  if (playerIndex !== 0 && playerIndex !== 1) return;
+  _warningState[playerIndex] = !!enabled;
+  const el = getControlElement(playerIndex);
+  if (el) {
+    el.classList.toggle(CONTROL_WARNING_CLASS, _warningState[playerIndex]);
+  }
+}
+
+function runSplash(subtitle) {
+  const now = Date.now();
+  if (now - _lastTriggerTs < MIN_TRIGGER_INTERVAL) {
+    _lastTriggerTs = now;
+    return;
+  }
+  _lastTriggerTs = now;
+  try {
+    showCheckSplash({ playerName: subtitle });
+  } catch (err) {
+    console.warn('[checkAlert] Не удалось показать заставку CHECK', err);
+  }
+}
+
+function updateControlCount(playerIndex, rawCount, { allowSplash = false, subtitle } = {}) {
+  if (playerIndex !== 0 && playerIndex !== 1) return;
+  const next = Number.isFinite(rawCount) ? rawCount : 0;
+  const prev = Number.isFinite(_controlCounts[playerIndex]) ? _controlCounts[playerIndex] : 0;
+  _controlCounts[playerIndex] = next;
+
+  const warning = next >= 4;
+  applyWarning(playerIndex, warning);
+
+  if (!allowSplash) return;
+
+  const crossedThreshold = warning && prev < 4;
+  if (!crossedThreshold) return;
+
+  const label = normalizePlayerName(playerIndex, `Игрок ${playerIndex + 1}`);
+  const finalSubtitle = subtitle || `${label}: 4 существа на поле`;
+  runSplash(finalSubtitle);
+}
+
+export function triggerCheck(playerIndex, options = {}) {
+  if (playerIndex !== 0 && playerIndex !== 1) return;
+  const label = normalizePlayerName(playerIndex, `Игрок ${playerIndex + 1}`);
+  const subtitle = options.subtitle || `${label}: 4 существа на поле`;
+  const prev = Number.isFinite(_controlCounts[playerIndex]) ? _controlCounts[playerIndex] : 0;
+  const forcedCount = prev < 4 ? 4 : prev;
+  updateControlCount(playerIndex, forcedCount, { allowSplash: true, subtitle });
+}
+
+export function setControlWarning(playerIndex, enabled) {
+  applyWarning(playerIndex, enabled);
+}
+
+export function syncControlPanels({ counts = [] } = {}) {
+  for (let i = 0; i < 2; i += 1) {
+    updateControlCount(i, counts[i], { allowSplash: true });
+  }
+}
+
+const api = { triggerCheck, syncControlPanels, setControlWarning };
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.checkAlert = api;
+  }
+} catch {}
+
+export default api;

--- a/src/ui/checkSplash.js
+++ b/src/ui/checkSplash.js
@@ -1,0 +1,105 @@
+// Яркая заставка "CHECK" для мгновенного оповещения
+import { refreshInputLockUI } from './inputLock.js';
+
+function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+
+export async function showCheckSplash({ playerName = null } = {}) {
+  const doc = typeof document !== 'undefined' ? document : null;
+  if (!doc) return;
+
+  const banner = doc.getElementById('check-banner');
+  if (!banner) return;
+
+  try {
+    if (typeof window !== 'undefined') {
+      window.splashActive = true;
+    }
+    refreshInputLockUI();
+  } catch {}
+
+  banner.innerHTML = '';
+
+  const wrap = doc.createElement('div');
+  wrap.className = 'check-wrap';
+
+  const glow = doc.createElement('div');
+  glow.className = 'check-glow';
+  wrap.appendChild(glow);
+
+  const frame = doc.createElement('div');
+  frame.className = 'check-frame';
+  wrap.appendChild(frame);
+
+  const title = doc.createElement('div');
+  title.className = 'check-title';
+  title.textContent = 'CHECK';
+  wrap.appendChild(title);
+
+  if (playerName) {
+    const subtitle = doc.createElement('div');
+    subtitle.className = 'check-subtitle';
+    subtitle.textContent = playerName;
+    wrap.appendChild(subtitle);
+  }
+
+  banner.appendChild(wrap);
+  banner.style.display = 'flex';
+  banner.classList.remove('hidden');
+  banner.classList.add('flex');
+
+  const tl = (typeof window !== 'undefined') ? window.gsap?.timeline?.() : null;
+  try {
+    if (tl) {
+      tl.set(wrap, { scale: 0.6, opacity: 0 })
+        .set(frame, { scale: 0.8, opacity: 0 })
+        .set(title, { opacity: 0, letterSpacing: '0.9em' })
+        .fromTo(glow, { opacity: 0 }, { opacity: 0.75, duration: 0.12, ease: 'power2.out' }, 0)
+        .to(frame, { opacity: 0.9, scale: 1, duration: 0.2, ease: 'back.out(2.1)' }, 0.02)
+        .to(wrap, { opacity: 1, scale: 1, duration: 0.22, ease: 'back.out(1.8)' }, 0.04)
+        .to(title, { opacity: 1, letterSpacing: '0.4em', duration: 0.22, ease: 'power2.out' }, 0.06)
+        .to(glow, { opacity: 0.35, duration: 0.32, ease: 'power1.out' }, 0.2)
+        .to(wrap, { opacity: 0, duration: 0.2, ease: 'power2.in' }, 0.92);
+
+      const total = typeof tl.totalDuration === 'function' ? tl.totalDuration() : 0;
+      if (total > 0 && typeof tl.timeScale === 'function') {
+        const desired = 1.0;
+        tl.timeScale(total / desired);
+      }
+
+      await new Promise(resolve => {
+        try {
+          tl.eventCallback('onComplete', () => resolve());
+        } catch {
+          resolve();
+        }
+      });
+    } else {
+      await sleep(1000);
+    }
+  } catch {
+    await sleep(1000);
+  } finally {
+    banner.classList.add('hidden');
+    banner.classList.remove('flex');
+    banner.style.display = 'none';
+    banner.style.opacity = '';
+    banner.innerHTML = '';
+    try {
+      if (typeof window !== 'undefined') {
+        window.splashActive = false;
+      }
+      refreshInputLockUI();
+    } catch {}
+  }
+}
+
+const api = { showCheckSplash };
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.checkSplash = api;
+  }
+} catch {}
+
+export default api;

--- a/src/ui/debugControls.js
+++ b/src/ui/debugControls.js
@@ -1,5 +1,6 @@
 // Простейшие отладочные элементы управления (чистый UI-код)
 import { grantManaToAllPlayers } from '../core/mana.js';
+import { bindToggle as bindTurnTimerToggle } from './turnTimerAuto.js';
 
 let initialized = false;
 
@@ -30,34 +31,41 @@ export function initDebugControls() {
   const setup = () => {
     if (initialized) return;
     const button = document.getElementById('debug-mana-btn');
-    if (!button) return;
+    const toggle = document.getElementById('auto-turn-toggle');
+    if (!button && !toggle) return;
 
-    const handleClick = () => {
-      try {
-        const state = window.gameState;
-        if (!state) return;
-        if (isOnline() && !isActivePlayer(state)) {
-          window.showNotification?.('Сейчас ходит оппонент — бонусная мана недоступна.', 'warning');
-          return;
-        }
-        const result = grantManaToAllPlayers(state, 10);
-        if (!result.entries.length) {
-          window.showNotification?.('Мана уже на максимуме.', 'info');
-          return;
-        }
-        window.addLog?.('DEBUG: оба игрока получают +10 маны.');
-        window.updateUI?.(state);
-        window.updateUnits?.(state);
-        window.updateHand?.(state);
+    if (button) {
+      const handleClick = () => {
         try {
-          window.schedulePush?.('debug-mana', { force: true });
-        } catch {}
-      } catch (err) {
-        console.error('[debugControls] Ошибка применения бонусной маны', err);
-      }
-    };
+          const state = window.gameState;
+          if (!state) return;
+          if (isOnline() && !isActivePlayer(state)) {
+            window.showNotification?.('Сейчас ходит оппонент — бонусная мана недоступна.', 'warning');
+            return;
+          }
+          const result = grantManaToAllPlayers(state, 10);
+          if (!result.entries.length) {
+            window.showNotification?.('Мана уже на максимуме.', 'info');
+            return;
+          }
+          window.addLog?.('DEBUG: оба игрока получают +10 маны.');
+          window.updateUI?.(state);
+          window.updateUnits?.(state);
+          window.updateHand?.(state);
+          try {
+            window.schedulePush?.('debug-mana', { force: true });
+          } catch {}
+        } catch (err) {
+          console.error('[debugControls] Ошибка применения бонусной маны', err);
+        }
+      };
 
-    button.addEventListener('click', handleClick);
+      button.addEventListener('click', handleClick);
+    }
+
+    if (toggle) {
+      bindTurnTimerToggle(toggle);
+    }
     initialized = true;
   };
 

--- a/src/ui/turnTimerAuto.js
+++ b/src/ui/turnTimerAuto.js
@@ -1,0 +1,114 @@
+// Управление автоматическим завершением хода по таймеру
+import * as TurnTimer from './turnTimer.js';
+import { hasPendingForcedDiscards, requestAutoEndTurn } from '../scene/interactions.js';
+
+const STORAGE_KEY = 'eog3d:autoTurnEnabled';
+let _autoEnabled = true;
+let _toggleEl = null;
+let _initialized = false;
+
+function loadSetting() {
+  if (typeof window === 'undefined') return true;
+  try {
+    const raw = window.localStorage?.getItem(STORAGE_KEY);
+    if (raw === '0') return false;
+    if (raw === '1') return true;
+  } catch {}
+  return true;
+}
+
+function persistSetting(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, value ? '1' : '0');
+  } catch {}
+}
+
+function applySetting(value, { silent = false } = {}) {
+  _autoEnabled = !!value;
+  if (typeof window !== 'undefined') {
+    window.__autoTurnTimerEnabled = _autoEnabled;
+  }
+  if (_toggleEl) {
+    _toggleEl.checked = _autoEnabled;
+  }
+  if (!silent && typeof window !== 'undefined') {
+    const text = _autoEnabled ? 'Автопереход по таймеру включен' : 'Автопереход по таймеру отключен';
+    window.__ui?.notifications?.show(text, 'info');
+  }
+  persistSetting(_autoEnabled);
+}
+
+function isMyTurn() {
+  if (typeof window === 'undefined') return true;
+  const state = window.gameState;
+  if (!state) return false;
+  if (typeof window.MY_SEAT === 'number') {
+    return state.active === window.MY_SEAT;
+  }
+  return true;
+}
+
+function handleTimerExpire() {
+  if (!_autoEnabled) return;
+  if (typeof window === 'undefined') return;
+  const state = window.gameState;
+  if (!state || state.winner !== null) return;
+  if (!isMyTurn()) return;
+  if (window.__endTurnInProgress) return;
+  if (hasPendingForcedDiscards()) {
+    window.__ui?.notifications?.show('Время вышло, завершите обязательные действия.', 'warning');
+    return;
+  }
+  const seconds = typeof TurnTimer.getSeconds === 'function'
+    ? TurnTimer.getSeconds()
+    : (typeof window.__turnTimerSeconds === 'number' ? window.__turnTimerSeconds : 0);
+  if (seconds > 0) return;
+
+  window.__ui?.notifications?.show('Время вышло: ход завершён автоматически.', 'info');
+  try {
+    requestAutoEndTurn();
+  } catch (err) {
+    console.warn('[turnTimerAuto] Не удалось инициировать завершение хода', err);
+  }
+}
+
+export function bindToggle(element) {
+  _toggleEl = element || null;
+  if (!_toggleEl) return;
+  _toggleEl.checked = _autoEnabled;
+  _toggleEl.addEventListener('change', () => {
+    applySetting(_toggleEl.checked);
+  });
+}
+
+export function setAutoEnabled(value) {
+  applySetting(value);
+}
+
+export function isAutoEnabled() {
+  return _autoEnabled;
+}
+
+export function initAutoTurnTimer() {
+  if (_initialized) return;
+  _autoEnabled = loadSetting();
+  applySetting(_autoEnabled, { silent: true });
+  try {
+    TurnTimer.onExpire(handleTimerExpire);
+  } catch (err) {
+    console.warn('[turnTimerAuto] Не удалось подключить обработчик истечения таймера', err);
+  }
+  _initialized = true;
+}
+
+const api = { initAutoTurnTimer, bindToggle, isAutoEnabled, setAutoEnabled };
+
+try {
+  if (typeof window !== 'undefined') {
+    window.__ui = window.__ui || {};
+    window.__ui.turnTimerAuto = api;
+  }
+} catch {}
+
+export default api;

--- a/src/ui/update.js
+++ b/src/ui/update.js
@@ -97,6 +97,7 @@ export function updateUI(gameState) {
   const controlB = countControlled(state, 1);
   const ci0 = doc.getElementById('control-info-0'); if (ci0) ci0.textContent = `Контроль: ${controlA}`;
   const ci1 = doc.getElementById('control-info-1'); if (ci1) ci1.textContent = `Контроль: ${controlB}`;
+  try { window.__ui?.checkAlert?.syncControlPanels?.({ counts: [controlA, controlB] }); } catch {}
 
   const playerNames = [
     (typeof state.players?.[0]?.name === 'string' && state.players[0].name.trim()) ? state.players[0].name.trim() : 'Player 1',

--- a/styles/main.css
+++ b/styles/main.css
@@ -105,6 +105,8 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
   transition: left .5s;
 }
 .glossy-btn:hover::after { left: 150%; }
+.timer-toggle { display: inline-flex; align-items: center; gap: 8px; font-weight: 600; letter-spacing: 0.04em; }
+.timer-toggle-input { width: 16px; height: 16px; accent-color: #f97316; cursor: pointer; }
 /* Prompt: кликабельна только панель, остальное кликается сквозь */
 #prompt-panel { pointer-events: none; }
 #prompt-panel .overlay-panel { pointer-events: auto; }
@@ -127,6 +129,18 @@ html, body { height: 100%; margin: 0; overflow: hidden; background: #0f172a; col
 .battle-flash-bg { position: absolute; inset: 0; background: radial-gradient(80% 60% at 50% 50%, rgba(255,255,255,0.08), rgba(0,0,0,0.8)); mix-blend-mode: screen; }
 .battle-flash-text { position: relative; font-weight: 900; letter-spacing: 0.08em; text-shadow: 0 0 20px rgba(255, 236, 153, .9), 0 0 40px rgba(255, 98, 0, .7); }
 .battle-flash-scan { position:absolute; inset:0; background: linear-gradient( to bottom, transparent 0%, rgba(255,255,255,0.08) 50%, transparent 100% ); transform: translateY(-100%); }
+/* Spectacular CHECK splash */
+.check-wrap { position: relative; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; padding: 32px 48px; border-radius: 28px; overflow: hidden; }
+.check-glow { position: absolute; inset: -40px; background: radial-gradient(70% 70% at 50% 50%, rgba(220,38,38,0.6), rgba(79,70,229,0.45), rgba(15,23,42,0.92)); filter: blur(6px); }
+.check-frame { position: absolute; inset: 0; border-radius: 28px; border: 2px solid rgba(248,113,113,0.85); box-shadow: 0 0 24px rgba(248,113,113,0.35); mix-blend-mode: screen; }
+.check-title { position: relative; font-size: clamp(48px, 8vw, 88px); font-weight: 900; letter-spacing: 0.22em; color: #fef9c3; text-transform: uppercase; text-shadow: 0 0 24px rgba(248,250,252,0.75), 0 0 44px rgba(248,113,113,0.65); }
+.check-subtitle { position: relative; font-size: clamp(16px, 3.4vw, 24px); font-weight: 600; letter-spacing: 0.12em; color: #fee2e2; text-transform: uppercase; text-shadow: 0 0 18px rgba(248,113,113,0.45); }
+
+@keyframes controlWarningPulse {
+  0%   { box-shadow: 0 0 0 2px rgba(239,68,68,0.82), 0 0 14px rgba(239,68,68,0.45); transform: translateY(0); }
+  100% { box-shadow: 0 0 0 3px rgba(248,113,113,0.95), 0 0 24px rgba(248,113,113,0.75); transform: translateY(-2px); }
+}
+.control-warning { animation: controlWarningPulse 0.9s ease-in-out infinite alternate; border-color: rgba(248,113,113,0.75); color: #fee2e2; }
 /* Tooltip для 3D-колод/кладбищ */
 #hover-tooltip { position: fixed; pointer-events: none; z-index: 50; }
 


### PR DESCRIPTION
## Summary
- add a dedicated CHECK splash screen and red warning pulse for control panels when a player reaches four creatures, ensuring it triggers for both players simultaneously
- introduce an optional automatic turn hand-off when the timer expires, including a UI toggle and expiry notification
- fix the visual duplication when cancelling a placement so the card snaps cleanly back into the hand

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f45f4941a883308bb9bb31d0537036